### PR TITLE
feat: enable overriding componentRef and ocmConfig per resource

### DIFF
--- a/charts/platform-mesh-operator-components/Chart.yaml
+++ b/charts/platform-mesh-operator-components/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: platform-mesh-operator-components
 description: A Helm chart for Kubernetes
 type: application
-version: 0.14.5
+version: 0.14.6
 appVersion: "1.0.0"

--- a/charts/platform-mesh-operator-components/templates/ocm-resources.yaml
+++ b/charts/platform-mesh-operator-components/templates/ocm-resources.yaml
@@ -19,7 +19,11 @@ metadata:
     {{- end }}
 spec:
   componentRef:
+    {{- if (($config.ocm).component).name }}
+    name: {{ $config.ocm.component.name }}
+    {{- else }}
     name: {{ $values.ocm.component.name }}
+    {{- end }}
   resource:
     byReference:
       resource:
@@ -37,7 +41,11 @@ spec:
   ocmConfig:
     - kind: Repository
       apiVersion: delivery.ocm.software/v1alpha1
+      {{- if (($config.ocm).repo).name }}
+      name: {{ $config.ocm.repo.name }}
+      {{- else }}
       name: {{ $values.ocm.repo.name }}
+      {{- end }}
       namespace: {{ $release.Namespace }}
 ---
 {{ end -}}

--- a/charts/platform-mesh-operator-components/tests/resource_test.yaml
+++ b/charts/platform-mesh-operator-components/tests/resource_test.yaml
@@ -32,6 +32,11 @@ tests:
             namespace: default
         referencePath:
           - name: test
+        ocm:
+          component:
+            name: comp-vw
+          repo:
+            name: repo-vw
   asserts:
     - equal:
         path: spec.resource.byReference.referencePath[0].name
@@ -39,6 +44,12 @@ tests:
     - lengthEqual:
         path: spec.resource.byReference.referencePath
         count: 1
+    - equal:
+        path: spec.componentRef.name
+        value: comp-vw
+    - equal:
+        path: spec.ocmConfig[0].name
+        value: repo-vw
 
 
 - it: default referencePath
@@ -72,3 +83,9 @@ tests:
     - lengthEqual:
         path: spec.resource.byReference.referencePath
         count: 2
+    - equal:
+        path: spec.componentRef.name
+        value: platform-mesh
+    - equal:
+        path: spec.ocmConfig[0].name
+        value: platform-mesh


### PR DESCRIPTION
This pull request introduces improvements to the `platform-mesh-operator-components` Helm chart by making the configuration of OCM component and repository names more flexible and updating associated tests. The main changes allow these names to be set via a custom config or fallback to default values, and ensure the chart version is incremented accordingly.

**Helm chart enhancements:**

* Made `spec.componentRef.name` configurable via `$config.ocm.component.name`, with a fallback to `$values.ocm.component.name` in `ocm-resources.yaml`.
* Made `spec.ocmConfig[0].name` configurable via `$config.ocm.repo.name`, with a fallback to `$values.ocm.repo.name` in `ocm-resources.yaml`.

**Testing improvements:**

* Updated `resource_test.yaml` to add test coverage for the new configurable fields, asserting that the chart correctly uses custom or default names for `componentRef.name` and `ocmConfig[0].name`. [[1]](diffhunk://#diff-33fbb5537c5ba2605d6b30236f7679ffec365a802e5313ef6f53f5cd0a2ab153R35-R52) [[2]](diffhunk://#diff-33fbb5537c5ba2605d6b30236f7679ffec365a802e5313ef6f53f5cd0a2ab153R86-R91)

**Versioning:**

* Bumped chart version from `0.14.5` to `0.14.6` in `Chart.yaml` to reflect these changes.