### PR TITLE
fix: comment out kubectl rollout commands in start.sh

### DIFF
--- a/local-setup/scripts/start.sh
+++ b/local-setup/scripts/start.sh
@@ -148,8 +148,6 @@ if [ "$1" == "--minimal" ]; then
   kubectl scale deployment/root-proxy --replicas=0 -n platform-mesh-system
   kubectl scale deployment/kcp-operator --replicas=0 -n kcp-operator
   kubectl scale deployment/etcd-druid --replicas=0 -n etcd-druid-system
-else
-  kubectl rollout restart deployment portal -n platform-mesh-system
 fi
 
 kubectl wait --namespace default \


### PR DESCRIPTION
Portal UI works after removing restarts

refers to https://github.com/platform-mesh/helm-charts/issues/169