### PR TITLE
chore(chart): improve istio related defaults for platform-mesh-operator

### DIFF
--- a/charts/platform-mesh-operator/Chart.yaml
+++ b/charts/platform-mesh-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: platform-mesh-operator
 description: A Helm chart to automate bootstrapping of new environment
 type: application
-version: 0.7.1
+version: 0.8.0
 appVersion: "v0.19.6"
 dependencies:
   - name: common

--- a/charts/platform-mesh-operator/templates/deployment.yaml
+++ b/charts/platform-mesh-operator/templates/deployment.yaml
@@ -30,6 +30,7 @@ spec:
         args:
           - operator
           {{- include "common.commonOperatorArgs" . | indent 8 }}
+          - --subroutines-deployment-enable-istio={{ (include "common.istioEnabled" .) }}
         ports:
         {{- include "common.PortsMetricsHealth" . | nindent 10 }}
         env:

--- a/charts/platform-mesh-operator/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform-mesh-operator/tests/__snapshot__/deployment_test.yaml.snap
@@ -42,6 +42,94 @@ deployment with tracing:
                 - --tracing-config-service-version=0.0.0
                 - --tracing-config-collector-endpoint=test:4317
                 - --subroutines-feature-toggles-enabled=true
+                - --subroutines-deployment-enable-istio=false
+              env: null
+              image: ghcr.io/platform-mesh/platform-mesh-operator:0.0.0
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 1
+                httpGet:
+                  path: /healthz
+                  port: 8090
+                periodSeconds: 10
+              name: platform-mesh-operator
+              ports:
+                - containerPort: 9090
+                  name: metrics
+                  protocol: TCP
+                - containerPort: 8090
+                  name: health-port
+                  protocol: TCP
+              readinessProbe:
+                httpGet:
+                  path: /readyz
+                  port: 8090
+                initialDelaySeconds: 5
+                periodSeconds: 10
+              resources:
+                limits:
+                  memory: 512Mi
+                requests:
+                  cpu: 40m
+                  memory: 50Mi
+              securityContext:
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
+              startupProbe:
+                failureThreshold: 30
+                httpGet:
+                  path: /readyz
+                  port: 8090
+                periodSeconds: 10
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          serviceAccountName: platform-mesh-operator
+          terminationGracePeriodSeconds: 10
+disables istio sidecar injection:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: platform-mesh-operator
+      namespace: NAMESPACE
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 3
+      selector:
+        matchLabels:
+          app: platform-mesh-operator
+      strategy:
+        rollingUpdate:
+          maxSurge: 5
+          maxUnavailable: 0
+        type: RollingUpdate
+      template:
+        metadata:
+          annotations: null
+          labels:
+            app: platform-mesh-operator
+            control-plane: controller-manager
+        spec:
+          automountServiceAccountToken: true
+          containers:
+            - args:
+                - operator
+                - --leader-elect
+                - --metrics-bind-address=:9090
+                - --health-probe-bind-address=:8090
+                - --log-level=debug
+                - --region=local
+                - --environment=local
+                - --image-tag=0.0.0
+                - --image-name="ghcr.io/platform-mesh/platform-mesh-operator"
+                - --shutdown-timeout=1m
+                - --max-concurrent-reconciles=10
+                - --subroutines-feature-toggles-enabled=true
+                - --subroutines-deployment-enable-istio=false
               env: null
               image: ghcr.io/platform-mesh/platform-mesh-operator:0.0.0
               imagePullPolicy: IfNotPresent
@@ -129,6 +217,7 @@ enables istio sidecar injection:
                 - --shutdown-timeout=1m
                 - --max-concurrent-reconciles=10
                 - --subroutines-feature-toggles-enabled=true
+                - --subroutines-deployment-enable-istio=true
               env: null
               image: ghcr.io/platform-mesh/platform-mesh-operator:0.0.0
               imagePullPolicy: IfNotPresent
@@ -357,6 +446,7 @@ operator match the snapshot:
                 - --shutdown-timeout=1m
                 - --max-concurrent-reconciles=10
                 - --subroutines-feature-toggles-enabled=true
+                - --subroutines-deployment-enable-istio=false
               env: null
               image: ghcr.io/platform-mesh/platform-mesh-operator:0.0.0
               imagePullPolicy: IfNotPresent

--- a/charts/platform-mesh-operator/tests/deployment_test.yaml
+++ b/charts/platform-mesh-operator/tests/deployment_test.yaml
@@ -64,3 +64,10 @@ tests:
       enabled: true
   asserts:
     - matchSnapshot: {}
+- it: disables istio sidecar injection
+  template: deployment.yaml
+  set:
+    istio:
+      enabled: false
+  asserts:
+    - matchSnapshot: {}


### PR DESCRIPTION
Set `--subroutines-deployment-enable-istio` cmdline arg in the operator deployment.