### PR TITLE
feat(chart): global hostAliases configuration in platform-mesh-operator-components

### DIFF
--- a/charts/platform-mesh-operator-components/Chart.yaml
+++ b/charts/platform-mesh-operator-components/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: platform-mesh-operator-components
 description: A Helm chart for Kubernetes
 type: application
-version: 0.30.0
+version: 0.31.0
 appVersion: "0.0.0"

--- a/charts/platform-mesh-operator-components/README.md
+++ b/charts/platform-mesh-operator-components/README.md
@@ -3,9 +3,23 @@
 A Helm chart for Kubernetes
 
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-## Values
+## PlatformMesh resource configuration
+
+This chart, when created by the `platform-mesh-operator` can receive certain configuration parameters from the corresponding `PlatformMesh` resource. Those are:
+
+- iamWebhookCA
+- baseDomain
+- protocol
+- port
+- baseDomainPort
+- hostAliases
+
+Those can be used in replacement templates in values.yaml.
+
+For hostAliases, the value is replaced for individual services with the global configuration if configured as `hostAliases: null` in the service values. Alternatively, if the hostAliases are configured directly in the service values, those will be used instead.## Values
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| hostAliases | list | `[]` |  |
 | iamWebhookCA | string | `nil` |  |
 | ocm.component.create | bool | `true` |  |
 | ocm.component.name | string | `"platform-mesh"` |  |
@@ -46,6 +60,7 @@ A Helm chart for Kubernetes
 | services.infra.dependsOn[0].name | string | `"kcp-operator"` |  |
 | services.infra.dependsOn[0].namespace | string | `"default"` |  |
 | services.infra.enabled | bool | `true` |  |
+| services.infra.values.hostAliases | string | `nil` |  |
 | services.infra.values.istio.main.gateway.hosts[0] | string | `"{{ .Values.baseDomain }}"` |  |
 | services.infra.values.istio.main.gateway.hosts[1] | string | `"*.{{ .Values.baseDomain }}"` |  |
 | services.infra.values.istio.main.gateway.name | string | `"https"` |  |
@@ -166,6 +181,7 @@ A Helm chart for Kubernetes
 | services.portal.values.auth.default.discoveryUrl | string | `"https://{{ .Values.baseDomainPort }}/keycloak/realms/${org-name}/.well-known/openid-configuration"` |  |
 | services.portal.values.cookieDomain | string | `"{{ .Values.baseDomain }}"` |  |
 | services.portal.values.crdGatewayApiUrl | string | `"https://${org-subdomain}{{ .Values.baseDomain }}/api/kubernetes-graphql-gateway/root:orgs:${org-name}/graphql"` |  |
+| services.portal.values.deployment.hostAliases | string | `nil` |  |
 | services.portal.values.environment | string | `"kind"` |  |
 | services.portal.values.extraEnvVars[0].name | string | `"DEFAULT_PORTAL_CONTEXT_CRD_GATEWAY_API_URL"` |  |
 | services.portal.values.extraEnvVars[0].value | string | `"https://${org-subdomain}{{ .Values.baseDomainPort }}/api/kubernetes-graphql-gateway/root:orgs:${org-name}/graphql"` |  |
@@ -188,12 +204,14 @@ A Helm chart for Kubernetes
 | services.security-operator.values.crds.enabled | bool | `false` |  |
 | services.security-operator.values.fga.inviteKeycloakBaseUrl | string | `"https://{{ .Values.baseDomainPort }}/keycloak"` |  |
 | services.security-operator.values.fga.target | string | `"openfga.platform-mesh-system.svc.cluster.local:8081"` |  |
+| services.security-operator.values.hostAliases | string | `nil` |  |
 | services.security-operator.values.initializer.kubeconfigSecret | string | `"security-initializer-kubeconfig"` |  |
 | services.security-operator.values.kubeconfigSecret | string | `"security-operator-kubeconfig"` |  |
 | services.security-operator.values.log.level | string | `"debug"` |  |
 | services.security-operator.values.operator.maxConcurrentReconciles | int | `1` |  |
 | services.security-operator.values.operator.shutdownTimeout | string | `"1m"` |  |
 | services.virtual-workspaces.enabled | bool | `true` |  |
+| services.virtual-workspaces.values | object | `{}` |  |
 | targetNamespace | string | `"platform-mesh-system"` |  |
 
 ## Overriding Values

--- a/charts/platform-mesh-operator-components/README.md.gotmpl
+++ b/charts/platform-mesh-operator-components/README.md.gotmpl
@@ -1,0 +1,14 @@
+## PlatformMesh resource configuration
+
+This chart, when created by the `platform-mesh-operator` can receive certain configuration parameters from the corresponding `PlatformMesh` resource. Those are:
+
+- iamWebhookCA
+- baseDomain
+- protocol
+- port
+- baseDomainPort
+- hostAliases
+
+Those can be used in replacement templates in values.yaml.
+
+For hostAliases, the value is replaced for individual services with the global configuration if configured as `hostAliases: null` in the service values. Alternatively, if the hostAliases are configured directly in the service values, those will be used instead.

--- a/charts/platform-mesh-operator-components/templates/_helpers.tpl
+++ b/charts/platform-mesh-operator-components/templates/_helpers.tpl
@@ -1,0 +1,19 @@
+{{/*
+Recursively search a map for a key named "hostAliases" with a null value
+and replace it with the global .Values.hostAliases list.
+*/}}
+{{- define "hostaliases.injectGlobalHostAliases" -}}
+  {{- $dict := .dict -}}
+  {{- $root := .root -}}
+  {{- range $key, $value := $dict -}}
+    {{- if eq $key "hostAliases" -}}
+      {{- if not $value -}}
+        {{- /* If key is hostAliases and value is null/falsy, replace it */ -}}
+        {{- $_ := set $dict $key $root.Values.hostAliases -}}
+      {{- end -}}
+    {{- else if (kindIs "map" $value) -}}
+      {{- /* If value is another map, recurse into it */ -}}
+      {{- $_ := include "hostaliases.injectGlobalHostAliases" (dict "dict" $value "root" $root) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/platform-mesh-operator-components/templates/helmreleases.yaml
+++ b/charts/platform-mesh-operator-components/templates/helmreleases.yaml
@@ -38,7 +38,9 @@ spec:
     {{ $config.dependsOn | toYaml | nindent 4 }}
   timeout: 15m
   values:
-{{ tpl (toYaml $config.values) $ | indent 4 }}
+    {{- $finalValues := (default dict $config.values) | deepCopy -}}
+    {{- $_ := include "hostaliases.injectGlobalHostAliases" (dict "dict" $finalValues "root" $) -}}
+    {{- tpl ( toYaml $finalValues ) $ | nindent 4 }}
 ---
 {{ end -}}
 {{ end -}}

--- a/charts/platform-mesh-operator-components/tests/__snapshot__/application_test.yaml.snap
+++ b/charts/platform-mesh-operator-components/tests/__snapshot__/application_test.yaml.snap
@@ -119,6 +119,7 @@ it should render the application manifests:
       targetNamespace: platform-mesh-system
       timeout: 15m
       values:
+        hostAliases: []
         istio:
           main:
             gateway:
@@ -411,6 +412,7 @@ it should render the application manifests:
         fga:
           inviteKeycloakBaseUrl: https://example.com:8443/keycloak
           target: openfga.platform-mesh-system.svc.cluster.local:8081
+        hostAliases: []
         initializer:
           kubeconfigSecret: security-initializer-kubeconfig
         kubeconfigSecret: security-operator-kubeconfig
@@ -435,7 +437,7 @@ it should render the application manifests:
       releaseName: virtual-workspaces
       targetNamespace: platform-mesh-system
       timeout: 15m
-      values: null
+      values: {}
   13: |
     apiVersion: delivery.ocm.software/v1alpha1
     kind: Resource

--- a/charts/platform-mesh-operator-components/tests/hostaliases_test.yaml
+++ b/charts/platform-mesh-operator-components/tests/hostaliases_test.yaml
@@ -1,0 +1,93 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: Test hostAliases replacement
+release:
+  name: operator-components
+  namespace: default
+values: []
+tests:
+- it: test hostAliases configuration
+  template: helmreleases.yaml
+  documentSelector:
+    path: metadata.name
+    value: security-operator
+  set:
+    hostAliases:
+    - hostnames:
+      - kcp.api.portal.dev.local
+      - portal.dev.local
+      ip: 10.96.188.4
+
+  asserts:
+    - equal:
+        path: spec.values.hostAliases
+        value:
+          - ip: 10.96.188.4
+            hostnames:
+              - kcp.api.portal.dev.local
+              - portal.dev.local
+    - equal:
+        path: spec.values.hostAliases[0].ip
+        value: "10.96.188.4"
+    - equal:
+        path: spec.values.hostAliases[0].hostnames[1]
+        value: portal.dev.local
+
+- it: test hostAliases portal configuration
+  template: helmreleases.yaml
+  documentSelector:
+    path: metadata.name
+    value: portal
+  set:
+    hostAliases:
+    - hostnames:
+      - kcp.api.portal.dev.local
+      - portal.dev.local
+      ip: 10.96.188.5
+    services:
+      portal:
+        enabled: true
+  asserts:
+    - equal:
+        path: spec.values.deployment.hostAliases
+        value:
+          - ip: 10.96.188.5
+            hostnames:
+              - kcp.api.portal.dev.local
+              - portal.dev.local
+    - equal:
+        path: spec.values.deployment.hostAliases[0].ip
+        value: "10.96.188.5"
+    - equal:
+        path: spec.values.deployment.hostAliases[0].hostnames[1]
+        value: portal.dev.local
+
+- it: test with non-global hostAliases
+  template: helmreleases.yaml
+  documentSelector:
+    path: metadata.name
+    value: newservice
+  set:
+    hostAliases:
+    - hostnames:
+      - kcp.api.portal.dev.local
+      - portal.dev.local
+      ip: 10.96.188.5
+    services:
+      newservice:
+        enabled: true
+        values:
+          hostAliases:
+            - ip: 1.2.3.4
+              hostnames:
+              - custom.local
+  asserts:
+    - equal:
+        path: spec.values.hostAliases
+        value:
+          - ip: 1.2.3.4
+            hostnames:
+            - custom.local
+    - equal:
+        path: spec.values.hostAliases[0].ip
+        value: "1.2.3.4"
+  

--- a/charts/platform-mesh-operator-components/values.yaml
+++ b/charts/platform-mesh-operator-components/values.yaml
@@ -12,6 +12,8 @@ ocm:
     create: true
     name: platform-mesh
 iamWebhookCA: null
+hostAliases: []
+
 services:
   account-operator:
     enabled: true
@@ -62,6 +64,7 @@ services:
   security-operator:
     enabled: true
     values:
+      hostAliases: null
       crds:
         enabled: false
       fga:
@@ -96,6 +99,7 @@ services:
       - name: kcp-operator
         namespace: default
     values:
+      hostAliases: null
       kcp:
         image:
           # FIXME: this is a temporary fix until we have support for the latest version
@@ -304,6 +308,8 @@ services:
   portal:
     enabled: false
     values:
+      deployment:
+        hostAliases: null
       kcp:
         kubeconfigSecret: portal-kubeconfig
       crdGatewayApiUrl: "https://${org-subdomain}{{ .Values.baseDomain }}/api/kubernetes-graphql-gateway/root:orgs:${org-name}/graphql"
@@ -346,6 +352,7 @@ services:
             enabled: true
   virtual-workspaces:
     enabled: true
+    values: {}
   organization-idp:
     enabled: true
     skipHelmRelease: true


### PR DESCRIPTION
Enables global configuration of 'hostAliases' in platform-mesh-operator-components chart.

#### Description
Uses a helm helper function to replace all `hostAliases: null` in the values with the configured yaml list.
