### PR TITLE
doc: podman requirements

### DIFF
--- a/local-setup/README.md
+++ b/local-setup/README.md
@@ -54,7 +54,7 @@ If you're using Windows Subsystem for Linux (WSL2):
 
 If you're using Podman on MacOS make sure to set the following env:
 ```sh
-KIND_EXPERIMENTAL_PROVIDER=podman
+KIND_EXPERIMENTAL_PROVIDER=podman <your-setup-command>
 ```
 
 ## Quick Start


### PR DESCRIPTION
Current versions of Kind do not support podman or shell aliasing. The current workaround is to enable the experimental feature via the env KIND_EXPERIMENTAL_PROVIDER.