### PR TITLE
feat: add support for external kubeconfig mounting in platform-mesh-operator

### DIFF
--- a/charts/platform-mesh-operator/Chart.yaml
+++ b/charts/platform-mesh-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: platform-mesh-operator
 description: A Helm chart to automate bootstrapping of new environment
 type: application
-version: 0.8.26
+version: 0.9.0
 appVersion: "v0.25.1"
 dependencies:
   - name: common

--- a/charts/platform-mesh-operator/README.md
+++ b/charts/platform-mesh-operator/README.md
@@ -11,6 +11,8 @@ A Helm chart to automate bootstrapping of new environment
 | extraArgs[0] | string | `"--subroutines-feature-toggles-enabled=true"` |  |
 | image.name | string | `"ghcr.io/platform-mesh/platform-mesh-operator"` |  |
 | istio.enabled | bool | `false` |  |
+| kubeConfig.enabled | bool | `false` | Allows the mounting of an external kubeconfig. If the kubeconfig is set, it is expected that the service account, that is used, is not connected to this chart and the rbac resources will not be generated. |
+| kubeConfig.secretName | string | `"platform-mesh-kubeconfig"` |  |
 | log.level | string | `"debug"` |  |
 | operator.leaderElect | bool | `true` |  |
 | tracing.collector.endpoint | string | `"observability-opentelemetry-collector.observability.svc.cluster.local:4317"` |  |

--- a/charts/platform-mesh-operator/templates/deployment.yaml
+++ b/charts/platform-mesh-operator/templates/deployment.yaml
@@ -35,4 +35,22 @@ spec:
         {{- include "common.PortsMetricsHealth" . | nindent 10 }}
         env:
         {{- include "common.basicEnvironment" . | nindent 10 }}
+        {{- if .Values.kubeConfig.enabled }}
+        - name: KUBECONFIG
+          value: /etc/kubeconfig
+        {{- end }}
+        {{- if .Values.kubeConfig.enabled }}
+        volumeMounts:
+        - name: external-kubeconfig
+          mountPath: /etc
+          readOnly: true
+        {{- end }}
+
       terminationGracePeriodSeconds: {{ include "common.terminationGracePeriodSeconds" .}}
+      {{- if .Values.kubeConfig.enabled }}
+      volumes:
+      - name: external-kubeconfig
+        secret:
+          secretName: {{ .Values.kubeConfig.secretName }}
+          defaultMode: 420
+      {{- end }}

--- a/charts/platform-mesh-operator/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform-mesh-operator/tests/__snapshot__/deployment_test.yaml.snap
@@ -264,6 +264,104 @@ enables istio sidecar injection:
               type: RuntimeDefault
           serviceAccountName: platform-mesh-operator
           terminationGracePeriodSeconds: 10
+external cluster enabled:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: platform-mesh-operator
+      namespace: NAMESPACE
+    spec:
+      replicas: 1
+      revisionHistoryLimit: 3
+      selector:
+        matchLabels:
+          app: platform-mesh-operator
+      strategy:
+        rollingUpdate:
+          maxSurge: 5
+          maxUnavailable: 0
+        type: RollingUpdate
+      template:
+        metadata:
+          annotations: null
+          labels:
+            app: platform-mesh-operator
+            control-plane: controller-manager
+        spec:
+          automountServiceAccountToken: true
+          containers:
+            - args:
+                - operator
+                - --leader-elect
+                - --metrics-bind-address=:9090
+                - --health-probe-bind-address=:8090
+                - --log-level=debug
+                - --region=local
+                - --environment=local
+                - --image-tag=0.0.0
+                - --image-name="ghcr.io/platform-mesh/platform-mesh-operator"
+                - --shutdown-timeout=1m
+                - --max-concurrent-reconciles=10
+                - --subroutines-feature-toggles-enabled=true
+                - --subroutines-deployment-enable-istio=false
+              env:
+                - name: KUBECONFIG
+                  value: /etc/kubeconfig
+              image: ghcr.io/platform-mesh/platform-mesh-operator:0.0.0
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                failureThreshold: 1
+                httpGet:
+                  path: /healthz
+                  port: 8090
+                periodSeconds: 10
+              name: platform-mesh-operator
+              ports:
+                - containerPort: 9090
+                  name: metrics
+                  protocol: TCP
+                - containerPort: 8090
+                  name: health-port
+                  protocol: TCP
+              readinessProbe:
+                httpGet:
+                  path: /readyz
+                  port: 8090
+                initialDelaySeconds: 5
+                periodSeconds: 10
+              resources:
+                limits:
+                  memory: 512Mi
+                requests:
+                  cpu: 40m
+                  memory: 50Mi
+              securityContext:
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
+              startupProbe:
+                failureThreshold: 30
+                httpGet:
+                  path: /readyz
+                  port: 8090
+                periodSeconds: 10
+              volumeMounts:
+                - mountPath: /etc
+                  name: external-kubeconfig
+                  readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          serviceAccountName: platform-mesh-operator
+          terminationGracePeriodSeconds: 10
+          volumes:
+            - name: external-kubeconfig
+              secret:
+                defaultMode: 420
+                secretName: my-external-cluster-kubeconfig
 operator match the snapshot:
   1: |
     apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/platform-mesh-operator/tests/deployment_test.yaml
+++ b/charts/platform-mesh-operator/tests/deployment_test.yaml
@@ -71,3 +71,14 @@ tests:
       enabled: false
   asserts:
     - matchSnapshot: {}
+- it: external cluster enabled
+  template: deployment.yaml
+  set:
+    kubeConfig:
+      enabled: true
+      secretName: "my-external-cluster-kubeconfig"
+  asserts:
+    - equal:
+        path: spec.template.spec.containers[0].env[?(@.name=="KUBECONFIG")].value
+        value: "/etc/kubeconfig"
+    - matchSnapshot: {}

--- a/charts/platform-mesh-operator/values.yaml
+++ b/charts/platform-mesh-operator/values.yaml
@@ -23,3 +23,8 @@ extraArgs:
 
 istio:
   enabled: false
+
+kubeConfig:
+  # -- Allows the mounting of an external kubeconfig. If the kubeconfig is set, it is expected that the service account, that is used, is not connected to this chart and the rbac resources will not be generated.
+  enabled: false
+  secretName: "platform-mesh-kubeconfig"


### PR DESCRIPTION
Add `kubeConfig:` in values.yaml to enable reconciliation in remote cluster.