### PR TITLE
feat(local-setup): add KCP kubectl plugin requirement check for example-data setup

### DIFF
--- a/local-setup/README.md
+++ b/local-setup/README.md
@@ -13,6 +13,7 @@ Is leverages Flux and Kustomize to manage the cluster and deploy Platform Mesh c
 - **Kind**: [Kubernetes in Docker](https://kind.sigs.k8s.io/) for local Kubernetes clusters. [Installation](https://kind.sigs.k8s.io/docs/user/quick-start/)
 - **Helm**: Required for bootstrapping Flux and managing Helm releases. [Installation](https://helm.sh/docs/intro/install/)
 - **kubectl**: Kubernetes command-line tool (usually installed with Docker Desktop or Kind)
+- **kubectl-kcp plugin** (required only for `--example-data` setup): KCP kubectl plugin for workspace management. [Installation](https://docs.kcp.io/kcp/main/setup/kubectl-plugin/)
 - **openssl**: Required for SSL certificate generation (typically pre-installed on Linux/macOS)
 - **base64**: Required for encoding/decoding operations (standard Unix utility, typically pre-installed)
 - **mkcert**: For generating local SSL certificates. [Installation](https://github.com/FiloSottile/mkcert?tab=readme-ov-file#installation)
@@ -93,6 +94,8 @@ kind delete cluster --name platform-mesh
 ### 2. Bootstrap with Example Data (Demo Setup)
 
 This setup includes an example provider ("httpbin") to showcase how provider integrations work in Platform Mesh. Perfect for demonstrations and learning.
+
+**Note**: The `--example-data` setup requires the [KCP kubectl plugin](https://docs.kcp.io/kcp/main/setup/kubectl-plugin/) to be installed for workspace creation commands.
 
 **Using Task:**
 ```sh

--- a/local-setup/scripts/check-environment.sh
+++ b/local-setup/scripts/check-environment.sh
@@ -138,23 +138,36 @@ check_architecture() {
     esac
 }
 
+check_kcp_plugin() {
+    if ! kubectl kcp --help &> /dev/null; then
+        echo -e "${RED}❌ Error: 'kubectl-kcp' plugin is not installed${COL_RES}"
+        echo -e "${COL}🔌 The KCP kubectl plugin is required for creating workspaces when using --example-data.${COL_RES}"
+        echo -e "${COL}📚 Installation guide: https://docs.kcp.io/kcp/main/setup/kubectl-plugin/${COL_RES}"
+        echo ""
+        return 1
+    fi
+
+    echo -e "${COL}[$(date '+%H:%M:%S')] ✅ kubectl-kcp plugin is available${COL_RES}"
+    return 0
+}
+
 # Run all environment checks
 run_environment_checks() {
     echo -e "${COL}🔍 Checking environment dependencies...${COL_RES}"
     echo ""
-    
+
     local checks_failed=0
-    
+
     # Check container runtime dependency (Docker or Podman)
     if ! check_container_runtime_dependency; then
         checks_failed=$((checks_failed + 1))
     fi
-    
+
     # Check kind dependency
     if ! check_kind_dependency; then
         checks_failed=$((checks_failed + 1))
     fi
-    
+
     # Check mkcert dependency
     if ! setup_mkcert_command; then
         checks_failed=$((checks_failed + 1))
@@ -167,13 +180,20 @@ run_environment_checks() {
     else
         echo -e "${COL}[$(date '+%H:%M:%S')] ✅ Architecture: $ARCH${COL_RES}"
     fi
-    
+
+    # Check KCP plugin if example-data mode is enabled
+    if [ "$EXAMPLE_DATA" = true ]; then
+        if ! check_kcp_plugin; then
+            checks_failed=$((checks_failed + 1))
+        fi
+    fi
+
     if [ $checks_failed -gt 0 ]; then
         echo -e "${RED}❌ $checks_failed dependency check(s) failed. Please install the missing dependencies and try again.${COL_RES}"
         echo ""
         exit 1
     fi
-    
+
     echo -e "${COL}✅ All environment checks passed!${COL_RES}"
     echo ""
 }
@@ -185,4 +205,5 @@ export -f check_docker_dependency
 export -f check_container_runtime_dependency
 export -f setup_mkcert_command
 export -f check_architecture
+export -f check_kcp_plugin
 export -f run_environment_checks


### PR DESCRIPTION
## Summary
Adds validation for the kubectl-kcp plugin when using the `--example-data` flag in local setup. This prevents users from encountering cryptic errors when running workspace creation commands without the plugin installed.

## Changes
- Added `check_kcp_plugin()` function to `local-setup/scripts/check-environment.sh` that verifies the kubectl-kcp plugin is installed
- Integrated the check into `run_environment_checks()` to run automatically when `EXAMPLE_DATA=true`
- Updated `local-setup/README.md` to document the kubectl-kcp plugin in the prerequisites section
- Added a note in the "Bootstrap with Example Data" section explaining the plugin requirement

## Benefits
- **Early failure**: The check runs during environment validation, before any cluster creation begins
- **Clear guidance**: Provides helpful error messages with installation link when the plugin is missing
- **Conditional**: Only enforces the check when actually needed (with `--example-data` flag)
- **Consistent**: Follows the existing pattern of dependency checks in the codebase
