### PR TITLE
feat(local-setup): add hosts entry validation before installation

### DIFF
--- a/local-setup/scripts/start.sh
+++ b/local-setup/scripts/start.sh
@@ -196,12 +196,10 @@ if [ "$EXAMPLE_DATA" = true ]; then
 
 fi
 
-echo -e "${COL}Please create an entry in your /etc/hosts with the following line: \"127.0.0.1 default.portal.dev.local portal.dev.local kcp.api.portal.dev.local\" ${COL_RES}"
-show_wsl_hosts_guidance
-
-echo -e "${YELLOW}⚠️  WARNING: You need to add a hosts entry for every organization that is onboarded!${COL_RES}"
+echo -e "${YELLOW}⚠️  REMINDER: You need to add a hosts entry for every organization that is onboarded!${COL_RES}"
 echo -e "${YELLOW}   Each organization will require its own subdomain entry in /etc/hosts${COL_RES}"
 echo -e "${YELLOW}   Example: 127.0.0.1 <organization-name>.portal.dev.local${COL_RES}"
+show_wsl_hosts_guidance
 
 echo -e "${COL}Once kcp is up and running, run '\033[0;32mexport KUBECONFIG=$(pwd)/.secret/kcp/admin.kubeconfig\033[0m' to gain access to the root workspace.${COL_RES}"
 


### PR DESCRIPTION
## Summary

Adds pre-installation validation to check that required DNS entries (`portal.dev.local` and `kcp.api.portal.dev.local`) are properly configured before starting the local setup process.

## Problem

Currently, the local setup only **suggests** adding hosts entries at the end of installation. This causes the installation to fail with cryptic connection errors when:
- kubectl commands try to connect to `kcp.api.portal.dev.local:8443` during example-data setup
- Users try to access the portal after installation completes

## Solution

Add early validation during the environment checks phase that:
- ✅ Verifies both hostnames resolve to `127.0.0.1`
- ✅ Fails early with clear, actionable error messages if entries are missing
- ✅ Works without sudo permissions
- ✅ Supports macOS, Linux, and WSL environments
- ✅ Provides platform-specific guidance

## Changes

### `local-setup/scripts/check-environment.sh`
- Added `check_hosts_entry()` function that detects OS and uses appropriate DNS resolution method
  - macOS: Uses `dscacheutil`
  - Linux: Uses `getent` (with fallback to direct `/etc/hosts` parsing)
  - Filters out IPv6 addresses (only checks for `127.0.0.1`)
- Added `check_hosts_entries()` function that validates both required hostnames
  - Shows clear error messages listing missing hosts
  - Provides copy-paste ready command for `/etc/hosts`
  - Includes WSL-specific guidance when detected
- Integrated check into `run_environment_checks()` to run before installation starts

### `local-setup/scripts/start.sh`
- Removed redundant hosts entry instruction at end (since we now validate upfront)
- Changed message to only remind about organization-specific hosts entries
- Moved WSL guidance after organization warning for better flow

