### PR TITLE
feat: added smtp argumetns to the security operator

### DIFF
--- a/local-setup/kustomize/components/platform-mesh-operator-resource/platform-mesh.yaml
+++ b/local-setup/kustomize/components/platform-mesh-operator-resource/platform-mesh.yaml
@@ -64,7 +64,6 @@ spec:
             - --idp-smtp-server=mailpit.platform-mesh-system.svc.cluster.local
             - --idp-smtp-port=1025
             - --idp-from-address=keycloak@portal.dev.local
-            - --idp-additional-redirect-urls="https://default.portal.dev.local:3000/callback*"
         initializer:
           extraArgs:
             - --domain-ca-lookup
@@ -72,7 +71,6 @@ spec:
             - --idp-smtp-server=mailpit.platform-mesh-system.svc.cluster.local
             - --idp-smtp-port=1025
             - --idp-from-address=keycloak@portal.dev.local
-            - --idp-additional-redirect-urls="https://default.portal.dev.local:3000/callback*"
         caSecret: domain-certificate-ca
         hostAliases:
           enabled: true


### PR DESCRIPTION
On-behalf-of: SAP aleh.yarshou@sap.com

Changes:

- I've added related to smtp arguments to the operator because now the operator is responsible for setting up smtp config in the newly created realms instead of the initializer. 
- The initializer still has extra smtp arguments to simplify the migration from crossplane to the idp resource usage. They will be deleted when the security operator and the portal are updated 