### PR TITLE
fix: update flux-sync.yaml to use specific commit reference instead of branch

### DIFF
--- a/local-setup/kustomize/base/ocm-k8s-toolkit/flux-sync.yaml
+++ b/local-setup/kustomize/base/ocm-k8s-toolkit/flux-sync.yaml
@@ -7,7 +7,7 @@ spec:
   interval: 1m
   url: https://github.com/open-component-model/open-component-model
   ref:
-    branch: main
+    commit: 0c8ad3c6f96172bd0b7c3e5385c4f859ad4e7043
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization


### PR DESCRIPTION
This PR pins the version of the used OCM kustomize files to a specific commit to avoid side effects