### PR TITLE
feat: update hostAliases default entries to localhost

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart containing reuse templates
 
 type: library
 
-version: 0.10.0
+version: 0.11.0

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -24,7 +24,7 @@ A Helm chart containing reuse templates
 | defaults.health.readiness | object | `{"initialDelaySeconds":5,"path":"/readyz","periodSeconds":10}` | readiness probe parameters |
 | defaults.health.startup | object | `{"failureThreshold":30,"path":"/readyz"}` | startup probe parameters |
 | defaults.hostAliases.enabled | bool | `false` | toggle to enable/disable hostAliases configuration |
-| defaults.hostAliases.entries | list | `[{"hostnames":["kcp.api.portal.dev.local","portal.dev.local"],"ip":"10.96.188.4"}]` | host aliases |
+| defaults.hostAliases.entries | list | `[{"hostnames":["localhost","portal.localhost"],"ip":"10.96.188.4"}]` | host aliases |
 | defaults.imagePullPolicy | string | `"IfNotPresent"` | imagePullPolicy is the policy to use when pulling images for all charts |
 | defaults.istio.enabled | bool | `false` | toggle to enable/disable istio |
 | defaults.istio.gateway.name | string | `"gateway"` | name of the gateway |

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -124,5 +124,5 @@ defaults:
     entries:
       - ip: "10.96.188.4"
         hostnames:
-          - "kcp.api.portal.dev.local"
-          - "portal.dev.local"
+          - "localhost"
+          - "portal.localhost"


### PR DESCRIPTION
## Summary
- This is a preparation pull request to transition the local setup away from the .local domain
- Update default hostAliases entries from `kcp.api.portal.dev.local` and `portal.dev.local` to `localhost` and `portal.localhost`
- Bump common chart version from 0.10.0 to 0.11.0