### PR TITLE
feat: add WAIT and WAIT_REASON fields to platform mesh CRDs

### DIFF
--- a/charts/platform-mesh-operator-crds/Chart.yaml
+++ b/charts/platform-mesh-operator-crds/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.3.1
+version: 0.4.0
 
 appVersion: "0.0.0"

--- a/charts/platform-mesh-operator-crds/templates/core.platform-mesh.io_platformmeshes.yaml
+++ b/charts/platform-mesh-operator-crds/templates/core.platform-mesh.io_platformmeshes.yaml
@@ -42,6 +42,15 @@ spec:
       name: DEPLOYMENT_REASON
       priority: 1
       type: string
+    - description: Wait status (shows reason if Unknown)
+      jsonPath: .status.conditions[?(@.type=='WaitSubroutine_Ready')].status
+      name: WAIT
+      type: string
+    - description: Wait reason if status is Unknown
+      jsonPath: .status.conditions[?(@.type=='WaitSubroutine_Ready')].reason
+      name: WAIT_REASON
+      priority: 1
+      type: string
     - description: Shows if resource is ready
       jsonPath: .status.conditions[?(@.type=='Ready')].status
       name: Ready
@@ -110,22 +119,6 @@ spec:
                       - workspaceTypePath
                       type: object
                     type: array
-                  extraInitializerConnections:
-                    items:
-                      properties:
-                        namespace:
-                          type: string
-                        path:
-                          type: string
-                        secret:
-                          type: string
-                        workspaceTypeName:
-                          type: string
-                      required:
-                      - path
-                      - workspaceTypeName
-                      type: object
-                    type: array
                   extraProviderConnections:
                     items:
                       properties:
@@ -174,22 +167,6 @@ spec:
                       required:
                       - path
                       - type
-                      type: object
-                    type: array
-                  initializerConnections:
-                    items:
-                      properties:
-                        namespace:
-                          type: string
-                        path:
-                          type: string
-                        secret:
-                          type: string
-                        workspaceTypeName:
-                          type: string
-                      required:
-                      - path
-                      - workspaceTypeName
                       type: object
                     type: array
                   providerConnections:

--- a/charts/platform-mesh-operator-crds/tests/__snapshot__/crds_test.yaml.snap
+++ b/charts/platform-mesh-operator-crds/tests/__snapshot__/crds_test.yaml.snap
@@ -43,6 +43,15 @@ operator match the snapshot:
               name: DEPLOYMENT_REASON
               priority: 1
               type: string
+            - description: Wait status (shows reason if Unknown)
+              jsonPath: .status.conditions[?(@.type=='WaitSubroutine_Ready')].status
+              name: WAIT
+              type: string
+            - description: Wait reason if status is Unknown
+              jsonPath: .status.conditions[?(@.type=='WaitSubroutine_Ready')].reason
+              name: WAIT_REASON
+              priority: 1
+              type: string
             - description: Shows if resource is ready
               jsonPath: .status.conditions[?(@.type=='Ready')].status
               name: Ready
@@ -111,22 +120,6 @@ operator match the snapshot:
                               - workspaceTypePath
                             type: object
                           type: array
-                        extraInitializerConnections:
-                          items:
-                            properties:
-                              namespace:
-                                type: string
-                              path:
-                                type: string
-                              secret:
-                                type: string
-                              workspaceTypeName:
-                                type: string
-                            required:
-                              - path
-                              - workspaceTypeName
-                            type: object
-                          type: array
                         extraProviderConnections:
                           items:
                             properties:
@@ -170,22 +163,6 @@ operator match the snapshot:
                             required:
                               - path
                               - type
-                            type: object
-                          type: array
-                        initializerConnections:
-                          items:
-                            properties:
-                              namespace:
-                                type: string
-                              path:
-                                type: string
-                              secret:
-                                type: string
-                              workspaceTypeName:
-                                type: string
-                            required:
-                              - path
-                              - workspaceTypeName
                             type: object
                           type: array
                         providerConnections:


### PR DESCRIPTION
## Summary
- Add WAIT and WAIT_REASON fields to PlatformMesh CRD status for improved observability
- Update platform-mesh-operator-crds chart version to 0.4.0
- Update snapshot tests to reflect CRD changes