### PR TITLE
feat(chart): add 'etcd store' configuration ability in the infra chart

### DIFF
--- a/charts/infra/Chart.yaml
+++ b/charts/infra/Chart.yaml
@@ -2,7 +2,7 @@ type: application
 apiVersion: v2
 name: infra
 description: A Helm chart for Kubernetes
-version: 0.21.3
+version: 0.22.0
 appVersion: "0.0.0"
 
 dependencies:

--- a/charts/infra/templates/kcp/etcd.yaml
+++ b/charts/infra/templates/kcp/etcd.yaml
@@ -49,6 +49,10 @@ spec:
     leaderElection:
       reelectionPeriod: {{ .Values.kcp.etcd.backup.leaderElection.reelectionPeriod | default "5s" }}
       etcdConnectionTimeout: {{ .Values.kcp.etcd.backup.leaderElection.etcdConnectionTimeout | default "5s" }}
+{{- if .Values.kcp.etcd.backup.store }}
+    store:
+{{ toYaml .Values.kcp.etcd.backup.store | indent 6 }}
+{{- end }}
 
   sharedConfig:
     autoCompactionMode: {{ .Values.kcp.etcd.sharedConfig.autoCompactionMode | default "periodic" }}

--- a/charts/infra/tests/__snapshot__/application_test.yaml.snap
+++ b/charts/infra/tests/__snapshot__/application_test.yaml.snap
@@ -829,6 +829,70 @@ Istio enabled:
           - POST
         accessControlMaxAge: 100
         addVaryHeader: true
+configure etcd backup store:
+  1: |
+    apiVersion: druid.gardener.cloud/v1alpha1
+    kind: Etcd
+    metadata:
+      labels:
+        app: etcd-statefulset
+        gardener.cloud/role: controlplane
+        role: kcp
+      name: etcd-kcp
+      namespace: platform-mesh-system
+    spec:
+      annotations:
+        app: etcd-statefulset
+        gardener.cloud/role: controlplane
+        role: kcp
+      backup:
+        compression:
+          enabled: false
+          policy: gzip
+        deltaSnapshotMemoryLimit: 1Gi
+        deltaSnapshotPeriod: 300s
+        fullSnapshotSchedule: 0 */24 * * *
+        garbageCollectionPeriod: 43200s
+        garbageCollectionPolicy: Exponential
+        leaderElection:
+          etcdConnectionTimeout: 5s
+          reelectionPeriod: 5s
+        port: 8080
+        resources:
+          limits:
+            cpu: 200m
+            memory: 1Gi
+          requests:
+            cpu: 23m
+            memory: 128Mi
+        store:
+          container: etcd-bucket
+          endpointOverride: http://localstack.default:4566
+          prefix: etcd-test
+          provider: S3
+          secretRef:
+            name: etcd-backup-aws
+      etcd:
+        clientPort: 2379
+        defragmentationSchedule: 0 */24 * * *
+        metrics: basic
+        quota: 8Gi
+        resources:
+          limits:
+            cpu: 500m
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        serverPort: 2380
+      labels:
+        app: etcd-statefulset
+        gardener.cloud/role: controlplane
+        role: kcp
+      replicas: 1
+      sharedConfig:
+        autoCompactionMode: periodic
+        autoCompactionRetention: 30m
 match snapshots:
   1: |
     apiVersion: gateway.networking.k8s.io/v1

--- a/charts/infra/tests/application_test.yaml
+++ b/charts/infra/tests/application_test.yaml
@@ -68,3 +68,28 @@ tests:
   - equal:
       path: spec.listeners[0].tls.certificateRefs[0].namespace
       value: default2
+- it: configure etcd backup store
+  templates:
+    - kcp/etcd.yaml
+  set:
+    kcp:
+      etcd:
+        backup:
+          store:
+            container: etcd-bucket
+            prefix: etcd-test
+            provider: S3
+            endpointOverride: http://localstack.default:4566
+            secretRef:
+              name: etcd-backup-aws
+  asserts:
+  - equal:
+      path: spec.backup.store
+      value:
+        container: etcd-bucket
+        prefix: etcd-test
+        provider: S3
+        endpointOverride: http://localstack.default:4566
+        secretRef:
+          name: etcd-backup-aws
+  - matchSnapshot: {}

--- a/charts/infra/values.yaml
+++ b/charts/infra/values.yaml
@@ -60,6 +60,13 @@ kcp:
       leaderElection:
         reelectionPeriod: 5s
         etcdConnectionTimeout: 5s
+      # store:
+      #   container: etcd-bucket
+      #   prefix: etcd-test
+      #   provider: S3
+      #   endpointOverride: http://localstack.default:4566
+      #   secretRef:
+      #     name: etcd-backup-aws
     sharedConfig:
       autoCompactionMode: periodic
       autoCompactionRetention: "30m"


### PR DESCRIPTION
Would be needed for `etcd` migration eventually.