### PR TITLE
feat(infra): add optional resource configuration for frontproxy and rootshard

### DIFF
--- a/charts/infra/Chart.yaml
+++ b/charts/infra/Chart.yaml
@@ -2,7 +2,7 @@ type: application
 apiVersion: v2
 name: infra
 description: A Helm chart for Kubernetes
-version: 0.22.0
+version: 0.23.0
 appVersion: "0.0.0"
 
 dependencies:

--- a/charts/infra/README.md
+++ b/charts/infra/README.md
@@ -71,6 +71,7 @@ A Helm chart for Kubernetes
 | kcp.frontProxy.name | string | `"frontproxy"` |  |
 | kcp.frontProxy.port | int | `8443` |  |
 | kcp.frontProxy.replicas | int | `1` |  |
+| kcp.frontProxy.resources | object | `{}` | Optional resource requests and limits for the front proxy |
 | kcp.image.tag | string | `""` |  |
 | kcp.namespace | string | `"platform-mesh-system"` |  |
 | kcp.oidc.caFileRef.key | string | `"tls.crt"` |  |
@@ -82,6 +83,7 @@ A Helm chart for Kubernetes
 | kcp.oidc.usernameClaim | string | `"email"` |  |
 | kcp.rootShard.extraArgs[0] | string | `"--feature-gates=WorkspaceAuthentication=true"` |  |
 | kcp.rootShard.replicas | int | `1` |  |
+| kcp.rootShard.resources | object | `{}` | Optional resource requests and limits for the root shard |
 | kcp.webhook.authorizationWebhookSecretName | string | `"kcp-webhook-secret"` |  |
 | kcp.webhook.caData | string | `""` |  |
 | kcp.webhook.enabled | bool | `true` |  |

--- a/charts/infra/templates/kcp/front-proxy.yaml
+++ b/charts/infra/templates/kcp/front-proxy.yaml
@@ -48,6 +48,10 @@ spec:
         protocol: TCP
         targetPort: 6443
   {{- end }}
+  {{- with .Values.kcp.frontProxy.resources }}
+  resources:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- if .Values.hostAliases.enabled }}
   {{- with .Values.hostAliases.entries }}
   deploymentTemplate:

--- a/charts/infra/templates/kcp/root-shard.yaml
+++ b/charts/infra/templates/kcp/root-shard.yaml
@@ -53,6 +53,10 @@ spec:
   image:
     tag: {{ . }}
   {{- end }}
+  {{- with .Values.kcp.rootShard.resources }}
+  resources:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   deploymentTemplate:
     spec:
       template:
@@ -61,6 +65,6 @@ spec:
             # this excludes webhook traffic from the istio sidecar
             traffic.sidecar.istio.io/excludeOutboundPorts: "{{ .Values.kcp.webhook.port }}"
         spec:
-        {{ include "common.hostAliases" $ | nindent 10 }}
+          {{- include "common.hostAliases" $ | nindent 10 }}
   extraArgs:
 {{ toYaml .Values.kcp.rootShard.extraArgs | indent 4 }}

--- a/charts/infra/tests/__snapshot__/application_test.yaml.snap
+++ b/charts/infra/tests/__snapshot__/application_test.yaml.snap
@@ -893,6 +893,92 @@ configure etcd backup store:
       sharedConfig:
         autoCompactionMode: periodic
         autoCompactionRetention: 30m
+configure frontproxy resources:
+  1: |
+    apiVersion: operator.kcp.io/v1alpha1
+    kind: FrontProxy
+    metadata:
+      name: frontproxy
+      namespace: platform-mesh-system
+    spec:
+      additionalPathMappings:
+        - backend: https://virtual-workspaces.platform-mesh-system:8443
+          backend_server_ca: /etc/kcp/tls/ca/tls.crt
+          path: /services/contentconfigurations
+          proxy_client_cert: /etc/kcp-front-proxy/requestheader-client/tls.crt
+          proxy_client_key: /etc/kcp-front-proxy/requestheader-client/tls.key
+        - backend: https://virtual-workspaces.platform-mesh-system:8443
+          backend_server_ca: /etc/kcp/tls/ca/tls.crt
+          path: /services/marketplace
+          proxy_client_cert: /etc/kcp-front-proxy/requestheader-client/tls.crt
+          proxy_client_key: /etc/kcp-front-proxy/requestheader-client/tls.key
+      external:
+        hostname: localhost
+        port: 8443
+      extraArgs:
+        - --feature-gates=WorkspaceAuthentication=true
+      replicas: 1
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi
+      rootShard:
+        ref:
+          name: root
+      serviceTemplate:
+        spec:
+          ports:
+            - appProtocol: https
+              name: https
+              port: 8443
+              protocol: TCP
+              targetPort: 6443
+          type: ClusterIP
+configure rootshard resources:
+  1: |
+    apiVersion: operator.kcp.io/v1alpha1
+    kind: RootShard
+    metadata:
+      name: root
+      namespace: platform-mesh-system
+    spec:
+      authorization:
+        webhook:
+          configSecretName: kcp-webhook-secret
+      cache:
+        embedded:
+          enabled: true
+      certificates:
+        issuerRef:
+          group: cert-manager.io
+          kind: Issuer
+          name: selfsigned
+      deploymentTemplate:
+        spec:
+          template:
+            metadata:
+              annotations:
+                traffic.sidecar.istio.io/excludeOutboundPorts: "9443"
+            spec: null
+      etcd:
+        endpoints:
+          - http://etcd-kcp-client.platform-mesh-system.svc.cluster.local:2379
+      external:
+        hostname: localhost
+        port: 8443
+      extraArgs:
+        - --feature-gates=WorkspaceAuthentication=true
+      replicas: 1
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 1Gi
+        requests:
+          cpu: 200m
+          memory: 256Mi
 match snapshots:
   1: |
     apiVersion: gateway.networking.k8s.io/v1

--- a/charts/infra/tests/application_test.yaml
+++ b/charts/infra/tests/application_test.yaml
@@ -68,6 +68,36 @@ tests:
   - equal:
       path: spec.listeners[0].tls.certificateRefs[0].namespace
       value: default2
+- it: configure frontproxy resources
+  templates:
+    - kcp/front-proxy.yaml
+  set:
+    kcp:
+      frontProxy:
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+  asserts:
+  - matchSnapshot: {}
+- it: configure rootshard resources
+  templates:
+    - kcp/root-shard.yaml
+  set:
+    kcp:
+      rootShard:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 1Gi
+          requests:
+            cpu: 200m
+            memory: 256Mi
+  asserts:
+  - matchSnapshot: {}
 - it: configure etcd backup store
   templates:
     - kcp/etcd.yaml

--- a/charts/infra/values.yaml
+++ b/charts/infra/values.yaml
@@ -91,6 +91,15 @@ kcp:
 
   rootShard:
     replicas: 1
+    # -- Optional resource requests and limits for the root shard
+    resources: {}
+    # resources:
+    #   limits:
+    #     cpu: "2"
+    #     memory: "2Gi"
+    #   requests:
+    #     cpu: "1"
+    #     memory: "1Gi"
     extraArgs:
     - --feature-gates=WorkspaceAuthentication=true
   frontProxy:
@@ -98,6 +107,15 @@ kcp:
     name: frontproxy
     clusterIP: ""
     port: 8443
+    # -- Optional resource requests and limits for the front proxy
+    resources: {}
+    # resources:
+    #   limits:
+    #     cpu: 500m
+    #     memory: 512Mi
+    #   requests:
+    #     cpu: 100m
+    #     memory: 128Mi
     additionalPathMappings:
       - path: /services/contentconfigurations
         backend: https://virtual-workspaces.platform-mesh-system:8443


### PR DESCRIPTION
## Summary

- Add `kcp.frontProxy.resources` and `kcp.rootShard.resources` values to optionally configure resource requests and limits
- Resources are set directly on the FrontProxy and RootShard CRs using the kcp-operator's native `spec.resources` field
- Both default to empty (not set), maintaining backward compatibility