### PR TITLE
refactor(rebac-authz-webhook): use common.podBasics template

### DIFF
--- a/charts/rebac-authz-webhook/Chart.yaml
+++ b/charts/rebac-authz-webhook/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rebac-authz-webhook
 description: A Helm chart for Kubernetes
 type: application
-version: 0.14.14
+version: 0.15.0
 appVersion: "v0.2.152"
 dependencies:
   - name: common

--- a/charts/rebac-authz-webhook/README.md
+++ b/charts/rebac-authz-webhook/README.md
@@ -12,6 +12,10 @@ A Helm chart for Kubernetes
 | certManager.enabled | bool | `true` |  |
 | certManager.ipAddresses[0] | string | `"10.96.86.219"` |  |
 | certificates.create | bool | `false` |  |
+| deployment.resources.limits.cpu | string | `"500m"` |  |
+| deployment.resources.limits.memory | string | `"128Mi"` |  |
+| deployment.resources.requests.cpu | string | `"40m"` |  |
+| deployment.resources.requests.memory | string | `"50Mi"` |  |
 | health.port | int | `8081` |  |
 | healthProbeBindAddress | string | `":8081"` |  |
 | image.name | string | `"ghcr.io/platform-mesh/rebac-authz-webhook"` |  |

--- a/charts/rebac-authz-webhook/templates/deployment.yaml
+++ b/charts/rebac-authz-webhook/templates/deployment.yaml
@@ -28,13 +28,8 @@ spec:
       {{- toYaml . | nindent 6 }}
       {{- end }}
       containers:
-      - name: {{ .Chart.Name }}
+      - {{- include "common.podBasics" . | indent 8 }}
         {{- include "common.operatorHealthAndReadyness" . | indent 8 }}
-        image: "{{ .Values.image.name }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-        resources:
-          limits:
-            memory: "128Mi"
-            cpu: "500m"
         volumeMounts:
           - name: certs
             mountPath: /config

--- a/charts/rebac-authz-webhook/tests/__snapshot__/application_test.yaml.snap
+++ b/charts/rebac-authz-webhook/tests/__snapshot__/application_test.yaml.snap
@@ -67,6 +67,7 @@ it should render the application manifests:
                 - name: KUBECONFIG
                   value: /api-kubeconfig/kubeconfig
               image: ghcr.io/platform-mesh/rebac-authz-webhook:0.0.0
+              imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 1
                 httpGet:
@@ -87,6 +88,9 @@ it should render the application manifests:
                 limits:
                   cpu: 500m
                   memory: 128Mi
+                requests:
+                  cpu: 40m
+                  memory: 50Mi
               startupProbe:
                 failureThreshold: 30
                 httpGet:
@@ -198,6 +202,7 @@ it should render the application manifests with service account:
                 - name: KUBECONFIG
                   value: /api-kubeconfig/kubeconfig
               image: ghcr.io/platform-mesh/rebac-authz-webhook:0.0.0
+              imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 1
                 httpGet:
@@ -218,6 +223,9 @@ it should render the application manifests with service account:
                 limits:
                   cpu: 500m
                   memory: 128Mi
+                requests:
+                  cpu: 40m
+                  memory: 50Mi
               startupProbe:
                 failureThreshold: 30
                 httpGet:
@@ -329,6 +337,7 @@ it should render the application manifests with service monitor:
                 - name: KUBECONFIG
                   value: /api-kubeconfig/kubeconfig
               image: ghcr.io/platform-mesh/rebac-authz-webhook:0.0.0
+              imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 1
                 httpGet:
@@ -349,6 +358,9 @@ it should render the application manifests with service monitor:
                 limits:
                   cpu: 500m
                   memory: 128Mi
+                requests:
+                  cpu: 40m
+                  memory: 50Mi
               startupProbe:
                 failureThreshold: 30
                 httpGet:
@@ -460,6 +472,7 @@ it should render the application manifests with useInClusterClient:
                 - name: KUBECONFIG
                   value: /api-kubeconfig/kubeconfig
               image: ghcr.io/platform-mesh/rebac-authz-webhook:0.0.0
+              imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 1
                 httpGet:
@@ -480,6 +493,9 @@ it should render the application manifests with useInClusterClient:
                 limits:
                   cpu: 500m
                   memory: 128Mi
+                requests:
+                  cpu: 40m
+                  memory: 50Mi
               startupProbe:
                 failureThreshold: 30
                 httpGet:
@@ -591,6 +607,7 @@ it should render the cert-manager manifests with certManager enabled:
                 - name: KUBECONFIG
                   value: /api-kubeconfig/kubeconfig
               image: ghcr.io/platform-mesh/rebac-authz-webhook:0.0.0
+              imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 1
                 httpGet:
@@ -611,6 +628,9 @@ it should render the cert-manager manifests with certManager enabled:
                 limits:
                   cpu: 500m
                   memory: 128Mi
+                requests:
+                  cpu: 40m
+                  memory: 50Mi
               startupProbe:
                 failureThreshold: 30
                 httpGet:

--- a/charts/rebac-authz-webhook/values.yaml
+++ b/charts/rebac-authz-webhook/values.yaml
@@ -6,6 +6,15 @@ certManager:
   caSecretName: rebac-authz-webhook-webhook-ca
   createCA: false
 
+deployment:
+  resources:
+    limits:
+      cpu: "500m"
+      memory: "128Mi"
+    requests:
+      cpu: "40m"
+      memory: "50Mi"
+
 image:
   name: ghcr.io/platform-mesh/rebac-authz-webhook
   # Overrides the image tag whose default is the chart appVersion.


### PR DESCRIPTION
## Summary

- Refactor deployment to use `common.podBasics` template instead of hardcoded container name, image, and resources
- Add `deployment.resources` configuration in values.yaml for configurable resource requests/limits
- Aligns rebac-authz-webhook chart with other charts in the repository that use the common helpers