### PR TITLE
fix(task): local-setup:cached:prerelease:example-data

### DIFF
--- a/local-setup/scripts/start.sh
+++ b/local-setup/scripts/start.sh
@@ -178,6 +178,7 @@ if [ "$PRERELEASE" = true ]; then
     echo -e "${COL}[$(date '+%H:%M:%S')] Install Platform-Mesh (prerelease with example-data) ${COL_RES}"
     # TODO: Create example-data-prerelease overlay if needed
     kubectl apply -k $SCRIPT_DIR/../kustomize/overlays/platform-mesh-resource-prerelease
+    kubectl apply -k $SCRIPT_DIR/../kustomize/overlays/example-data
   else
     echo -e "${COL}[$(date '+%H:%M:%S')] Install Platform-Mesh (prerelease) ${COL_RES}"
     kubectl apply -k $SCRIPT_DIR/../kustomize/overlays/platform-mesh-resource-prerelease


### PR DESCRIPTION
Fixes the `task local-setup:cached:prerelease:example-data`

Adds misisng `sync-agent` component reference under platform-mesh/example-httpbin-operator.

refers to https://github.com/platform-mesh/helm-charts/issues/992