### PR TITLE
chore: bump terminal-controller-manager to v0.1.1

### DIFF
--- a/charts/terminal-controller-manager/Chart.yaml
+++ b/charts/terminal-controller-manager/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: terminal-controller-manager
 description: A Helm chart to deploy platform-mesh Terminal Controller Manager
 type: application
-version: 0.1.0
-appVersion: "v0.1.0"
+version: 0.1.1
+appVersion: "v0.1.1"
 dependencies:
   - name: common
     version: 0.11.2


### PR DESCRIPTION
## Summary

- Bump terminal-controller-manager chart version and appVersion from v0.1.0 to v0.1.1