### PR TITLE
chore: update version and unpin kcp image tag

### DIFF
--- a/local-setup/kustomize/components/platform-mesh-operator-resource/platform-mesh.yaml
+++ b/local-setup/kustomize/components/platform-mesh-operator-resource/platform-mesh.yaml
@@ -93,8 +93,8 @@ spec:
           auth:
             serviceAccount:
               enabled: true
-          image:
-            tag: "097afc12c" # bump kcp image to work around WatchList issues
+          # image:
+          #   tag: "097afc12c" # bump kcp image to work around WatchList issues
           frontProxy:
             clusterIP: "10.96.0.100"
         traefik:

--- a/local-setup/kustomize/components/platform-mesh-operator-resource/platform-mesh.yaml
+++ b/local-setup/kustomize/components/platform-mesh-operator-resource/platform-mesh.yaml
@@ -93,8 +93,6 @@ spec:
           auth:
             serviceAccount:
               enabled: true
-          # image:
-          #   tag: "097afc12c" # bump kcp image to work around WatchList issues
           frontProxy:
             clusterIP: "10.96.0.100"
         traefik:


### PR DESCRIPTION
Changes:
- unpin kcp image tag after updating the kcp and kcp-operator versions