### PR TITLE
chore(example-httpbin-operator): bump chart to 0.5.13

### DIFF
--- a/charts/example-httpbin-operator/Chart.yaml
+++ b/charts/example-httpbin-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: example-httpbin-operator
 description: A Helm chart for deploying the httpbin operator and its CRDs
 type: application
 version: 0.5.13
-appVersion: "v0.5.4"
+appVersion: "v0.5.3"
 annotations:
   # Automatically install and upgrade CRDs
   "helm.sh/resource-policy": keep

--- a/charts/example-httpbin-operator/Chart.yaml
+++ b/charts/example-httpbin-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: example-httpbin-operator
 description: A Helm chart for deploying the httpbin operator and its CRDs
 type: application
-version: 0.5.12
-appVersion: "v0.5.3"
+version: 0.5.13
+appVersion: "v0.5.4"
 annotations:
   # Automatically install and upgrade CRDs
   "helm.sh/resource-policy": keep


### PR DESCRIPTION
## Summary
- testing OCM release updates - requires version bump
