### PR TITLE
fix(gateway): render controller flags with explicit true/false

### DIFF
--- a/charts/kubernetes-graphql-gateway/Chart.yaml
+++ b/charts/kubernetes-graphql-gateway/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.38.1
+version: 0.38.2
 appVersion: v1.6.0
 name: kubernetes-graphql-gateway
 description: Basic helm chart that contains listener and gateway

--- a/charts/kubernetes-graphql-gateway/README.md
+++ b/charts/kubernetes-graphql-gateway/README.md
@@ -23,12 +23,12 @@ kubeConfig:
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |
 | gateway.extraArgs | list | `[]` |  |
-| gateway.graphiql | bool | `true` |  |
 | gateway.healthCheck.enabled | bool | `true` |  |
 | gateway.healthCheck.port | int | `8080` |  |
 | gateway.introspectionAuthentication | bool | `true` |  |
 | gateway.logLevel | string | `"trace"` |  |
 | gateway.metricsPort | int | `8081` |  |
+| gateway.playground | bool | `true` |  |
 | gateway.port | int | `8080` |  |
 | gateway.resources.limits.memory | string | `"1200Mi"` |  |
 | gateway.resources.requests.cpu | string | `"250m"` |  |

--- a/charts/kubernetes-graphql-gateway/templates/deploy-gateway.yaml
+++ b/charts/kubernetes-graphql-gateway/templates/deploy-gateway.yaml
@@ -73,6 +73,9 @@ spec:
         - --schemas-dir={{ .Values.schemaHandler.schemasDir }}
         {{- end }}
         {{- include "common.collectorArgs" . | nindent 8 }}
+        {{- if .Values.gateway.playground }}
+        - --enable-playground
+        {{- end }}
         {{- with .Values.gateway.extraArgs }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/kubernetes-graphql-gateway/templates/deploy-listener.yaml
+++ b/charts/kubernetes-graphql-gateway/templates/deploy-listener.yaml
@@ -109,12 +109,8 @@ spec:
         - --additional-path-annotation-key={{ .Values.listener.additionalPathAnnotationKey }}
         {{- end }}
         - --metrics-bind-address=:{{ .Values.listener.metricsPort }}
-        {{- if .Values.listener.enableResourceController }}
-        - --enable-resource-controller
-        {{- end }}
-        {{- if .Values.listener.enableClusterAccessController }}
-        - --enable-clusteraccess-controller
-        {{- end }}
+        - --enable-resource-controller={{ .Values.listener.enableResourceController }}
+        - --enable-clusteraccess-controller={{ .Values.listener.enableClusterAccessController }}
         {{- if .Values.listener.cacheNamespaces }}
         - --cache-namespaces={{ join "," .Values.listener.cacheNamespaces }}
         {{- end }}

--- a/charts/kubernetes-graphql-gateway/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/kubernetes-graphql-gateway/tests/__snapshot__/deployment_test.yaml.snap
@@ -123,8 +123,8 @@ has all hostAliases configured:
                 - --reconciler-gvr=apibindings.v1alpha2.apis.kcp.io
                 - --additional-path-annotation-key=kcp.io/path
                 - --metrics-bind-address=:8091
-                - --enable-resource-controller
-                - --enable-clusteraccess-controller
+                - --enable-resource-controller=true
+                - --enable-clusteraccess-controller=true
                 - --single-kubeconfig=/app/single-kubeconfig/kubeconfig
                 - --resource-controller-providers=kcp
                 - --clusteraccess-controller-providers=single
@@ -314,8 +314,8 @@ matches the Snapshot:
                 - --reconciler-gvr=apibindings.v1alpha2.apis.kcp.io
                 - --additional-path-annotation-key=kcp.io/path
                 - --metrics-bind-address=:8091
-                - --enable-resource-controller
-                - --enable-clusteraccess-controller
+                - --enable-resource-controller=true
+                - --enable-clusteraccess-controller=true
                 - --single-kubeconfig=/app/single-kubeconfig/kubeconfig
                 - --resource-controller-providers=kcp
                 - --clusteraccess-controller-providers=single
@@ -418,8 +418,8 @@ renders default multi-mode with all features enabled:
                 - --reconciler-gvr=apibindings.v1alpha2.apis.kcp.io
                 - --additional-path-annotation-key=kcp.io/path
                 - --metrics-bind-address=:8091
-                - --enable-resource-controller
-                - --enable-clusteraccess-controller
+                - --enable-resource-controller=true
+                - --enable-clusteraccess-controller=true
                 - --single-kubeconfig=/app/single-kubeconfig/kubeconfig
                 - --resource-controller-providers=kcp
                 - --clusteraccess-controller-providers=single
@@ -518,8 +518,8 @@ renders listener with kcp provider mode:
                 - --reconciler-gvr=apibindings.v1alpha2.apis.kcp.io
                 - --additional-path-annotation-key=kcp.io/path
                 - --metrics-bind-address=:8091
-                - --enable-resource-controller
-                - --enable-clusteraccess-controller
+                - --enable-resource-controller=true
+                - --enable-clusteraccess-controller=true
               env:
                 - name: KUBECONFIG
                   value: /app/kubeconfig/kubeconfig
@@ -619,8 +619,8 @@ renders listener with multi provider mode and all flags:
                 - --reconciler-gvr=apibindings.v1alpha2.apis.kcp.io
                 - --additional-path-annotation-key=kcp.io/path
                 - --metrics-bind-address=:8091
-                - --enable-resource-controller
-                - --enable-clusteraccess-controller
+                - --enable-resource-controller=true
+                - --enable-clusteraccess-controller=true
                 - --single-kubeconfig=/app/single-kubeconfig/kubeconfig
                 - --resource-controller-providers=kcp,single
                 - --clusteraccess-controller-providers=single
@@ -717,8 +717,8 @@ renders listener with single provider mode:
                 - --grpc-listen-addr=:50051
                 - --multicluster-runtime-provider=single
                 - --metrics-bind-address=:8091
-                - --enable-resource-controller
-                - --enable-clusteraccess-controller
+                - --enable-resource-controller=true
+                - --enable-clusteraccess-controller=true
               env:
                 - name: KUBECONFIG
                   value: /app/kubeconfig/kubeconfig

--- a/charts/kubernetes-graphql-gateway/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/kubernetes-graphql-gateway/tests/__snapshot__/deployment_test.yaml.snap
@@ -28,6 +28,7 @@ has all hostAliases configured:
                 - gateway
                 - --schema-handler=grpc
                 - --grpc-listener-address=platform-mesh-kubernetes-graphql-gateway-listener.platform-mesh-system.svc.cluster.local:50051
+                - --enable-playground
               env:
                 - name: KUBECONFIG
                   value: /app/kubeconfig/kubeconfig
@@ -224,6 +225,7 @@ matches the Snapshot:
                 - gateway
                 - --schema-handler=grpc
                 - --grpc-listener-address=platform-mesh-kubernetes-graphql-gateway-listener.platform-mesh-system.svc.cluster.local:50051
+                - --enable-playground
               env:
                 - name: KUBECONFIG
                   value: /app/kubeconfig/kubeconfig

--- a/charts/kubernetes-graphql-gateway/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubernetes-graphql-gateway/tests/__snapshot__/snapshot_test.yaml.snap
@@ -28,6 +28,7 @@ match the Snapshot:
                 - gateway
                 - --schema-handler=grpc
                 - --grpc-listener-address=platform-mesh-kubernetes-graphql-gateway-listener.platform-mesh-system.svc.cluster.local:50051
+                - --enable-playground
               env:
                 - name: KUBECONFIG
                   value: /app/kubeconfig/kubeconfig

--- a/charts/kubernetes-graphql-gateway/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubernetes-graphql-gateway/tests/__snapshot__/snapshot_test.yaml.snap
@@ -118,8 +118,8 @@ match the Snapshot:
                 - --reconciler-gvr=apibindings.v1alpha2.apis.kcp.io
                 - --additional-path-annotation-key=kcp.io/path
                 - --metrics-bind-address=:8091
-                - --enable-resource-controller
-                - --enable-clusteraccess-controller
+                - --enable-resource-controller=true
+                - --enable-clusteraccess-controller=true
                 - --single-kubeconfig=/app/single-kubeconfig/kubeconfig
                 - --resource-controller-providers=kcp
                 - --clusteraccess-controller-providers=single

--- a/charts/kubernetes-graphql-gateway/tests/__snapshot__/test_values_test.yaml.snap
+++ b/charts/kubernetes-graphql-gateway/tests/__snapshot__/test_values_test.yaml.snap
@@ -398,8 +398,8 @@ match the Snapshot:
                 - --reconciler-gvr=apibindings.v1alpha2.apis.kcp.io
                 - --additional-path-annotation-key=kcp.io/path
                 - --metrics-bind-address=:8091
-                - --enable-resource-controller
-                - --enable-clusteraccess-controller
+                - --enable-resource-controller=true
+                - --enable-clusteraccess-controller=true
                 - --single-kubeconfig=/app/single-kubeconfig/kubeconfig
                 - --resource-controller-providers=kcp
                 - --clusteraccess-controller-providers=single
@@ -974,8 +974,8 @@ match the Snapshot with crds:
                 - --reconciler-gvr=apibindings.v1alpha2.apis.kcp.io
                 - --additional-path-annotation-key=kcp.io/path
                 - --metrics-bind-address=:8091
-                - --enable-resource-controller
-                - --enable-clusteraccess-controller
+                - --enable-resource-controller=true
+                - --enable-clusteraccess-controller=true
                 - --single-kubeconfig=/app/single-kubeconfig/kubeconfig
                 - --resource-controller-providers=kcp
                 - --clusteraccess-controller-providers=single

--- a/charts/kubernetes-graphql-gateway/tests/__snapshot__/test_values_test.yaml.snap
+++ b/charts/kubernetes-graphql-gateway/tests/__snapshot__/test_values_test.yaml.snap
@@ -308,6 +308,7 @@ match the Snapshot:
                 - gateway
                 - --schema-handler=grpc
                 - --grpc-listener-address=platform-mesh-kubernetes-graphql-gateway-listener.platform-mesh-system.svc.cluster.local:50051
+                - --enable-playground
               env:
                 - name: KUBECONFIG
                   value: /app/kubeconfig/kubeconfig
@@ -884,6 +885,7 @@ match the Snapshot with crds:
                 - gateway
                 - --schema-handler=grpc
                 - --grpc-listener-address=platform-mesh-kubernetes-graphql-gateway-listener.platform-mesh-system.svc.cluster.local:50051
+                - --enable-playground
               env:
                 - name: KUBECONFIG
                   value: /app/kubeconfig/kubeconfig

--- a/charts/kubernetes-graphql-gateway/values.yaml
+++ b/charts/kubernetes-graphql-gateway/values.yaml
@@ -29,7 +29,7 @@ gateway:
     enabled: true
     port: 8080
   metricsPort: 8081
-  graphiql: true
+  playground: true
   logLevel: trace
   shouldImpersonate: false
   introspectionAuthentication: true


### PR DESCRIPTION
## Summary

Fixes three issues in the `kubernetes-graphql-gateway` chart:

1. **`enableResourceController` / `enableClusterAccessController` not working when set to `false`**
   - The template only rendered the bare flag when `true`, omitting it when `false`
   - Since the binary defaults both to `true`, setting them to `false` had no effect
   - Now renders `--enable-resource-controller=<bool>` and `--enable-clusteraccess-controller=<bool>` explicitly

2. **GraphQL playground not wired in chart**
   - The `gateway.graphiql` value existed but was never referenced in the deployment template
   - Renamed to `gateway.playground` and wired to `--enable-playground` flag

3. **Chart version bump to 0.38.2**

## Changed files

- `templates/deploy-listener.yaml` — explicit boolean flags
- `templates/deploy-gateway.yaml` — playground flag
- `values.yaml` — rename `graphiql` → `playground`
- `Chart.yaml` — version bump
- `README.md` — regenerated docs
- `tests/__snapshot__/*` — updated snapshots

## Test plan

- [x] `helm unittest` — all 21 tests pass, 37 snapshots updated
- [x] `ct lint` — passes
- [x] `task docs` — README regenerated
- [x] Verified `helm template` renders `--enable-resource-controller=false` when set
- [x] Verified `helm template` renders `--enable-playground` when `gateway.playground=true`
- [x] Verified `--enable-playground` omitted when `gateway.playground=false`