### PR TITLE
fix: restart stopped containers instead of failing on re-run

### DIFF
--- a/local-setup/scripts/check-environment.sh
+++ b/local-setup/scripts/check-environment.sh
@@ -7,14 +7,21 @@ COL='\033[92m'
 RED='\033[91m'
 COL_RES='\033[0m'
 
+detect_container_runtime() {
+    if command -v docker &> /dev/null && docker info &> /dev/null; then
+        echo "docker"
+    elif command -v podman &> /dev/null && podman info &> /dev/null; then
+        echo "podman"
+    else
+        echo ""
+    fi
+}
+
 check_kind_cluster() {
     # Check if kind cluster is registered
     if [ $(kind get clusters 2>/dev/null | grep -c platform-mesh) -gt 0 ]; then
-        # Detect container runtime
-        local runtime="docker"
-        if command -v podman &> /dev/null && podman info &> /dev/null; then
-            runtime="podman"
-        fi
+        local runtime
+        runtime=$(detect_container_runtime)
 
         # Verify the control-plane container is actually running; start it if stopped
         if ! $runtime ps --format '{{.Names}}' | grep -q '^platform-mesh-control-plane$'; then
@@ -287,6 +294,7 @@ run_environment_checks() {
 }
 
 # Export functions so they can be used by the main script
+export -f detect_container_runtime
 export -f check_kind_cluster
 export -f check_kind_dependency
 export -f check_kubectl_dependency

--- a/local-setup/scripts/check-environment.sh
+++ b/local-setup/scripts/check-environment.sh
@@ -8,8 +8,31 @@ RED='\033[91m'
 COL_RES='\033[0m'
 
 check_kind_cluster() {
-    # Check if kind cluster is already running
+    # Check if kind cluster is registered
     if [ $(kind get clusters 2>/dev/null | grep -c platform-mesh) -gt 0 ]; then
+        # Detect container runtime
+        local runtime="docker"
+        if command -v podman &> /dev/null && podman info &> /dev/null; then
+            runtime="podman"
+        fi
+
+        # Verify the control-plane container is actually running; start it if stopped
+        if ! $runtime ps --format '{{.Names}}' | grep -q '^platform-mesh-control-plane$'; then
+            echo -e "${COL}[$(date '+%H:%M:%S')] Kind cluster exists but control-plane is stopped, restarting... ${COL_RES}"
+            $runtime start platform-mesh-control-plane
+            # Wait for the API server to become ready before proceeding
+            local deadline=60
+            local elapsed=0
+            while ! kubectl cluster-info --request-timeout=2s &>/dev/null; do
+                if [ $elapsed -ge $deadline ]; then
+                    echo -e "${RED}❌ Timed out waiting for API server to become ready${COL_RES}"
+                    return 1
+                fi
+                sleep 2
+                elapsed=$((elapsed + 2))
+            done
+        fi
+
         echo -e "${COL}[$(date '+%H:%M:%S')] Kind cluster already running, using existing ${COL_RES}"
         kind export kubeconfig --name platform-mesh
         return 0  # Return 0 to indicate cluster exists

--- a/local-setup/scripts/setup-registry-proxies.sh
+++ b/local-setup/scripts/setup-registry-proxies.sh
@@ -10,7 +10,6 @@ COL_RES='\033[0m'
 setup_registry_proxies() {
     echo -e "${COL}[$(date '+%H:%M:%S')] Setting up registry proxies for cached mode ${COL_RES}"
 
-    # Reuse shared runtime detection from check-environment.sh
     CONTAINER_RUNTIME=$(detect_container_runtime)
     if [ -z "$CONTAINER_RUNTIME" ]; then
         echo -e "${RED}❌ Error: No container runtime available${COL_RES}"

--- a/local-setup/scripts/setup-registry-proxies.sh
+++ b/local-setup/scripts/setup-registry-proxies.sh
@@ -10,12 +10,9 @@ COL_RES='\033[0m'
 setup_registry_proxies() {
     echo -e "${COL}[$(date '+%H:%M:%S')] Setting up registry proxies for cached mode ${COL_RES}"
 
-    # Detect container runtime (docker or podman)
-    if command -v docker &> /dev/null && docker info &> /dev/null; then
-        CONTAINER_RUNTIME="docker"
-    elif command -v podman &> /dev/null && podman info &> /dev/null; then
-        CONTAINER_RUNTIME="podman"
-    else
+    # Reuse shared runtime detection from check-environment.sh
+    CONTAINER_RUNTIME=$(detect_container_runtime)
+    if [ -z "$CONTAINER_RUNTIME" ]; then
         echo -e "${RED}❌ Error: No container runtime available${COL_RES}"
         return 1
     fi

--- a/local-setup/scripts/setup-registry-proxies.sh
+++ b/local-setup/scripts/setup-registry-proxies.sh
@@ -28,27 +28,36 @@ setup_registry_proxies() {
     fi
 
     # Start proxy-quay if not already running
-    if ! $CONTAINER_RUNTIME ps --format '{{.Names}}' | grep -q '^proxy-quay$'; then
+    if $CONTAINER_RUNTIME ps --format '{{.Names}}' | grep -q '^proxy-quay$'; then
+        echo -e "${COL}[$(date '+%H:%M:%S')] ✅ proxy-quay registry already running ${COL_RES}"
+    elif $CONTAINER_RUNTIME ps -a --format '{{.Names}}' | grep -q '^proxy-quay$'; then
+        echo -e "${COL}[$(date '+%H:%M:%S')] Starting existing proxy-quay container ${COL_RES}"
+        $CONTAINER_RUNTIME start proxy-quay
+    else
         echo -e "${COL}[$(date '+%H:%M:%S')] Starting proxy-quay registry ${COL_RES}"
         $CONTAINER_RUNTIME run -d --name proxy-quay --restart=always --net=kind -e REGISTRY_PROXY_REMOTEURL=https://quay.io registry:2
-    else
-        echo -e "${COL}[$(date '+%H:%M:%S')] ✅ proxy-quay registry already running ${COL_RES}"
     fi
 
     # Start proxy-ghcr if not already running
-    if ! $CONTAINER_RUNTIME ps --format '{{.Names}}' | grep -q '^proxy-ghcr$'; then
+    if $CONTAINER_RUNTIME ps --format '{{.Names}}' | grep -q '^proxy-ghcr$'; then
+        echo -e "${COL}[$(date '+%H:%M:%S')] ✅ proxy-ghcr registry already running ${COL_RES}"
+    elif $CONTAINER_RUNTIME ps -a --format '{{.Names}}' | grep -q '^proxy-ghcr$'; then
+        echo -e "${COL}[$(date '+%H:%M:%S')] Starting existing proxy-ghcr container ${COL_RES}"
+        $CONTAINER_RUNTIME start proxy-ghcr
+    else
         echo -e "${COL}[$(date '+%H:%M:%S')] Starting proxy-ghcr registry ${COL_RES}"
         $CONTAINER_RUNTIME run -d --name proxy-ghcr --restart=always --net=kind -e REGISTRY_PROXY_REMOTEURL=https://ghcr.io registry:2
-    else
-        echo -e "${COL}[$(date '+%H:%M:%S')] ✅ proxy-ghcr registry already running ${COL_RES}"
     fi
 
     # Start proxy-k8s-io if not already running
-    if ! $CONTAINER_RUNTIME ps --format '{{.Names}}' | grep -q '^proxy-k8s-io$'; then
+    if $CONTAINER_RUNTIME ps --format '{{.Names}}' | grep -q '^proxy-k8s-io$'; then
+        echo -e "${COL}[$(date '+%H:%M:%S')] ✅ proxy-k8s-io registry already running ${COL_RES}"
+    elif $CONTAINER_RUNTIME ps -a --format '{{.Names}}' | grep -q '^proxy-k8s-io$'; then
+        echo -e "${COL}[$(date '+%H:%M:%S')] Starting existing proxy-k8s-io container ${COL_RES}"
+        $CONTAINER_RUNTIME start proxy-k8s-io
+    else
         echo -e "${COL}[$(date '+%H:%M:%S')] Starting proxy-k8s-io registry ${COL_RES}"
         $CONTAINER_RUNTIME run -d --name proxy-k8s-io --restart=always --net=kind -e REGISTRY_PROXY_REMOTEURL=https://registry.k8s.io registry:2
-    else
-        echo -e "${COL}[$(date '+%H:%M:%S')] ✅ proxy-k8s-io registry already running ${COL_RES}"
     fi
 
     return 0


### PR DESCRIPTION
Fix re-run failures caused by containers that exist but are stopped.

- setup-registry-proxies.sh: adds a stopped-container check (ps -a) for each proxy registry — if found but not running, calls start instead of run, avoiding the "container name already in use" error

- check-environment.sh: when the kind cluster is registered but platform-mesh-control-plane is not in the running containers list, starts the container and polls kubectl cluster-info until the API server is ready (60s timeout) before exporting the kubeconfig