### PR TITLE
feat(local-setup): finalize KCP-local convergence in one script

### DIFF
--- a/local-setup/scripts/finalizeKcpLocal.sh
+++ b/local-setup/scripts/finalizeKcpLocal.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Post-install steps that every local KCP setup needs but the Flux/Helm
+# chart path can't produce on its own.
+#
+# 1. Patch CoreDNS so in-cluster pods resolve `root.kcp.localhost` and the
+#    other localhost-based KCP URLs to the Traefik ClusterIP (the only
+#    in-cluster service listening on 8443). Without this, sync-agents and
+#    the portal fail to reach KCP from inside the cluster.
+#
+# 2. Disable the security workspace initializer. The security operator
+#    cannot manage Keycloak realms locally (403 Forbidden), which blocks
+#    WorkspaceType initialization and leaves new workspaces stuck in
+#    "Initializing".
+#
+# 3. Ensure the `root:providers` KCP workspace exists so per-provider
+#    tutorials (private-llm, chat-ui, etc.) can go straight to
+#    `kubectl kcp workspace create <provider> --type=root:provider`
+#    without the prerequisite of creating the parent workspace first.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+KCP_KUBECONFIG="$SCRIPT_DIR/../../.secret/kcp/admin.kubeconfig"
+KCP_URL="${KCP_URL:-https://localhost:8443}"
+
+COL=${COL:-"\033[0;36m"}
+COL_RES=${COL_RES:-"\033[0m"}
+
+echo -e "${COL}[$(date '+%H:%M:%S')] Patching CoreDNS to resolve kcp.localhost hostnames to Traefik ${COL_RES}"
+TRAEFIK_IP=$(kubectl get svc -n default traefik -o jsonpath='{.spec.clusterIP}')
+kubectl get configmap coredns -n kube-system -o json | \
+  python3 -c "
+import sys, json
+cm = json.load(sys.stdin)
+ip = '$TRAEFIK_IP'
+hosts_block = f'''hosts {{
+           {ip} localhost portal.localhost kcp.localhost root.kcp.localhost
+           fallthrough
+        }}
+        '''
+corefile = cm['data']['Corefile']
+# Idempotent: only inject the hosts block if it isn't already present.
+if 'root.kcp.localhost' not in corefile:
+    cm['data']['Corefile'] = corefile.replace(
+        'kubernetes cluster.local', hosts_block + 'kubernetes cluster.local')
+json.dump(cm, sys.stdout)
+" | kubectl apply -f - >/dev/null
+
+kubectl rollout restart deploy coredns -n kube-system >/dev/null
+kubectl rollout status deploy coredns -n kube-system --timeout=60s >/dev/null
+
+echo -e "${COL}[$(date '+%H:%M:%S')] Disabling security workspace initializer (Keycloak realm creation is not supported locally) ${COL_RES}"
+kubectl scale deploy -n platform-mesh-system security-operator-initializer --replicas=0 >/dev/null
+kubectl --kubeconfig="$KCP_KUBECONFIG" patch workspacetype security \
+  --server="$KCP_URL/clusters/root" \
+  --type=merge -p '{"spec":{"initializer":false}}' >/dev/null
+
+echo -e "${COL}[$(date '+%H:%M:%S')] Ensuring root:providers workspace exists ${COL_RES}"
+KUBECONFIG="$KCP_KUBECONFIG" kubectl create-workspace providers \
+  --type=root:providers --ignore-existing \
+  --server="$KCP_URL/clusters/root" >/dev/null

--- a/local-setup/scripts/start.sh
+++ b/local-setup/scripts/start.sh
@@ -225,6 +225,13 @@ kubectl wait --namespace platform-mesh-system \
 echo -e "${COL}[$(date '+%H:%M:%S')] Preparing KCP Secrets for admin access ${COL_RES}"
 $SCRIPT_DIR/createKcpAdminKubeconfig.sh
 
+# Apply KCP-local fixes that every setup needs: CoreDNS hosts entry for
+# root.kcp.localhost, security-operator-initializer off (Keycloak realm
+# management doesn't work locally), and the root:providers workspace
+# pre-created so per-provider tutorials can skip the parent-workspace
+# prerequisite.
+$SCRIPT_DIR/finalizeKcpLocal.sh
+
 # Run post-platform-mesh hook if it exists (PlatformMesh is ready, KCP is accessible)
 if [ -f "$SCRIPT_DIR/post-platform-mesh-hook.sh" ]; then
     echo -e "${COL}[$(date '+%H:%M:%S')] Running post-platform-mesh hook ${COL_RES}"
@@ -232,8 +239,7 @@ if [ -f "$SCRIPT_DIR/post-platform-mesh-hook.sh" ]; then
 fi
 
 if [ "$EXAMPLE_DATA" = true ]; then
-  
-  KUBECONFIG=$(pwd)/.secret/kcp/admin.kubeconfig kubectl create-workspace providers --type=root:providers --ignore-existing --server="https://localhost:8443/clusters/root"
+
   KUBECONFIG=$(pwd)/.secret/kcp/admin.kubeconfig kubectl create-workspace httpbin-provider --type=root:provider --ignore-existing --server="https://localhost:8443/clusters/root:providers"
   KUBECONFIG=$(pwd)/.secret/kcp/admin.kubeconfig kubectl apply -k $SCRIPT_DIR/../example-data/root/providers/httpbin-provider --server="https://localhost:8443/clusters/root:providers:httpbin-provider"
   KUBECONFIG=$(pwd)/.secret/kcp/admin.kubeconfig kubectl apply -k $SCRIPT_DIR/../example-data/root/orgs --server="https://localhost:8443/clusters/root:orgs"


### PR DESCRIPTION
## Summary

Three post-install fixes every local Platform Mesh setup needs — bundled
into an idempotent `finalizeKcpLocal.sh` called from `start.sh` right
after KCP admin kubeconfig is generated:

1. **CoreDNS hosts block** for `root.kcp.localhost` → Traefik ClusterIP.
   Sync-agents and the portal can't reach KCP from inside the Kind
   cluster without this.
2. **Disable security workspace initializer**. Keycloak realm creation
   isn't supported locally, so the initializer leaves new workspaces
   stuck `Initializing`.
3. **Pre-create `root:providers` workspace** so per-provider tutorials
   can skip the parent-workspace prerequisite (was already created
   when `--example-data` was passed; just moving it out).

## Why

[apeirora-docu#259](https://github.tools.sap/ApeiroRA/apeirora-docu/pull/259)
currently carries a scary Python CoreDNS heredoc + security-initializer
disable + workspace bootstrap block. With this PR those user-facing
blocks go away: the tutorial starts at `task local-setup` → `helm install`.

Same story for future per-provider tutorials.

## Idempotency

Script checks for existing state before mutating, `--ignore-existing` on
workspace creation, scale/patch are naturally idempotent. Safe to
re-run via `task local-setup:iterate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)