### PR TITLE
fix(local-setup): bump kindest/node v1.35.0 → v1.35.1

### DIFF
--- a/local-setup/scripts/start.sh
+++ b/local-setup/scripts/start.sh
@@ -14,7 +14,7 @@ YELLOW='\033[93m'
 COL_RES='\033[0m'
 
 KUBECTL_WAIT_TIMEOUT="${KUBECTL_WAIT_TIMEOUT:-900s}"
- KINDEST_VERSION="kindest/node:v1.35.0"
+ KINDEST_VERSION="kindest/node:v1.35.1"
 
 SCRIPT_DIR=$(dirname "$0")
 


### PR DESCRIPTION
## Summary

`kindest/node:v1.35.0` kubelet crash-loops during kubeadm-init on Apple Silicon Docker Desktop (arm64). `task local-setup` never completes; Mac contributors are blocked before the first tutorial step.

`v1.35.1` (same minor) fixes it. Verified on arm64 macOS / Docker Desktop kernel 6.12.76-linuxkit:

| Image | Result |
|---|---|
| `kindest/node:v1.35.0` | ❌ kubeadm crash-looping, node never Ready |
| `kindest/node:v1.35.1` | ✅ `Ready after 16s` |
| `kindest/node:v1.34.3` | ✅ (fallback if anyone needs the prior minor) |

All three images publish `linux/arm64` manifests — this was a kubelet bug in `v1.35.0`, not a missing arch.

## Impact

- Apple Silicon contributors no longer need to hand-edit `start.sh` before running `task local-setup`.
- Linux + Intel-macOS users: no observable change (same 1.35.x line, patch bump).

## Test plan

- [x] `kind create cluster --image=kindest/node:v1.35.1` on arm64 Docker Desktop — Ready in 16s
- [ ] Linux regression check
- [ ] Intel-macOS regression check