### PR TITLE
fix(local-setup): Retry PlatformMesh bootstrap until ready

### DIFF
--- a/local-setup/scripts/createKcpAdminKubeconfig.sh
+++ b/local-setup/scripts/createKcpAdminKubeconfig.sh
@@ -6,6 +6,7 @@ KCP_URL=https://localhost:8443
 #KCP_URL=https://kcp.api.portal.cc-one.showroom.apeirora.eu
 
 mkdir -p $PWD/.secret/kcp
+rm -f $PWD/.secret/kcp/admin.kubeconfig
 kubectl get secret $KCP_CA_SECRET -n platform-mesh-system -o=jsonpath='{.data.ca\.crt}' | base64 -d > $PWD/.secret/kcp/ca.crt
 kubectl --kubeconfig=$PWD/.secret/kcp/admin.kubeconfig config set-cluster --embed-certs  workspace.kcp.io/current --server $KCP_URL/clusters/root --certificate-authority=$PWD/.secret/kcp/ca.crt
 kubectl get secret $KCP_ADMIN_SECRET -n platform-mesh-system -o=jsonpath='{.data.tls\.crt}' | base64 -d > $PWD/.secret/kcp/client.crt

--- a/local-setup/scripts/start.sh
+++ b/local-setup/scripts/start.sh
@@ -218,9 +218,26 @@ fi
 
 # wait for kind: PlatformMesh resource to become ready
 echo -e "${COL}[$(date '+%H:%M:%S')] Waiting for kind: PlatformMesh resource to become ready ${COL_RES}"
-kubectl wait --namespace platform-mesh-system \
-  --for=condition=Ready platformmesh \
-  --timeout=$KUBECTL_WAIT_TIMEOUT platform-mesh
+wait_timeout_seconds="${KUBECTL_WAIT_TIMEOUT%s}"
+deadline=$((SECONDS + wait_timeout_seconds))
+while true; do
+  ready_status="$(kubectl get --namespace platform-mesh-system platformmesh/platform-mesh -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || true)"
+  if [ "$ready_status" = "True" ]; then
+    break
+  fi
+
+  if [ $SECONDS -ge $deadline ]; then
+    kubectl get --namespace platform-mesh-system platformmesh/platform-mesh -o wide
+    kubectl describe --namespace platform-mesh-system platformmesh/platform-mesh
+    echo -e "${RED}[$(date '+%H:%M:%S')] Timed out waiting for PlatformMesh to become ready ${COL_RES}"
+    exit 1
+  fi
+
+  kubectl annotate --namespace platform-mesh-system platformmesh/platform-mesh \
+    local-setup.platform-mesh.io/retry-ts="$(date +%s)" \
+    --overwrite >/dev/null
+  sleep 10
+done
 
 echo -e "${COL}[$(date '+%H:%M:%S')] Preparing KCP Secrets for admin access ${COL_RES}"
 $SCRIPT_DIR/createKcpAdminKubeconfig.sh


### PR DESCRIPTION
## Summary

- keep `local-setup` retrying `PlatformMesh` reconciliation until the resource actually reaches `Ready` or the existing timeout expires
- recreate `.secret/kcp/admin.kubeconfig` from scratch so a partial bootstrap cannot leave stale cluster data behind
- fix the fresh-cluster Step 1 path where startup races in KCP and the security webhook could stop `task local-setup` even though the cluster would converge on a later retry

## Validation

- `bash -n local-setup/scripts/start.sh`
- `bash -n local-setup/scripts/createKcpAdminKubeconfig.sh`
- `kind delete cluster --name platform-mesh`
- `task local-setup`
- end-to-end rerun of the local MSP tutorial on the fresh cluster:
  - `LLMInstance demo-llm` reached `Ready`
  - `APITokenRequest demo-llm` reached `Ready`
  - `ChatUIInstance demo-chat` reached `Ready`
  - `kubectl port-forward ... svc/demo-chat-chatui 8080:8080`
  - `curl -I http://127.0.0.1:8080` returned `HTTP/1.1 200 OK`

## Why This Fix

- the failing path was transient bootstrap drift, not a steady-state configuration problem
- retrying the existing `PlatformMesh` reconcile is the smallest safe fix because it preserves the current local installation model and only makes bootstrap resilient to startup ordering races
