### PR TITLE
docs: migration to 0.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ bin/*
 .claude
 oci/
 *.webm
-
 local-setup/webhook-config/*
 !local-setup/webhook-config/*.sh
 !local-setup/webhook-config/*.yaml
@@ -26,7 +25,8 @@ registry-ca.pem
 local-setup/rootCA.pem
 local-setup/e2e/node_modules/
 local-setup/e2e/*.png
-local-setup/scripts/post-flux-hook.sh
-local-setup/scripts/post-platform-mesh-hook.sh
-local-setup/scripts/platform-mesh-resource-hook.sh
+local-setup/scripts/load-custom-images.sh
 /convo
+docs/migration-0.3/kcp-exports
+local-setup/backup
+tmp/

--- a/docs/migration-0.2.0/backup-restore.md
+++ b/docs/migration-0.2.0/backup-restore.md
@@ -1,0 +1,139 @@
+# Backup and Restore Guide
+
+This guide covers backing up and restoring the platform-mesh data stores: **etcd** (kcp), **OpenFGA**, and **Keycloak**. These procedures are applicable during version upgrades and migration scenarios. Data restoration is not always required.
+
+## Prerequisites
+
+- `fga` CLI installed
+- `kubectl` configured with access to the target cluster
+- etcd-backup-restore Docker image from [gardener/etcd-backup-restore](https://github.com/gardener/etcd-backup-restore):
+
+  ```text
+  europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl:v0.41.0
+  ```
+
+## Backup
+
+> **Note:** Ensure you have a valid backup before attempting any restore operation.
+
+### Preparation
+
+Create the backup directories:
+
+```shell
+mkdir -p backup/etcd
+mkdir -p backup/fga/postgres
+mkdir -p backup/keycloak/postgres
+```
+
+Load the etcd-backup-restore image into the cluster and port-forward the OpenFGA service:
+
+```shell
+kind load docker-image europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl:v0.41.0 --name platform-mesh
+kubectl -n platform-mesh-system port-forward svc/openfga 3000 8080 8081
+```
+
+### Backup OpenFGA
+
+Backs up the OpenFGA PostgreSQL database and exports the store using the FGA CLI.
+
+```shell
+local-setup/scripts/fga_backup.sh
+```
+
+### Backup etcd (kcp)
+
+Creates a full etcd snapshot.
+
+```shell
+local-setup/scripts/etcd_backup.sh
+```
+
+### Backup Keycloak
+
+Backs up the Keycloak PostgreSQL database and the database credentials secret.
+
+```shell
+local-setup/scripts/keycloak_backup.sh
+```
+
+## Restore
+
+### Restore OpenFGA
+
+Deletes the existing pod, PVC, and PV, waits for the StatefulSet to recreate them with a clean volume, and restores the PostgreSQL dump.
+
+```shell
+local-setup/scripts/openfga_postgres_restore.sh
+```
+
+### Restore etcd (kcp)
+
+**Step 1** -- Scale down the etcd StatefulSet:
+
+```shell
+kubectl -n platform-mesh-system scale statefulset etcd-kcp --replicas=0
+```
+
+**Step 2** -- Create a temporary restore pod with the etcd PVC mounted:
+
+```shell
+kubectl -n platform-mesh-system apply -f - <<'EOF'
+apiVersion: v1
+kind: Pod
+metadata:
+  name: etcd-restore
+  namespace: platform-mesh-system
+spec:
+  containers:
+  - name: restore
+    image: europe-docker.pkg.dev/gardener-project/public/gardener/etcdbrctl:v0.41.0
+    command: ["sleep", "3600"]
+    volumeMounts:
+    - name: etcd-data
+      mountPath: /var/etcd/data
+  volumes:
+  - name: etcd-data
+    persistentVolumeClaim:
+      claimName: etcd-kcp-etcd-kcp-0
+EOF
+```
+
+**Step 3** -- Copy the snapshot into the restore pod (run from the host):
+
+```shell
+kubectl -n platform-mesh-system exec -ti etcd-restore -- mkdir -p /root/tmp/etcd-backup/v2
+kubectl -n platform-mesh-system cp \
+  backup/etcd/Full-00000000-00016935-1770191336.gz \
+  etcd-restore:/root/tmp/etcd-backup/v2/Full-00000000-00016935-1770191336.gz.final
+```
+
+**Step 4** -- Restore the data (run inside the restore pod):
+
+```shell
+kubectl -n platform-mesh-system exec -it etcd-restore -- sh
+```
+
+Once inside the pod, run:
+
+```shell
+./etcdbrctl restore \
+  --storage-provider="Local" \
+  --store-container="/tmp/etcd-backup" \
+  --data-dir="/tmp/etcd-data" \
+  --restoration-temp-snapshots-dir="/tmp/restoration.tmp"
+```
+
+**Step 5** -- Fix permissions on the restored data (still inside the pod):
+
+```shell
+chown -R 65532:65532 /var/etcd/data/new.etcd/member/
+```
+
+### Restore Keycloak
+
+Similar to OpenFGA, this deletes the existing pod, PVC, and PV, waits for recreation, restores the database secret, and then restores the PostgreSQL dump using the password from the secret.
+
+```shell
+local-setup/scripts/keycloak_postgres_restore.sh
+```

--- a/docs/migration-0.2.0/create_identityprovider_config.sh
+++ b/docs/migration-0.2.0/create_identityprovider_config.sh
@@ -1,0 +1,281 @@
+#!/bin/bash
+
+# Script to create IdentityProviderConfiguration resources in all org workspaces
+# Creates missing IdentityProviderConfiguration resources under :root:orgs with
+# default client configurations for portal and kubectl.
+
+set -euo pipefail
+
+# Configuration - can be overridden via environment variables
+PORTAL_HOST="${PORTAL_HOST:-localhost}"
+KUBECONFIG_KCP="${KUBECONFIG_KCP:-}"
+DRY_RUN="${DRY_RUN:-false}"
+DEBUG="${DEBUG:-false}"
+SECRET_NAMESPACE="${SECRET_NAMESPACE:-default}"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+log_debug() {
+    if [ "$DEBUG" = "true" ]; then
+        echo -e "${BLUE}[DEBUG]${NC} $1"
+    fi
+}
+
+# Check prerequisites
+check_prerequisites() {
+    if ! command -v kubectl &> /dev/null; then
+        log_error "kubectl is not installed or not in PATH"
+        exit 1
+    fi
+
+    if ! command -v yq &> /dev/null; then
+        log_error "yq is not installed or not in PATH"
+        exit 1
+    fi
+}
+
+# Generate IdentityProviderConfiguration manifest
+generate_manifest() {
+    local workspace_name="$1"
+    local portal_host="$2"
+
+    # Build redirect URIs - always include localhost + portal host URIs
+    local default_client_redirects='    - http://localhost:8000/callback*
+    - http://localhost:4300/callback*'
+    local default_client_logout_redirects='    - http://localhost:8000/logout*'
+
+    # Add portal host URIs if not localhost
+    if [ -n "$portal_host" ] && [ "$portal_host" != "localhost" ]; then
+        default_client_redirects+='
+    - https://'"${portal_host}"'/*
+    - https://'"${workspace_name}"'.'"${portal_host}"'/*'
+        default_client_logout_redirects+='
+    - https://'"${portal_host}"'/logout*'
+    fi
+
+    # Generate workspace-specific secret names
+    local secret_name_default="portal-client-secret-${workspace_name}-${workspace_name}"
+    local secret_name_kubectl="portal-client-secret-${workspace_name}-kubectl"
+
+    cat <<EOF
+apiVersion: core.platform-mesh.io/v1alpha1
+kind: IdentityProviderConfiguration
+metadata:
+  name: ${workspace_name}
+spec:
+  clients:
+  - clientName: default
+    clientType: confidential
+    postLogoutRedirectUris:
+${default_client_logout_redirects}
+    redirectUris:
+${default_client_redirects}
+    secretRef:
+      name: ${secret_name_default}
+      namespace: ${SECRET_NAMESPACE}
+  - clientName: kubectl
+    clientType: public
+    redirectUris:
+    - http://localhost:8000
+    - http://localhost:18000
+    secretRef:
+      name: ${secret_name_kubectl}
+      namespace: ${SECRET_NAMESPACE}
+EOF
+}
+
+# Check if IdentityProviderConfiguration already exists in the current workspace
+has_identity_provider_config() {
+    local workspace_name="$1"
+
+    kubectl get identityproviderconfiguration "$workspace_name" &>/dev/null
+    return $?
+}
+
+# Create IdentityProviderConfiguration for an org in its own workspace
+create_org_identity_provider_config() {
+    local workspace_path="$1"
+    local workspace_name="$2"
+
+    log_info "Processing org workspace: ${workspace_path}"
+
+    # Navigate to the org workspace
+    kubectl ws "${workspace_path}" &>/dev/null || {
+        log_error "  Failed to navigate to workspace: ${workspace_path}"
+        return 1
+    }
+
+    if has_identity_provider_config "${workspace_name}"; then
+        log_warn "  IdentityProviderConfiguration '${workspace_name}' already exists, skipping"
+        return 0
+    fi
+
+    log_info "  Creating IdentityProviderConfiguration..."
+
+    local manifest
+    manifest=$(generate_manifest "$workspace_name" "$PORTAL_HOST")
+
+    if [ "$DRY_RUN" = "true" ]; then
+        log_warn "  Dry run - would create IdentityProviderConfiguration:"
+        echo "$manifest" | yq '.' || echo "$manifest"
+        return 0
+    fi
+
+    if echo "$manifest" | kubectl apply -f - 2>/dev/null; then
+        log_success "  Created IdentityProviderConfiguration '${workspace_name}' in ${workspace_path}"
+        return 0
+    else
+        log_error "  Failed to create IdentityProviderConfiguration '${workspace_name}' in ${workspace_path}"
+        return 1
+    fi
+}
+
+# Show help
+show_help() {
+    cat <<EOF
+Usage: $0 [OPTIONS]
+
+Create IdentityProviderConfiguration resources in all org workspaces under :root:orgs.
+Creates missing IdentityProviderConfiguration resources with default client configurations
+for portal and kubectl access.
+
+The script automatically generates workspace-specific secret names in the format:
+  - portal-client-secret-<workspace>-default
+  - portal-client-secret-<workspace>-kubectl
+
+Options:
+  --dry-run                    Show what would be done without making changes
+  --debug                      Enable debug output
+  --portal-host HOST           Portal hostname for redirect URIs (default: \$PORTAL_HOST or localhost)
+  --secret-namespace NS        Secret namespace (default: \$SECRET_NAMESPACE or default)
+  --kubeconfig-kcp PATH        Kubeconfig for kcp (default: \$KUBECONFIG_KCP or \$KUBECONFIG)
+  -h, --help                   Show this help message
+
+Environment variables:
+  PORTAL_HOST                  Portal hostname for redirect URIs
+  SECRET_NAMESPACE             Secret namespace
+  KUBECONFIG_KCP               Kubeconfig for kcp
+  DRY_RUN                      Set to "true" for dry-run mode
+  DEBUG                        Set to "true" for debug output
+
+Example:
+  # Create resources in all org workspaces with portal host
+  PORTAL_HOST=portal.example.com $0
+
+  # Dry run with custom portal host
+  $0 --dry-run --portal-host portal.example.com
+
+  # Using environment variables
+  export PORTAL_HOST=portal.example.com
+  export KUBECONFIG_KCP=/path/to/kcp/kubeconfig
+  $0
+EOF
+}
+
+# Main
+main() {
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --dry-run)
+                DRY_RUN=true
+                shift
+                ;;
+            --debug)
+                DEBUG=true
+                shift
+                ;;
+            --portal-host)
+                PORTAL_HOST="$2"
+                shift 2
+                ;;
+            --secret-namespace)
+                SECRET_NAMESPACE="$2"
+                shift 2
+                ;;
+            --kubeconfig-kcp)
+                KUBECONFIG_KCP="$2"
+                shift 2
+                ;;
+            -h|--help)
+                show_help
+                exit 0
+                ;;
+            *)
+                log_error "Unknown option: $1"
+                show_help
+                exit 1
+                ;;
+        esac
+    done
+
+    check_prerequisites
+
+    if [ -n "$KUBECONFIG_KCP" ]; then
+        export KUBECONFIG="$KUBECONFIG_KCP"
+        log_info "Using kcp kubeconfig: $KUBECONFIG_KCP"
+    fi
+
+    if [ "$DRY_RUN" = "true" ]; then
+        log_warn "Running in dry-run mode - no changes will be applied"
+    fi
+
+    log_info "Portal host: $PORTAL_HOST"
+    log_info "Secret namespace: ${SECRET_NAMESPACE}"
+    log_info "Secret names will be generated per workspace: portal-client-secret-<workspace>-{default,kubectl}"
+    echo ""
+
+    # Navigate to :root:orgs to get list of org workspaces
+    log_info "Navigating to :root:orgs to list org workspaces"
+
+    if ! kubectl ws :root:orgs &>/dev/null; then
+        log_error "Failed to navigate to :root:orgs workspace"
+        exit 1
+    fi
+
+    # Get all top-level orgs
+    local top_level_orgs
+    top_level_orgs=$(kubectl get workspaces -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
+
+    if [[ -z "$top_level_orgs" ]]; then
+        log_warn "No workspaces found under :root:orgs"
+        exit 0
+    fi
+
+    log_info "Found top-level orgs: $top_level_orgs"
+    echo ""
+
+    # Create IdentityProviderConfiguration in each org workspace
+    for org in $top_level_orgs; do
+        create_org_identity_provider_config ":root:orgs:${org}" "$org"
+    done
+
+    # Return to root workspace
+    kubectl ws :root &>/dev/null || true
+
+    echo ""
+    log_success "Completed creating IdentityProviderConfiguration resources"
+}
+
+main "$@"

--- a/docs/migration-0.2.0/export-kcp-resources.sh
+++ b/docs/migration-0.2.0/export-kcp-resources.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Export all KCP resources from all workspaces as YAML.
+#
+# Usage:
+#   docs/migration-0.3/export-kcp-resources.sh <output-dir>
+#
+# Example:
+#   docs/migration-0.3/export-kcp-resources.sh docs/migration-0.3/kcp-exports/v0.2
+
+OUTDIR="${1:?Usage: $0 <output-dir>}"
+KUBECONFIG_KCP="${KUBECONFIG_KCP:-.secret/kcp/admin.kubeconfig}"
+KCP_SERVER="${KCP_SERVER:-https://localhost:8443}"
+
+if [[ ! -f "$KUBECONFIG_KCP" ]]; then
+  echo "Error: KCP admin kubeconfig not found at $KUBECONFIG_KCP" >&2
+  echo "Run 'local-setup/scripts/createKcpAdminKubeconfig.sh' first." >&2
+  exit 1
+fi
+
+KC="kubectl --kubeconfig=$KUBECONFIG_KCP"
+
+kcp_get() {
+  local ws="$1" resource="$2"
+  $KC get "$resource" --server "${KCP_SERVER}/clusters/${ws}" -o yaml 2>/dev/null || true
+}
+
+kcp_api_resources() {
+  local ws="$1"
+  $KC api-resources --server "${KCP_SERVER}/clusters/${ws}" 2>/dev/null || true
+}
+
+discover_workspaces() {
+  local parent="$1"
+  echo "$parent"
+  local children
+  children=$($KC get workspace --server "${KCP_SERVER}/clusters/${parent}" \
+    -o jsonpath='{.items[*].metadata.name}' 2>/dev/null) || true
+  for child in $children; do
+    discover_workspaces "${parent}:${child}"
+  done
+}
+
+has_items() {
+  local yaml="$1"
+  [[ -n "$yaml" ]] && echo "$yaml" | grep -q '^kind:' && ! echo "$yaml" | grep -q '^items: \[\]$'
+}
+
+KCP_RESOURCES=(
+  apiexports.apis.kcp.io
+  apiexportendpointslices.apis.kcp.io
+  apiresourceschemas.apis.kcp.io
+  apibindings.apis.kcp.io
+  apiconversions.apis.kcp.io
+  workspaces.tenancy.kcp.io
+  workspacetypes.tenancy.kcp.io
+  logicalclusters.core.kcp.io
+  shards.core.kcp.io
+  clusterroles
+  clusterrolebindings
+  workspaceauthenticationconfiguration.tenancy.kcp.io
+)
+
+PLATFORM_MESH_RESOURCES=(
+  accounts.core.platform-mesh.io
+  accountinfos.core.platform-mesh.io
+  identityproviderconfigurations.core.platform-mesh.io
+  stores.core.platform-mesh.io
+  authorizationmodels.core.platform-mesh.io
+  invites.core.platform-mesh.io
+  apiexportpolicies.core.platform-mesh.io
+  httpbins.orchestrate.platform-mesh.io
+)
+
+echo "=== Discovering workspaces ==="
+WORKSPACES=()
+while IFS= read -r ws; do
+  WORKSPACES+=("$ws")
+done < <(discover_workspaces "root")
+
+echo "Found ${#WORKSPACES[@]} workspaces:"
+printf "  %s\n" "${WORKSPACES[@]}"
+
+mkdir -p "$OUTDIR"
+
+echo ""
+echo "=== Exporting KCP resources ==="
+
+for ws in "${WORKSPACES[@]}"; do
+  ws_dir="$OUTDIR/${ws//:/_}"
+  mkdir -p "$ws_dir"
+
+  echo "--- Workspace: $ws ---"
+
+  echo "  api-resources"
+  kcp_api_resources "$ws" > "$ws_dir/api-resources.txt"
+
+  for resource in "${KCP_RESOURCES[@]}" "${PLATFORM_MESH_RESOURCES[@]}"; do
+    short="${resource%%.*}"
+    result=$(kcp_get "$ws" "$resource")
+    if has_items "$result"; then
+      echo "  $short"
+      echo "$result" > "$ws_dir/${short}.yaml"
+    fi
+  done
+done
+
+echo ""
+echo "=== Exporting K8s-side resources ==="
+
+K8S_DIR="$OUTDIR/k8s"
+mkdir -p "$K8S_DIR"
+
+for resource in helmreleases.helm.toolkit.fluxcd.io components.delivery.ocm.software \
+  resourcegraphdefinitions.kro.run platformmeshes.core.platform-mesh.io \
+  resources.delivery.ocm.software; do
+  short="${resource%%.*}"
+  echo "  $short"
+  kubectl get "$resource" -A -o yaml > "$K8S_DIR/${short}.yaml" 2>/dev/null || true
+done
+
+kubectl get pods -n platform-mesh-system -o wide > "$K8S_DIR/pods.txt" 2>/dev/null || true
+kubectl get helmrelease -A > "$K8S_DIR/helmrelease-status.txt" 2>/dev/null || true
+
+echo ""
+echo "=== Export complete ==="
+echo "Output directory: $OUTDIR"
+find "$OUTDIR" -type f | wc -l | xargs -I{} echo "Total files: {}"

--- a/docs/migration-0.2.0/fix_accountinfo.sh
+++ b/docs/migration-0.2.0/fix_accountinfo.sh
@@ -1,0 +1,372 @@
+#!/bin/bash
+set -euo pipefail
+
+# Script to patch AccountInfo objects for all workspaces under :root:orgs.
+# Updates OIDC configuration, issuer URL, URL hostnames, and syncs client
+# IDs from Keycloak so they match the currently configured clients.
+
+# Keycloak configuration (KEYCLOAK_URL derived from PlatformMesh if not set)
+KEYCLOAK_URL="${KEYCLOAK_URL:-}"
+ISSUER_BASE_URL="${ISSUER_BASE_URL:-}"
+KEYCLOAK_USER="${KEYCLOAK_USER:-keycloak-admin}"
+KEYCLOAK_PASSWORD="${KEYCLOAK_PASSWORD:-admin}"
+OLD_HOST="${OLD_HOST:-kcp.api.portal.dev.local}"
+NEW_HOST="${NEW_HOST:-localhost}"
+
+# Global variables
+ADMIN_TOKEN=""
+DRY_RUN=false
+KUBECONFIG_KCP="${KUBECONFIG_KCP:-}"
+KUBECONFIG_K8S="${KUBECONFIG_K8S:-}"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Derive Keycloak URL from the PlatformMesh resource in the regular k8s cluster.
+# Uses KUBECONFIG_K8S when set so the lookup targets the host cluster, not kcp.
+get_keycloak_url_from_cluster() {
+    local kc_args=()
+    if [ -n "$KUBECONFIG_K8S" ]; then
+        kc_args+=(--kubeconfig "$KUBECONFIG_K8S")
+    fi
+
+    local base_domain port
+    base_domain=$(kubectl "${kc_args[@]}" -n platform-mesh-system get platformmesh platform-mesh \
+        -o jsonpath='{.spec.exposure.baseDomain}' 2>/dev/null) || return 1
+    port=$(kubectl "${kc_args[@]}" -n platform-mesh-system get platformmesh platform-mesh \
+        -o jsonpath='{.spec.exposure.port}' 2>/dev/null) || return 1
+
+    if [ -z "$base_domain" ] || [ -z "$port" ]; then
+        return 1
+    fi
+
+    echo "https://${base_domain}:${port}/keycloak"
+}
+
+# Check for required tools
+check_dependencies() {
+    local missing=()
+
+    for tool in kubectl curl jq; do
+        if ! command -v "$tool" &> /dev/null; then
+            missing+=("$tool")
+        fi
+    done
+
+    if [ ${#missing[@]} -ne 0 ]; then
+        log_error "Missing required tools: ${missing[*]}"
+        exit 1
+    fi
+}
+
+# Get Keycloak admin token
+get_admin_token() {
+    curl -sk -X POST "${KEYCLOAK_URL}/realms/master/protocol/openid-connect/token" \
+        -H "Content-Type: application/x-www-form-urlencoded" \
+        -d "username=${KEYCLOAK_USER}" \
+        -d "password=${KEYCLOAK_PASSWORD}" \
+        -d "grant_type=password" \
+        -d "client_id=admin-cli" | jq -r '.access_token'
+}
+
+# Get the clientId (UUID) for a client by its display name in a realm.
+# The security-operator creates clients with UUIDs as clientId and the
+# human-readable identifier in the 'name' field, so we match on .name.
+get_client_id() {
+    local token="$1"
+    local realm="$2"
+    local client_name="$3"
+
+    curl -sk -X GET "${KEYCLOAK_URL}/admin/realms/${realm}/clients" \
+        -H "Authorization: Bearer ${token}" \
+        | jq -r --arg name "$client_name" '[.[] | select(.name == $name)] | .[0].clientId // empty'
+}
+
+# Recursive function to process workspaces and patch AccountInfo
+# Arguments: $1 = workspace path (e.g., :root:orgs:default)
+process_workspace() {
+    local ws_path="$1"
+    local indent="$2"
+
+    log_info "${indent}Processing workspace: $ws_path"
+
+    # Navigate to the workspace
+    kubectl ws "$ws_path"
+
+    # Extract realm name from the workspace path (last segment after :root:orgs:)
+    # e.g., :root:orgs:default -> default, :root:orgs:default:testaccount -> testaccount
+    local realm_name
+    realm_name=$(echo "$ws_path" | sed 's/.*:orgs://' | tr ':' '-')
+    # For nested paths like default:testaccount, use the full path with dashes
+    # But for Keycloak realm lookup, we need to determine the actual realm
+    local keycloak_realm
+    keycloak_realm=$(echo "$ws_path" | sed 's/.*:orgs://' | sed 's/:.*$//')
+
+    # Check if AccountInfo named "account" exists in this workspace
+    if kubectl get accountinfo account &>/dev/null; then
+        log_info "${indent}  Found AccountInfo 'account', patching..."
+
+        # Get current URLs and replace hostname
+        local account_url org_url parent_url
+        account_url=$(kubectl get accountinfo account -o jsonpath='{.spec.account.url}' 2>/dev/null || echo "")
+        org_url=$(kubectl get accountinfo account -o jsonpath='{.spec.organization.url}' 2>/dev/null || echo "")
+        parent_url=$(kubectl get accountinfo account -o jsonpath='{.spec.parentAccount.url}' 2>/dev/null || echo "")
+
+        log_info "${indent}  Current account.url: '$account_url'"
+        log_info "${indent}  Current organization.url: '$org_url'"
+        log_info "${indent}  Current parentAccount.url: '$parent_url'"
+
+        # Patch each URL field individually using JSON Patch for precise updates
+        # This avoids issues with merge patch and empty values
+
+        if [[ -n "$account_url" && "$account_url" == *"$OLD_HOST"* ]]; then
+            local new_account_url
+            new_account_url="${account_url//$OLD_HOST/$NEW_HOST}"
+            if [ "$DRY_RUN" = "true" ]; then
+                log_warn "${indent}  Dry run - would patch account.url: $account_url -> $new_account_url"
+            else
+                log_info "${indent}  Patching account.url: $account_url -> $new_account_url"
+                kubectl patch accountinfo account --type=json \
+                    -p "[{\"op\": \"replace\", \"path\": \"/spec/account/url\", \"value\": \"${new_account_url}\"}]"
+            fi
+        fi
+
+        if [[ -n "$org_url" && "$org_url" == *"$OLD_HOST"* ]]; then
+            local new_org_url
+            new_org_url="${org_url//$OLD_HOST/$NEW_HOST}"
+            if [ "$DRY_RUN" = "true" ]; then
+                log_warn "${indent}  Dry run - would patch organization.url: $org_url -> $new_org_url"
+            else
+                log_info "${indent}  Patching organization.url: $org_url -> $new_org_url"
+                kubectl patch accountinfo account --type=json \
+                    -p "[{\"op\": \"replace\", \"path\": \"/spec/organization/url\", \"value\": \"${new_org_url}\"}]"
+            fi
+        fi
+
+        if [[ -n "$parent_url" && "$parent_url" == *"$OLD_HOST"* ]]; then
+            local new_parent_url
+            new_parent_url="${parent_url//$OLD_HOST/$NEW_HOST}"
+            if [ "$DRY_RUN" = "true" ]; then
+                log_warn "${indent}  Dry run - would patch parentAccount.url: $parent_url -> $new_parent_url"
+            else
+                log_info "${indent}  Patching parentAccount.url: $parent_url -> $new_parent_url"
+                kubectl patch accountinfo account --type=json \
+                    -p "[{\"op\": \"replace\", \"path\": \"/spec/parentAccount/url\", \"value\": \"${new_parent_url}\"}]"
+            fi
+        fi
+
+        # Fetch client IDs from Keycloak using the top-level realm.
+        # The realm-named client matches the workspace name (e.g. realm
+        # "myorg1" has a client named "myorg1"). 'kubectl' is always fixed.
+        log_info "${indent}  Fetching client IDs from Keycloak for realm: $keycloak_realm"
+        local default_client_id kubectl_client_id
+        default_client_id=$(get_client_id "$ADMIN_TOKEN" "$keycloak_realm" "$keycloak_realm")
+        kubectl_client_id=$(get_client_id "$ADMIN_TOKEN" "$keycloak_realm" "kubectl")
+
+        if [[ -z "$default_client_id" ]]; then
+            log_warn "${indent}  Client '$keycloak_realm' not found in Keycloak realm $keycloak_realm"
+        else
+            log_info "${indent}  Found '$keycloak_realm' client ID: $default_client_id"
+        fi
+
+        if [[ -z "$kubectl_client_id" ]]; then
+            log_warn "${indent}  Client 'kubectl' not found in Keycloak realm $keycloak_realm"
+        else
+            log_info "${indent}  Found 'kubectl' client ID: $kubectl_client_id"
+        fi
+
+        # Build OIDC patch with issuerUrl and any resolved client IDs
+        local oidc_patch='{"spec":{"oidc":{"issuerUrl":"'"${ISSUER_BASE_URL}/${keycloak_realm}"'"'
+
+        if [[ -n "$default_client_id" && -n "$kubectl_client_id" ]]; then
+            oidc_patch+=',"clients":{"default":{"clientId":"'"${default_client_id}"'"},"kubectl":{"clientId":"'"${kubectl_client_id}"'"}}'
+        elif [[ -n "$default_client_id" ]]; then
+            oidc_patch+=',"clients":{"default":{"clientId":"'"${default_client_id}"'"}}'
+        elif [[ -n "$kubectl_client_id" ]]; then
+            oidc_patch+=',"clients":{"kubectl":{"clientId":"'"${kubectl_client_id}"'"}}'
+        fi
+
+        oidc_patch+='}}}'
+
+        if [ "$DRY_RUN" = "true" ]; then
+            log_warn "${indent}  Dry run - would patch OIDC configuration:"
+            echo "$oidc_patch" | jq .
+        else
+            log_info "${indent}  Patching OIDC configuration and client IDs..."
+            kubectl patch accountinfo account --type=merge -p "$oidc_patch"
+            log_info "${indent}  Successfully patched AccountInfo"
+        fi
+    else
+        log_info "${indent}  No AccountInfo 'account' found, skipping patch..."
+    fi
+
+    # Get child workspaces and process them recursively
+    local children
+    children=$(kubectl get workspaces -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
+
+    if [[ -n "$children" ]]; then
+        log_info "${indent}  Found child workspaces: $children"
+        for child in $children; do
+            process_workspace "${ws_path}:${child}" "${indent}  "
+        done
+    fi
+}
+
+# Main function
+main() {
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --dry-run)
+                DRY_RUN=true
+                shift
+                ;;
+            --keycloak-user)
+                KEYCLOAK_USER="$2"
+                shift 2
+                ;;
+            --keycloak-password)
+                KEYCLOAK_PASSWORD="$2"
+                shift 2
+                ;;
+            --issuer-base-url)
+                ISSUER_BASE_URL="$2"
+                shift 2
+                ;;
+            --old-host)
+                OLD_HOST="$2"
+                shift 2
+                ;;
+            --new-host)
+                NEW_HOST="$2"
+                shift 2
+                ;;
+            --kubeconfig)
+                KUBECONFIG_K8S="$2"
+                shift 2
+                ;;
+            --kubeconfig-kcp)
+                KUBECONFIG_KCP="$2"
+                shift 2
+                ;;
+            -h|--help)
+                echo "Usage: $0 [OPTIONS]"
+                echo ""
+                echo "Patch AccountInfo objects for all workspaces under :root:orgs."
+                echo "Updates OIDC configuration, issuer URL, URL hostnames, and syncs"
+                echo "client IDs from Keycloak."
+                echo ""
+                echo "Options:"
+                echo "  --dry-run                Show what would be done without making changes"
+                echo "  --keycloak-user USER     Keycloak admin username (default: \$KEYCLOAK_USER or keycloak-admin)"
+                echo "  --keycloak-password PW   Keycloak admin password (default: \$KEYCLOAK_PASSWORD or admin)"
+                echo "  --issuer-base-url URL    OIDC issuer base URL (default: \$ISSUER_BASE_URL or \$KEYCLOAK_URL/realms)"
+                echo "  --old-host HOST          Hostname to replace in URLs (default: \$OLD_HOST or kcp.api.portal.dev.local)"
+                echo "  --new-host HOST          Replacement hostname (default: \$NEW_HOST or localhost)"
+                echo "  --kubeconfig PATH        Kubeconfig for the Kubernetes cluster (default: \$KUBECONFIG_K8S or \$KUBECONFIG)"
+                echo "  --kubeconfig-kcp PATH    Kubeconfig for kcp (default: \$KUBECONFIG_KCP or \$KUBECONFIG)"
+                echo "  -h, --help               Show this help message"
+                echo ""
+                echo "Environment variables:"
+                echo "  KEYCLOAK_URL             Keycloak base URL"
+                echo "  KEYCLOAK_USER            Keycloak admin username"
+                echo "  KEYCLOAK_PASSWORD        Keycloak admin password"
+                echo "  ISSUER_BASE_URL          OIDC issuer base URL"
+                echo "  OLD_HOST                 Hostname to replace"
+                echo "  NEW_HOST                 Replacement hostname"
+                echo "  KUBECONFIG_K8S           Kubeconfig for the Kubernetes cluster"
+                echo "  KUBECONFIG_KCP           Kubeconfig for kcp"
+                exit 0
+                ;;
+            *)
+                log_error "Unknown option: $1"
+                exit 1
+                ;;
+        esac
+    done
+
+    check_dependencies
+
+    if [ -n "$KUBECONFIG_K8S" ]; then
+        log_info "Using k8s kubeconfig: $KUBECONFIG_K8S"
+    fi
+
+    if [ "$DRY_RUN" = "true" ]; then
+        log_warn "Running in dry-run mode - no changes will be applied"
+    fi
+
+    # Derive Keycloak URL from PlatformMesh resource if not explicitly set.
+    # This must happen before switching to the kcp kubeconfig because
+    # PlatformMesh lives in the regular Kubernetes cluster.
+    if [ -z "$KEYCLOAK_URL" ]; then
+        log_info "KEYCLOAK_URL not set, reading from PlatformMesh resource..."
+        KEYCLOAK_URL=$(get_keycloak_url_from_cluster) || true
+        if [ -z "$KEYCLOAK_URL" ]; then
+            log_error "Failed to derive Keycloak URL from PlatformMesh resource."
+            log_error "Set KEYCLOAK_URL explicitly."
+            exit 1
+        fi
+        log_info "Derived Keycloak URL: $KEYCLOAK_URL"
+    fi
+
+    # Switch to kcp kubeconfig for all subsequent kubectl commands
+    if [ -n "$KUBECONFIG_KCP" ]; then
+        export KUBECONFIG="$KUBECONFIG_KCP"
+        log_info "Using kcp kubeconfig: $KUBECONFIG_KCP"
+    fi
+
+    # Derive ISSUER_BASE_URL from KEYCLOAK_URL if not explicitly set
+    if [ -z "$ISSUER_BASE_URL" ]; then
+        ISSUER_BASE_URL="${KEYCLOAK_URL}/realms"
+        log_info "Derived ISSUER_BASE_URL: $ISSUER_BASE_URL"
+    fi
+
+    # Get Keycloak admin token
+    log_info "Fetching Keycloak admin token from $KEYCLOAK_URL..."
+    ADMIN_TOKEN=$(get_admin_token)
+    if [[ -z "$ADMIN_TOKEN" || "$ADMIN_TOKEN" == "null" ]]; then
+        log_error "Failed to get Keycloak admin token. Check your credentials."
+        exit 1
+    fi
+    log_info "Successfully obtained admin token"
+
+    # Start recursive processing from :root:orgs
+    log_info "=== Starting recursive AccountInfo patching from :root:orgs ==="
+
+    # First, get all top-level orgs
+    kubectl ws :root:orgs
+    TOP_LEVEL_ORGS=$(kubectl get workspaces -o jsonpath='{.items[*].metadata.name}')
+
+    if [[ -z "$TOP_LEVEL_ORGS" ]]; then
+        log_warn "No workspaces found under :root:orgs"
+        exit 0
+    fi
+
+    log_info "Found top-level orgs: $TOP_LEVEL_ORGS"
+
+    for org in $TOP_LEVEL_ORGS; do
+        process_workspace ":root:orgs:${org}" ""
+    done
+
+    # Return to root workspace
+    kubectl ws :root
+
+    log_info "=== Done patching all AccountInfo objects recursively (OIDC and URL) ==="
+}
+
+main "$@"

--- a/docs/migration-0.2.0/fix_apibindings.sh
+++ b/docs/migration-0.2.0/fix_apibindings.sh
@@ -1,0 +1,210 @@
+#!/bin/bash
+
+# Script to traverse all KCP workspaces starting from :root and patch APIBinding resources
+# with name prefix "core.platform-mesh.io-" to add a permission claim for secrets.
+
+set -euo pipefail
+
+# Configuration - can be overridden via environment variables
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+KUBECONFIG_PATH="${KUBECONFIG_PATH:-${REPO_ROOT}/.secret/kcp/admin.kubeconfig}"
+KCP_SERVER="${KCP_SERVER:-https://localhost:8443}"
+APIBINDING_PREFIX="core.platform-mesh.io-"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+log_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Check prerequisites
+check_prerequisites() {
+    if ! command -v kubectl &> /dev/null; then
+        log_error "kubectl is not installed or not in PATH"
+        exit 1
+    fi
+
+    if ! command -v jq &> /dev/null; then
+        log_error "jq is not installed or not in PATH"
+        exit 1
+    fi
+
+    if [[ ! -f "${KUBECONFIG_PATH}" ]]; then
+        log_error "Kubeconfig not found at: ${KUBECONFIG_PATH}"
+        exit 1
+    fi
+}
+
+# Permission claim JSON to add
+PERMISSION_CLAIM='{
+  "group": "",
+  "identityHash": "",
+  "resource": "secrets",
+  "selector": {
+    "matchAll": true
+  },
+  "state": "Accepted",
+  "verbs": ["*"]
+}'
+
+# Check if secrets permission claim already exists in the APIBinding
+has_secrets_permission_claim() {
+    local workspace_path=$1
+    local apibinding_name=$2
+    local server_url="${KCP_SERVER}/clusters/${workspace_path}"
+
+    local existing_claims
+    existing_claims=$(kubectl --kubeconfig="${KUBECONFIG_PATH}" get apibinding "${apibinding_name}" \
+        --server="${server_url}" \
+        -o jsonpath='{.spec.permissionClaims}' 2>/dev/null || echo "[]")
+
+    if [[ -z "${existing_claims}" || "${existing_claims}" == "null" ]]; then
+        return 1  # No claims exist
+    fi
+
+    # Check if secrets claim already exists
+    local has_secrets
+    has_secrets=$(echo "${existing_claims}" | jq '[.[] | select(.resource == "secrets")] | length')
+
+    if [[ "${has_secrets}" -gt 0 ]]; then
+        return 0  # Secrets claim exists
+    fi
+    return 1  # No secrets claim
+}
+
+# Patch APIBinding to add secrets permission claim
+patch_apibinding() {
+    local workspace_path=$1
+    local apibinding_name=$2
+    local server_url="${KCP_SERVER}/clusters/${workspace_path}"
+
+    # Check if permissionClaims array exists
+    local existing_claims
+    existing_claims=$(kubectl --kubeconfig="${KUBECONFIG_PATH}" get apibinding "${apibinding_name}" \
+        --server="${server_url}" \
+        -o jsonpath='{.spec.permissionClaims}' 2>/dev/null || echo "")
+
+    local patch_json
+    if [[ -z "${existing_claims}" || "${existing_claims}" == "null" ]]; then
+        # permissionClaims doesn't exist, create it with the claim
+        patch_json=$(jq -n --argjson claim "${PERMISSION_CLAIM}" '[{"op": "add", "path": "/spec/permissionClaims", "value": [$claim]}]')
+    else
+        # permissionClaims exists, append to it
+        patch_json=$(jq -n --argjson claim "${PERMISSION_CLAIM}" '[{"op": "add", "path": "/spec/permissionClaims/-", "value": $claim}]')
+    fi
+
+    if kubectl --kubeconfig="${KUBECONFIG_PATH}" patch apibinding "${apibinding_name}" \
+        --server="${server_url}" \
+        --type='json' \
+        -p="${patch_json}" 2>/dev/null; then
+        log_success "Patched APIBinding '${apibinding_name}' in workspace '${workspace_path}'"
+        return 0
+    else
+        log_error "Failed to patch APIBinding '${apibinding_name}' in workspace '${workspace_path}'"
+        return 1
+    fi
+}
+
+# Process APIBindings in a workspace
+process_apibindings_in_workspace() {
+    local workspace_path=$1
+    local server_url="${KCP_SERVER}/clusters/${workspace_path}"
+
+    log_info "Processing workspace: ${workspace_path}"
+
+    # Get all APIBindings
+    local apibindings_json
+    apibindings_json=$(kubectl --kubeconfig="${KUBECONFIG_PATH}" get apibindings \
+        --server="${server_url}" \
+        -o json 2>/dev/null || echo '{"items":[]}')
+
+    # Filter APIBindings with the prefix
+    local matching_apibindings
+    matching_apibindings=$(echo "${apibindings_json}" | jq -r \
+        --arg prefix "${APIBINDING_PREFIX}" \
+        '.items[] | select(.metadata.name | startswith($prefix)) | .metadata.name')
+
+    if [[ -z "${matching_apibindings}" ]]; then
+        log_info "  No APIBindings with prefix '${APIBINDING_PREFIX}' found"
+        return 0
+    fi
+
+    # Process each matching APIBinding
+    while IFS= read -r apibinding_name; do
+        if [[ -n "${apibinding_name}" ]]; then
+            if has_secrets_permission_claim "${workspace_path}" "${apibinding_name}"; then
+                log_warning "  APIBinding '${apibinding_name}' already has secrets permission claim, skipping"
+            else
+                log_info "  Patching APIBinding '${apibinding_name}'..."
+                patch_apibinding "${workspace_path}" "${apibinding_name}" || true
+            fi
+        fi
+    done <<< "${matching_apibindings}"
+}
+
+# Recursively traverse workspaces
+traverse_workspace() {
+    local workspace_path=$1
+    local server_url="${KCP_SERVER}/clusters/${workspace_path}"
+
+    # Process APIBindings in current workspace
+    process_apibindings_in_workspace "${workspace_path}"
+
+    # Get child workspaces
+    local workspaces_json
+    workspaces_json=$(kubectl --kubeconfig="${KUBECONFIG_PATH}" get workspaces \
+        --server="${server_url}" \
+        -o json 2>/dev/null || echo '{"items":[]}')
+
+    local child_workspaces
+    child_workspaces=$(echo "${workspaces_json}" | jq -r '.items[].metadata.name // empty')
+
+    if [[ -z "${child_workspaces}" ]]; then
+        return 0
+    fi
+
+    # Recursively process each child workspace
+    while IFS= read -r child_name; do
+        if [[ -n "${child_name}" ]]; then
+            local child_path="${workspace_path}:${child_name}"
+            traverse_workspace "${child_path}"
+        fi
+    done <<< "${child_workspaces}"
+}
+
+# Main
+main() {
+    log_info "Starting KCP workspace traversal for APIBinding patching"
+    log_info "Kubeconfig: ${KUBECONFIG_PATH}"
+    log_info "KCP Server: ${KCP_SERVER}"
+    log_info "APIBinding prefix: ${APIBINDING_PREFIX}"
+    echo ""
+
+    check_prerequisites
+
+    # Start traversal from root
+    traverse_workspace "root"
+
+    echo ""
+    log_success "Workspace traversal completed"
+}
+
+main "$@"

--- a/docs/migration-0.2.0/fix_apiexport.sh
+++ b/docs/migration-0.2.0/fix_apiexport.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+#
+# Script to fix the APIExport in kcp after the 0.2.0 migration.
+# Deletes the core.platform-mesh.io APIExport in :root:platform-mesh-system
+# and restarts the platform-mesh-operator pods so it gets recreated with
+# the updated schema.
+#
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Global variables
+DRY_RUN=false
+KUBECONFIG_KCP="${KUBECONFIG_KCP:-}"
+KUBECONFIG_K8S="${KUBECONFIG_K8S:-}"
+NAMESPACE="platform-mesh-system"
+
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Check for required tools
+check_dependencies() {
+    local missing=()
+
+    for tool in kubectl; do
+        if ! command -v "$tool" &> /dev/null; then
+            missing+=("$tool")
+        fi
+    done
+
+    if [ ${#missing[@]} -ne 0 ]; then
+        log_error "Missing required tools: ${missing[*]}"
+        exit 1
+    fi
+}
+
+# Main function
+main() {
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --dry-run)
+                DRY_RUN=true
+                shift
+                ;;
+            --namespace)
+                NAMESPACE="$2"
+                shift 2
+                ;;
+            --kubeconfig)
+                KUBECONFIG_K8S="$2"
+                shift 2
+                ;;
+            --kubeconfig-kcp)
+                KUBECONFIG_KCP="$2"
+                shift 2
+                ;;
+            -h|--help)
+                echo "Usage: $0 [OPTIONS]"
+                echo ""
+                echo "Delete the core.platform-mesh.io APIExport in kcp and restart"
+                echo "the platform-mesh-operator pods so the APIExport is recreated."
+                echo ""
+                echo "Options:"
+                echo "  --dry-run              Show what would be done without making changes"
+                echo "  --namespace NS         Kubernetes namespace (default: platform-mesh-system)"
+                echo "  --kubeconfig PATH      Kubeconfig for the Kubernetes cluster (default: \$KUBECONFIG_K8S or \$KUBECONFIG)"
+                echo "  --kubeconfig-kcp PATH  Kubeconfig for kcp (default: \$KUBECONFIG_KCP or \$KUBECONFIG)"
+                echo "  -h, --help             Show this help message"
+                echo ""
+                echo "Environment variables:"
+                echo "  KUBECONFIG_K8S         Kubeconfig for the Kubernetes cluster"
+                echo "  KUBECONFIG_KCP         Kubeconfig for kcp"
+                exit 0
+                ;;
+            *)
+                log_error "Unknown option: $1"
+                exit 1
+                ;;
+        esac
+    done
+
+    check_dependencies
+
+    if [ "$DRY_RUN" = "true" ]; then
+        log_warn "Running in dry-run mode - no changes will be applied"
+    fi
+
+    # --- kcp: delete the APIExport ---
+    log_info "=== Deleting APIExport in kcp ==="
+
+    local kcp_args=()
+    if [ -n "$KUBECONFIG_KCP" ]; then
+        kcp_args+=(--kubeconfig "$KUBECONFIG_KCP")
+        log_info "Using kcp kubeconfig: $KUBECONFIG_KCP"
+    fi
+
+    log_info "Navigating to :root:platform-mesh-system workspace..."
+    if [ "$DRY_RUN" = "true" ]; then
+        log_warn "Dry run - would run: kubectl ${kcp_args[*]+"${kcp_args[*]}"} ws :root:platform-mesh-system"
+        log_warn "Dry run - would run: kubectl ${kcp_args[*]+"${kcp_args[*]}"} delete apiexport core.platform-mesh.io"
+    else
+        kubectl "${kcp_args[@]+"${kcp_args[@]}"}" ws :root:platform-mesh-system
+        log_info "Deleting APIExport core.platform-mesh.io..."
+        kubectl "${kcp_args[@]+"${kcp_args[@]}"}" delete apiexport core.platform-mesh.io
+        log_info "APIExport deleted"
+    fi
+
+    # --- k8s: restart the operator ---
+    log_info "=== Restarting platform-mesh-operator pods ==="
+
+    local k8s_args=()
+    if [ -n "$KUBECONFIG_K8S" ]; then
+        k8s_args+=(--kubeconfig "$KUBECONFIG_K8S")
+        log_info "Using k8s kubeconfig: $KUBECONFIG_K8S"
+    fi
+
+    if [ "$DRY_RUN" = "true" ]; then
+        log_warn "Dry run - would run: kubectl ${k8s_args[*]+"${k8s_args[*]}"} -n $NAMESPACE delete pod -l app=platform-mesh-operator"
+    else
+        kubectl "${k8s_args[@]+"${k8s_args[@]}"}" -n "$NAMESPACE" delete pod -l app=platform-mesh-operator
+        log_info "platform-mesh-operator pods restarted"
+    fi
+
+    echo ""
+    log_info "=== APIExport fix complete ==="
+}
+
+main "$@"

--- a/docs/migration-0.2.0/fix_stores.sh
+++ b/docs/migration-0.2.0/fix_stores.sh
@@ -1,0 +1,242 @@
+#!/bin/bash
+#
+# Script to update FGA Store resources with the latest core module model
+# from the security-operator chart. Patches spec.coreModule on all Store
+# resources in the :root:orgs workspace and clears the stale
+# authorizationModelId from their status so the security-operator can
+# reconcile them cleanly.
+#
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Global variables
+DRY_RUN=false
+KUBECONFIG_KCP="${KUBECONFIG_KCP:-}"
+
+# The current core module model from the security-operator chart
+CORE_MODULE='
+module core
+
+type user
+
+type role
+  relations
+    define assignee: [user,user:*]
+
+type core_platform-mesh_io_account
+  relations
+    define parent: [core_platform-mesh_io_account]
+
+    define owner: [role#assignee] or owner from parent
+    define member: [role#assignee] or owner
+
+    define get: member
+    define update: member
+    define patch: member
+    define delete: owner
+
+    define create_core_platform-mesh_io_accounts: member
+    define list_core_platform-mesh_io_accounts: member
+    define watch_core_platform-mesh_io_accounts: member
+
+    # org and account specific
+    define watch: member
+
+    define create_core_platform-mesh_io_accountinfos: member
+    define list_core_platform-mesh_io_accountinfos: member
+    define watch_core_platform-mesh_io_accountinfos: member
+
+    define list_core_kcp_io_logicalclusters: member
+    define watch_core_kcp_io_logicalclusters: member
+
+    # IAM specific
+    define manage_iam_roles: owner
+    define get_iam_roles: member
+    define get_iam_users: member
+
+type core_platform-mesh_io_accountinfo
+  relations
+    define parent: [core_platform-mesh_io_account]
+
+    define member: member from parent
+    define owner: owner from parent
+
+    define get: member
+    define watch: member
+
+    # IAM specific
+    define manage_iam_roles: owner
+    define get_iam_roles: member
+    define get_iam_users: member
+
+type core_kcp_io_logicalcluster
+  relations
+    define parent: [core_platform-mesh_io_account]
+
+    define member: member from parent
+
+    define get: member
+    define watch: member
+'
+
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Check for required tools
+check_dependencies() {
+    local missing=()
+
+    for tool in kubectl jq; do
+        if ! command -v "$tool" &> /dev/null; then
+            missing+=("$tool")
+        fi
+    done
+
+    if [ ${#missing[@]} -ne 0 ]; then
+        log_error "Missing required tools: ${missing[*]}"
+        exit 1
+    fi
+}
+
+# Patch a single Store resource with the new core module
+patch_store() {
+    local store_name="$1"
+
+    local current_module
+    current_module=$(kubectl get store "$store_name" -o jsonpath='{.spec.coreModule}' 2>/dev/null || echo "")
+
+    if [ "$current_module" = "$CORE_MODULE" ]; then
+        log_info "  Store '$store_name' already up to date, skipping"
+        return 0
+    fi
+
+    if [ "$DRY_RUN" = "true" ]; then
+        log_warn "  Dry run - would patch Store '$store_name' with new coreModule"
+        return 0
+    fi
+
+    local patch
+    patch=$(jq -n --arg model "$CORE_MODULE" '{"spec": {"coreModule": $model}}')
+
+    kubectl patch store "$store_name" --type=merge -p "$patch"
+    log_info "  Successfully patched Store '$store_name'"
+}
+
+# Clear the stale authorizationModelId from a Store's status
+clear_authorization_model_id() {
+    local store_name="$1"
+
+    local model_id
+    model_id=$(kubectl get store "$store_name" -o jsonpath='{.status.authorizationModelId}' 2>/dev/null || echo "")
+
+    if [ -z "$model_id" ]; then
+        log_info "  Store '$store_name' has no authorizationModelId, skipping"
+        return 0
+    fi
+
+    if [ "$DRY_RUN" = "true" ]; then
+        log_warn "  Dry run - would clear authorizationModelId '$model_id' from Store '$store_name'"
+        return 0
+    fi
+
+    kubectl patch store "$store_name" --type=json \
+        -p '[{"op": "remove", "path": "/status/authorizationModelId"}]' --subresource=status
+    log_info "  Cleared authorizationModelId from Store '$store_name'"
+}
+
+# Main function
+main() {
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --dry-run)
+                DRY_RUN=true
+                shift
+                ;;
+            --kubeconfig-kcp)
+                KUBECONFIG_KCP="$2"
+                shift 2
+                ;;
+            -h|--help)
+                echo "Usage: $0 [OPTIONS]"
+                echo ""
+                echo "Update FGA Store resources in :root:orgs with the latest core module"
+                echo "model from the security-operator chart and clear stale"
+                echo "authorizationModelId from their status."
+                echo ""
+                echo "Options:"
+                echo "  --dry-run              Show what would be done without making changes"
+                echo "  --kubeconfig-kcp PATH  Kubeconfig for kcp (default: \$KUBECONFIG_KCP or \$KUBECONFIG)"
+                echo "  -h, --help             Show this help message"
+                echo ""
+                echo "Environment variables:"
+                echo "  KUBECONFIG_KCP         Kubeconfig for kcp"
+                exit 0
+                ;;
+            *)
+                log_error "Unknown option: $1"
+                exit 1
+                ;;
+        esac
+    done
+
+    check_dependencies
+
+    if [ -n "$KUBECONFIG_KCP" ]; then
+        export KUBECONFIG="$KUBECONFIG_KCP"
+        log_info "Using kubeconfig: $KUBECONFIG_KCP"
+    fi
+
+    if [ "$DRY_RUN" = "true" ]; then
+        log_warn "Running in dry-run mode - no changes will be applied"
+    fi
+
+    # Navigate to :root:orgs workspace
+    log_info "Navigating to :root:orgs workspace..."
+    kubectl ws :root:orgs
+
+    # List all Store resources
+    local stores
+    stores=$(kubectl get stores -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
+
+    if [ -z "$stores" ]; then
+        log_warn "No Store resources found in :root:orgs"
+        kubectl ws :root
+        exit 0
+    fi
+
+    log_info "Found stores: $stores"
+
+    local updated_count=0
+
+    for store_name in $stores; do
+        log_info "Processing Store: $store_name"
+        patch_store "$store_name"
+        clear_authorization_model_id "$store_name"
+        ((updated_count++))
+    done
+
+    # Return to root workspace
+    kubectl ws :root
+
+    echo ""
+    log_info "Summary: Processed $updated_count stores"
+    log_info "=== FGA Store model update complete ==="
+}
+
+main "$@"

--- a/docs/migration-0.2.0/fix_workspaceauthenticationconfiguration.sh
+++ b/docs/migration-0.2.0/fix_workspaceauthenticationconfiguration.sh
@@ -1,0 +1,395 @@
+#!/bin/bash
+#
+# Script to update WorkspaceAuthenticationConfiguration resources
+# Updates audiences with client IDs from Keycloak
+#
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Keycloak configuration (KEYCLOAK_URL derived from PlatformMesh if not set)
+KEYCLOAK_URL="${KEYCLOAK_URL:-}"
+KEYCLOAK_USER="${KEYCLOAK_USER:-keycloak-admin}"
+KEYCLOAK_PASSWORD="${KEYCLOAK_PASSWORD:-admin}"
+
+# Global variables
+ADMIN_TOKEN=""
+DEBUG="${DEBUG:-false}"
+KUBECONFIG_KCP="${KUBECONFIG_KCP:-}"
+KUBECONFIG_K8S="${KUBECONFIG_K8S:-}"
+
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Derive Keycloak URL from the PlatformMesh resource in the regular k8s cluster.
+# Uses KUBECONFIG_K8S when set so the lookup targets the host cluster, not kcp.
+get_keycloak_url_from_cluster() {
+    local kc_args=()
+    if [ -n "$KUBECONFIG_K8S" ]; then
+        kc_args+=(--kubeconfig "$KUBECONFIG_K8S")
+    fi
+
+    local base_domain port
+    base_domain=$(kubectl "${kc_args[@]}" -n platform-mesh-system get platformmesh platform-mesh \
+        -o jsonpath='{.spec.exposure.baseDomain}' 2>/dev/null) || return 1
+    port=$(kubectl "${kc_args[@]}" -n platform-mesh-system get platformmesh platform-mesh \
+        -o jsonpath='{.spec.exposure.port}' 2>/dev/null) || return 1
+
+    if [ -z "$base_domain" ] || [ -z "$port" ]; then
+        return 1
+    fi
+
+    echo "https://${base_domain}:${port}/keycloak"
+}
+
+# Check for required tools
+check_dependencies() {
+    local missing=()
+
+    if ! command -v kubectl &> /dev/null; then
+        missing+=("kubectl")
+    fi
+
+    if ! command -v yq &> /dev/null; then
+        missing+=("yq")
+    fi
+
+    if ! command -v jq &> /dev/null; then
+        missing+=("jq")
+    fi
+
+    if ! command -v curl &> /dev/null; then
+        missing+=("curl")
+    fi
+
+    if [ ${#missing[@]} -ne 0 ]; then
+        log_error "Missing required tools: ${missing[*]}"
+        log_error "Please install them before running this script."
+        exit 1
+    fi
+}
+
+# Get Keycloak admin token
+get_admin_token() {
+    curl -sk -X POST "${KEYCLOAK_URL}/realms/master/protocol/openid-connect/token" \
+        -H "Content-Type: application/x-www-form-urlencoded" \
+        -d "username=${KEYCLOAK_USER}" \
+        -d "password=${KEYCLOAK_PASSWORD}" \
+        -d "grant_type=password" \
+        -d "client_id=admin-cli" | jq -r '.access_token'
+}
+
+# Get all custom client IDs (UUIDs) from a realm
+# Custom clients have clientId values that are UUIDs (not built-in clients like account, admin-cli, etc.)
+get_custom_client_ids() {
+    local token="$1"
+    local realm="$2"
+
+    local response
+    response=$(curl -sk -X GET "${KEYCLOAK_URL}/admin/realms/${realm}/clients/" \
+        -H "Authorization: Bearer ${token}")
+
+    if [ "$DEBUG" = "true" ]; then
+        echo "[DEBUG] Keycloak clients response for realm '$realm':" >&2
+        echo "$response" | jq -r '.[].clientId' >&2
+    fi
+
+    # Filter clients whose clientId is a UUID pattern and return their clientId (which IS the audience value)
+    echo "$response" | jq -r '.[] | select(.clientId | test("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")) | .clientId'
+}
+
+# Extract realm name from issuer URL
+# e.g., https://portal.localhost:8443/keycloak/realms/default -> default
+extract_realm_from_url() {
+    local url="$1"
+    echo "$url" | sed -E 's|.*/realms/([^/]+).*|\1|'
+}
+
+# Backup a resource before modifying
+backup_resource() {
+    local name="$1"
+    local backup_dir="${BACKUP_DIR:-./wac-backups}"
+    local timestamp
+    timestamp=$(date +%Y%m%d_%H%M%S)
+
+    mkdir -p "$backup_dir"
+
+    local backup_file="${backup_dir}/${name}_${timestamp}.yaml"
+    kubectl get workspaceauthenticationconfiguration "$name" -o yaml > "$backup_file"
+    log_info "Backed up $name to $backup_file"
+}
+
+# Check if audiences contain old-style names (not UUIDs)
+has_old_style_audiences() {
+    local resource="$1"
+    local audiences
+    audiences=$(echo "$resource" | yq -r '.spec.jwt[0].issuer.audiences[]' 2>/dev/null || echo "")
+
+    for audience in $audiences; do
+        # Check if audience is NOT a UUID (UUIDs have format xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
+        if ! echo "$audience" | grep -qE '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Check if a resource needs updating
+needs_update() {
+    local name="$1"
+    local resource
+    resource=$(kubectl get workspaceauthenticationconfiguration "$name" -o yaml)
+
+    # Check if audiences contain old-style names instead of UUIDs
+    if has_old_style_audiences "$resource"; then
+        return 0
+    fi
+
+    return 1
+}
+
+# Fix a single WorkspaceAuthenticationConfiguration resource
+fix_resource() {
+    local name="$1"
+    local dry_run="${2:-false}"
+
+    log_info "Processing WorkspaceAuthenticationConfiguration: $name"
+
+    # Get the current resource
+    local resource
+    resource=$(kubectl get workspaceauthenticationconfiguration "$name" -o yaml)
+
+    # Check if audiences need updating
+    if ! has_old_style_audiences "$resource"; then
+        log_info "Resource $name is already up to date, skipping."
+        return 0
+    fi
+
+    # Create the updated resource
+    local updated_resource="$resource"
+
+    # Update audiences with client UUIDs from Keycloak
+    log_info "  - Updating audiences with client UUIDs from Keycloak"
+
+    # Extract realm from issuer URL
+    local issuer_url
+    issuer_url=$(echo "$resource" | yq -r '.spec.jwt[0].issuer.url')
+    local realm
+    realm=$(extract_realm_from_url "$issuer_url")
+    log_info "    Realm: $realm"
+
+    # Fetch custom client IDs from Keycloak
+    # Custom clients have UUID-style clientId values (the clientId IS the audience)
+    local client_ids
+    client_ids=$(get_custom_client_ids "$ADMIN_TOKEN" "$realm")
+
+    if [ -z "$client_ids" ]; then
+        log_warn "    No custom clients found in Keycloak realm '$realm'"
+    else
+        log_info "    Found custom client IDs:"
+        for cid in $client_ids; do
+            log_info "      - $cid"
+        done
+    fi
+
+    # Build new audiences array from client IDs
+    local new_audiences="[]"
+    for cid in $client_ids; do
+        new_audiences=$(echo "$new_audiences" | jq --arg uuid "$cid" '. + [$uuid]')
+    done
+
+    if [ "$new_audiences" != "[]" ]; then
+        # Convert YAML to JSON, update with jq, then back to YAML
+        updated_resource=$(echo "$updated_resource" | yq -o=json | jq --argjson audiences "$new_audiences" '
+            .spec.jwt[0].issuer.audiences = $audiences
+        ' | yq -P)
+    else
+        log_warn "    No client UUIDs found, keeping existing audiences"
+    fi
+
+    # Remove resourceVersion and other server-managed fields for apply
+    updated_resource=$(echo "$updated_resource" | yq '
+        del(.metadata.resourceVersion) |
+        del(.metadata.uid) |
+        del(.metadata.creationTimestamp) |
+        del(.metadata.generation) |
+        del(.status)
+    ')
+
+    if [ "$dry_run" = "true" ]; then
+        log_info "Dry run - would apply the following changes:"
+        echo "$updated_resource"
+        return 0
+    fi
+
+    # Backup before applying
+    backup_resource "$name"
+
+    # Apply the updated resource
+    echo "$updated_resource" | kubectl apply -f -
+
+    log_info "Successfully updated $name"
+}
+
+# Main function
+main() {
+    local dry_run=false
+    local specific_name=""
+
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --debug)
+                DEBUG=true
+                shift
+                ;;
+            --dry-run)
+                dry_run=true
+                shift
+                ;;
+            --name)
+                specific_name="$2"
+                shift 2
+                ;;
+            --backup-dir)
+                export BACKUP_DIR="$2"
+                shift 2
+                ;;
+            --keycloak-user)
+                KEYCLOAK_USER="$2"
+                shift 2
+                ;;
+            --keycloak-password)
+                KEYCLOAK_PASSWORD="$2"
+                shift 2
+                ;;
+            --kubeconfig)
+                KUBECONFIG_K8S="$2"
+                shift 2
+                ;;
+            --kubeconfig-kcp)
+                KUBECONFIG_KCP="$2"
+                shift 2
+                ;;
+            -h|--help)
+                echo "Usage: $0 [OPTIONS]"
+                echo ""
+                echo "Update WorkspaceAuthenticationConfiguration resources by:"
+                echo "  - Updating audiences with client UUIDs from Keycloak"
+                echo ""
+                echo "Options:"
+                echo "  --debug              Enable debug output"
+                echo "  --dry-run            Show what would be changed without applying"
+                echo "  --name NAME          Only process a specific resource"
+                echo "  --backup-dir DIR     Directory for backups (default: ./wac-backups)"
+                echo "  --keycloak-user USER Keycloak admin username (default: \$KEYCLOAK_USER or keycloak-admin)"
+                echo "  --keycloak-password  Keycloak admin password (default: \$KEYCLOAK_PASSWORD or admin)"
+                echo "  --kubeconfig PATH    Kubeconfig for the Kubernetes cluster (default: \$KUBECONFIG_K8S or \$KUBECONFIG)"
+                echo "  --kubeconfig-kcp PATH Kubeconfig for kcp (default: \$KUBECONFIG_KCP or \$KUBECONFIG)"
+                echo "  -h, --help           Show this help message"
+                echo ""
+                echo "Environment variables:"
+                echo "  KEYCLOAK_URL         Keycloak base URL"
+                echo "  KEYCLOAK_USER        Keycloak admin username"
+                echo "  KEYCLOAK_PASSWORD    Keycloak admin password"
+                echo "  KUBECONFIG_K8S       Kubeconfig for the Kubernetes cluster"
+                echo "  KUBECONFIG_KCP       Kubeconfig for kcp"
+                echo "  BACKUP_DIR           Directory for backups"
+                exit 0
+                ;;
+            *)
+                log_error "Unknown option: $1"
+                exit 1
+                ;;
+        esac
+    done
+
+    check_dependencies
+
+    if [ -n "$KUBECONFIG_K8S" ]; then
+        log_info "Using k8s kubeconfig: $KUBECONFIG_K8S"
+    fi
+
+    if [ "$dry_run" = "true" ]; then
+        log_warn "Running in dry-run mode - no changes will be applied"
+    fi
+
+    # Derive Keycloak URL from PlatformMesh resource if not explicitly set.
+    # This must happen before switching to the kcp kubeconfig because
+    # PlatformMesh lives in the regular Kubernetes cluster.
+    if [ -z "$KEYCLOAK_URL" ]; then
+        log_info "KEYCLOAK_URL not set, reading from PlatformMesh resource..."
+        KEYCLOAK_URL=$(get_keycloak_url_from_cluster) || true
+        if [ -z "$KEYCLOAK_URL" ]; then
+            log_error "Failed to derive Keycloak URL from PlatformMesh resource."
+            log_error "Set KEYCLOAK_URL explicitly."
+            exit 1
+        fi
+        log_info "Derived Keycloak URL: $KEYCLOAK_URL"
+    fi
+
+    # Switch to kcp kubeconfig for all subsequent kubectl commands
+    if [ -n "$KUBECONFIG_KCP" ]; then
+        export KUBECONFIG="$KUBECONFIG_KCP"
+        log_info "Using kcp kubeconfig: $KUBECONFIG_KCP"
+    fi
+
+    # Get Keycloak admin token
+    log_info "Fetching Keycloak admin token from $KEYCLOAK_URL..."
+    ADMIN_TOKEN=$(get_admin_token)
+    if [ -z "$ADMIN_TOKEN" ] || [ "$ADMIN_TOKEN" = "null" ]; then
+        log_error "Failed to get Keycloak admin token. Check your credentials."
+        exit 1
+    fi
+    log_info "Successfully obtained Keycloak admin token"
+
+    if [ -n "$specific_name" ]; then
+        # Process specific resource
+        if needs_update "$specific_name"; then
+            fix_resource "$specific_name" "$dry_run"
+        else
+            log_info "Resource $specific_name does not need updating"
+        fi
+    else
+        # Process all WorkspaceAuthenticationConfiguration resources
+        local resources
+        resources=$(kubectl get workspaceauthenticationconfiguration -o jsonpath='{.items[*].metadata.name}')
+
+        if [ -z "$resources" ]; then
+            log_warn "No WorkspaceAuthenticationConfiguration resources found"
+            exit 0
+        fi
+
+        local updated_count=0
+        local skipped_count=0
+
+        for name in $resources; do
+            if needs_update "$name"; then
+                fix_resource "$name" "$dry_run"
+                ((updated_count++))
+            else
+                log_info "Resource $name is already up to date, skipping."
+                ((skipped_count++))
+            fi
+        done
+
+        echo ""
+        log_info "Summary: Updated $updated_count, Skipped $skipped_count"
+    fi
+}
+
+main "$@"

--- a/docs/migration-0.2.0/invite_org_owners.sh
+++ b/docs/migration-0.2.0/invite_org_owners.sh
@@ -1,0 +1,294 @@
+#!/bin/bash
+
+# Script to create Invite resources for organization owners
+# For each org workspace under :root:orgs, looks up the creator email from
+# the Account resource in :root:orgs and creates an Invite in that org's workspace.
+
+set -euo pipefail
+
+# Configuration - can be overridden via environment variables
+KUBECONFIG_KCP="${KUBECONFIG_KCP:-}"
+DRY_RUN="${DRY_RUN:-false}"
+DEBUG="${DEBUG:-false}"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+log_debug() {
+    if [ "$DEBUG" = "true" ]; then
+        echo -e "${BLUE}[DEBUG]${NC} $1"
+    fi
+}
+
+# Check prerequisites
+check_prerequisites() {
+    if ! command -v kubectl &> /dev/null; then
+        log_error "kubectl is not installed or not in PATH"
+        exit 1
+    fi
+
+    if ! command -v yq &> /dev/null; then
+        log_error "yq is not installed or not in PATH"
+        exit 1
+    fi
+}
+
+# Get creator email from Account resource in :root:orgs
+get_creator_email() {
+    local org_name="$1"
+
+    local account_yaml
+    account_yaml=$(kubectl get account "$org_name" -o yaml 2>&1) || {
+        log_error "  Failed to get Account resource '$org_name': $account_yaml"
+        return 1
+    }
+
+    local creator_email
+    creator_email=$(echo "$account_yaml" | yq -r '.spec.creator' 2>&1) || {
+        log_error "  Failed to extract creator email from Account '$org_name'"
+        return 1
+    }
+
+    if [ -z "$creator_email" ] || [ "$creator_email" = "null" ]; then
+        log_warn "  Account '$org_name' has no creator email, skipping"
+        return 1
+    fi
+
+    echo "$creator_email"
+}
+
+# Generate Invite resource name from email (use part before @)
+generate_invite_name() {
+    local email="$1"
+    echo "$email" | sed 's/@.*//'
+}
+
+# Generate Invite manifest
+generate_invite_manifest() {
+    local invite_name="$1"
+    local email="$2"
+
+    cat <<EOF
+apiVersion: core.platform-mesh.io/v1alpha1
+kind: Invite
+metadata:
+  name: ${invite_name}
+spec:
+  email: ${email}
+EOF
+}
+
+# Check if Invite already exists in the current workspace by name
+has_invite() {
+    local invite_name="$1"
+
+    kubectl get invite "$invite_name" &>/dev/null
+    return $?
+}
+
+# Check if Invite with same email already exists in the current workspace
+has_invite_with_email() {
+    local email="$1"
+
+    local invites
+    invites=$(kubectl get invite -o jsonpath='{.items[*].spec.email}' 2>/dev/null || echo "")
+
+    if [[ " $invites " == *" $email "* ]]; then
+        return 0  # Email exists
+    fi
+    return 1  # Email doesn't exist
+}
+
+# Create Invite resource for org owner in org workspace
+create_invite_for_owner() {
+    local workspace_path="$1"
+    local org_name="$2"
+
+    log_info "Processing org workspace: ${workspace_path}"
+
+    # First, get creator email from Account resource (need to be in :root:orgs for this)
+    # Switch to :root:orgs to read Account
+    kubectl ws :root:orgs &>/dev/null || {
+        log_error "  Failed to navigate to :root:orgs to read Account"
+        return 1
+    }
+
+    local creator_email
+    if ! creator_email=$(get_creator_email "$org_name"); then
+        return 0  # Continue to next org instead of failing
+    fi
+
+    log_info "  Found creator email: ${creator_email}"
+
+    # Now switch to org workspace to create the Invite
+    kubectl ws "${workspace_path}" &>/dev/null || {
+        log_error "  Failed to navigate to workspace: ${workspace_path}"
+        return 1
+    }
+
+    # Generate invite name from email
+    local invite_name
+    invite_name=$(generate_invite_name "$creator_email")
+
+    log_debug "  Invite name: ${invite_name}"
+
+    # Check if invite with same name already exists
+    if has_invite "${invite_name}"; then
+        log_warn "  Invite '${invite_name}' already exists, skipping"
+        return 0
+    fi
+
+    # Check if invite with same email already exists
+    if has_invite_with_email "${creator_email}"; then
+        log_warn "  Invite with email '${creator_email}' already exists, skipping"
+        return 0
+    fi
+
+    log_info "  Creating Invite for '${creator_email}'..."
+
+    local manifest
+    manifest=$(generate_invite_manifest "$invite_name" "$creator_email")
+
+    if [ "$DRY_RUN" = "true" ]; then
+        log_warn "  Dry run - would create Invite:"
+        echo "$manifest" | yq '.' || echo "$manifest"
+        return 0
+    fi
+
+    if echo "$manifest" | kubectl apply -f - 2>/dev/null; then
+        log_success "  Created Invite '${invite_name}' in ${workspace_path}"
+        return 0
+    else
+        log_error "  Failed to create Invite '${invite_name}' in ${workspace_path}"
+        return 1
+    fi
+}
+
+# Show help
+show_help() {
+    cat <<EOF
+Usage: $0 [OPTIONS]
+
+Create Invite resources for organization owners in all org workspaces under :root:orgs.
+Looks up the creator email from Account resources in :root:orgs and creates
+corresponding Invite resources in each org's workspace.
+
+Options:
+  --dry-run                    Show what would be done without making changes
+  --debug                      Enable debug output
+  --kubeconfig-kcp PATH        Kubeconfig for kcp (default: \$KUBECONFIG_KCP or \$KUBECONFIG)
+  -h, --help                   Show this help message
+
+Environment variables:
+  KUBECONFIG_KCP               Kubeconfig for kcp
+  DRY_RUN                      Set to "true" for dry-run mode
+  DEBUG                        Set to "true" for debug output
+
+Example:
+  # Create invites for all org owners
+  $0
+
+  # Dry run to preview invites
+  $0 --dry-run
+
+  # Using environment variables
+  export KUBECONFIG_KCP=/path/to/kcp/kubeconfig
+  $0
+EOF
+}
+
+# Main
+main() {
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --dry-run)
+                DRY_RUN=true
+                shift
+                ;;
+            --debug)
+                DEBUG=true
+                shift
+                ;;
+            --kubeconfig-kcp)
+                KUBECONFIG_KCP="$2"
+                shift 2
+                ;;
+            -h|--help)
+                show_help
+                exit 0
+                ;;
+            *)
+                log_error "Unknown option: $1"
+                show_help
+                exit 1
+                ;;
+        esac
+    done
+
+    check_prerequisites
+
+    if [ -n "$KUBECONFIG_KCP" ]; then
+        export KUBECONFIG="$KUBECONFIG_KCP"
+        log_info "Using kcp kubeconfig: $KUBECONFIG_KCP"
+    fi
+
+    if [ "$DRY_RUN" = "true" ]; then
+        log_warn "Running in dry-run mode - no changes will be applied"
+    fi
+
+    echo ""
+
+    # Navigate to :root:orgs to get list of org workspaces
+    log_info "Navigating to :root:orgs to list org workspaces"
+
+    if ! kubectl ws :root:orgs &>/dev/null; then
+        log_error "Failed to navigate to :root:orgs workspace"
+        exit 1
+    fi
+
+    # Get all top-level orgs
+    local top_level_orgs
+    top_level_orgs=$(kubectl get workspaces -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
+
+    if [[ -z "$top_level_orgs" ]]; then
+        log_warn "No workspaces found under :root:orgs"
+        exit 0
+    fi
+
+    log_info "Found top-level orgs: $top_level_orgs"
+    echo ""
+
+    # Create Invite resources for each org owner
+    for org in $top_level_orgs; do
+        create_invite_for_owner ":root:orgs:${org}" "$org" || true
+    done
+
+    # Return to root workspace
+    kubectl ws :root &>/dev/null || true
+
+    echo ""
+    log_success "Completed creating Invite resources for org owners"
+}
+
+main "$@"

--- a/docs/migration-0.2.0/list_apiresourceschemas.sh
+++ b/docs/migration-0.2.0/list_apiresourceschemas.sh
@@ -1,0 +1,287 @@
+#!/bin/bash
+#
+# Lists all APIResourceSchemas and AuthorizationModels across all KCP workspaces.
+#
+# This script recursively traverses the KCP workspace tree and finds:
+# - All APIExport resources and their exported APIResourceSchemas
+# - All AuthorizationModel resources
+#
+# Usage:
+#   ./list_apiresourceschemas.sh [OPTIONS]
+#
+# Options:
+#   -d, --details    Show detailed information about each resource
+#   -h, --help       Show this help message
+#
+
+set -euo pipefail
+
+###############################################################################
+# Configuration
+###############################################################################
+
+KUBECONFIG_KCP="${KUBECONFIG_KCP:-}"
+KCP_SERVER="${KCP_SERVER:-}"
+SHOW_DETAILS=false
+
+###############################################################################
+# Color codes for output
+###############################################################################
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m' # No Color
+
+###############################################################################
+# Helper functions
+###############################################################################
+
+log_info() {
+    echo -e "${CYAN}[INFO]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+log_header() {
+    echo ""
+    echo -e "${BOLD}${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${BOLD}${BLUE}$1${NC}"
+    echo -e "${BOLD}${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+}
+
+kcp_kubectl() {
+    if [ -n "$KUBECONFIG_KCP" ]; then
+        KUBECONFIG="$KUBECONFIG_KCP" kubectl "$@"
+    elif [ -n "$KCP_SERVER" ]; then
+        kubectl --server="$KCP_SERVER" "$@"
+    else
+        kubectl "$@"
+    fi
+}
+
+###############################################################################
+# Main functions
+###############################################################################
+
+list_apiexports_in_workspace() {
+    local ws_path="$1"
+    local indent="${2:-}"
+    local show_details="${3:-false}"
+
+    # Navigate to workspace
+    # Handle special case for root workspace
+    local ws_target="$ws_path"
+    if [ "$ws_path" = ":root" ]; then
+        ws_target=":"
+    fi
+
+    kcp_kubectl ws "$ws_target" &>/dev/null || {
+        log_error "${indent}Cannot navigate to workspace $ws_path"
+        return
+    }
+
+    # Get all APIExports in this workspace
+    local apiexports_json
+    apiexports_json=$(kcp_kubectl get apiexports -o json 2>/dev/null || echo '{"items":[]}')
+    local export_count
+    export_count=$(echo "$apiexports_json" | jq '.items | length')
+
+    # Get all AuthorizationModels in this workspace
+    local authmodels_json
+    authmodels_json=$(kcp_kubectl get authorizationmodels -o json 2>/dev/null || echo '{"items":[]}')
+    local authmodel_count
+    authmodel_count=$(echo "$authmodels_json" | jq '.items | length')
+
+    # Only print workspace header if there's content to show
+    if [ "$export_count" -gt 0 ] || [ "$authmodel_count" -gt 0 ]; then
+        echo -e "${indent}${BOLD}Workspace: ${CYAN}$ws_path${NC}"
+
+        # Process APIExports
+        if [ "$export_count" -gt 0 ]; then
+            while IFS= read -r export_json; do
+                local export_name
+                export_name=$(echo "$export_json" | jq -r '.metadata.name')
+
+                echo -e "${indent}  ${BOLD}${GREEN}APIExport:${NC} $export_name"
+
+                # Get latest resource schemas
+                local schemas
+                schemas=$(echo "$export_json" | jq -r '.spec.latestResourceSchemas // [] | .[]')
+
+                if [ -z "$schemas" ]; then
+                    echo -e "${indent}    ${YELLOW}(no APIResourceSchemas)${NC}"
+                else
+                    while IFS= read -r schema; do
+                        [ -z "$schema" ] && continue
+
+                        if [ "$show_details" = "true" ]; then
+                            # Get APIResourceSchema details
+                            local schema_json
+                            schema_json=$(kcp_kubectl get apiresourceschema "$schema" -o json 2>/dev/null || echo '{}')
+
+                            if [ "$schema_json" != "{}" ]; then
+                                local group version kind plural
+                                group=$(echo "$schema_json" | jq -r '.spec.group // ""')
+                                version=$(echo "$schema_json" | jq -r '.spec.versions[0].name // ""')
+                                kind=$(echo "$schema_json" | jq -r '.spec.names.kind // ""')
+                                plural=$(echo "$schema_json" | jq -r '.spec.names.plural // ""')
+
+                                echo -e "${indent}    - ${BOLD}$schema${NC}"
+                                echo -e "${indent}      Group: $group, Version: $version, Kind: $kind, Plural: $plural"
+                            else
+                                echo -e "${indent}    - $schema ${YELLOW}(not found)${NC}"
+                            fi
+                        else
+                            echo -e "${indent}    - $schema"
+                        fi
+                    done <<< "$schemas"
+                fi
+
+                echo ""
+            done < <(echo "$apiexports_json" | jq -c '.items[]')
+        fi
+
+        # Process AuthorizationModels
+        if [ "$authmodel_count" -gt 0 ]; then
+            echo -e "${indent}  ${BOLD}${GREEN}AuthorizationModels:${NC}"
+            while IFS= read -r authmodel_json; do
+                local authmodel_name
+                authmodel_name=$(echo "$authmodel_json" | jq -r '.metadata.name')
+
+                if [ "$show_details" = "true" ]; then
+                    local store_id model_id type_count
+                    store_id=$(echo "$authmodel_json" | jq -r '.spec.storeId // "unknown"')
+                    model_id=$(echo "$authmodel_json" | jq -r '.spec.authorizationModelId // "unknown"')
+                    type_count=$(echo "$authmodel_json" | jq -r '.spec.typeDefinitions | length // 0')
+
+                    echo -e "${indent}    - ${BOLD}$authmodel_name${NC}"
+                    echo -e "${indent}      StoreId: $store_id, ModelId: $model_id, Types: $type_count"
+                else
+                    echo -e "${indent}    - $authmodel_name"
+                fi
+            done < <(echo "$authmodels_json" | jq -c '.items[]')
+            echo ""
+        fi
+    fi
+
+    # Recurse into child workspaces
+    local children
+    children=$(kcp_kubectl get workspaces -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
+    for child in $children; do
+        [ -z "$child" ] && continue
+        # Build child workspace path
+        local child_path
+        if [ "$ws_path" = ":root" ] || [ "$ws_path" = "root" ]; then
+            child_path=":root:${child}"
+        else
+            child_path="${ws_path}:${child}"
+        fi
+        list_apiexports_in_workspace "$child_path" "${indent}  " "$show_details"
+    done
+}
+
+check_dependencies() {
+    local missing_deps=()
+
+    if ! command -v kubectl &> /dev/null; then
+        missing_deps+=("kubectl")
+    fi
+
+    if ! command -v jq &> /dev/null; then
+        missing_deps+=("jq")
+    fi
+
+    if [ ${#missing_deps[@]} -gt 0 ]; then
+        log_error "Missing required dependencies: ${missing_deps[*]}"
+        log_error "Please install them and try again."
+        exit 1
+    fi
+}
+
+show_help() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Lists all APIResourceSchemas and AuthorizationModels across all KCP workspaces.
+
+This script recursively traverses workspaces and displays:
+  - APIExports with their exported APIResourceSchemas
+  - AuthorizationModel resources
+
+Options:
+  -d, --details    Show detailed information about each resource
+                   - APIResourceSchemas: group, version, kind, plural
+                   - AuthorizationModels: storeId, modelId, type count
+  -h, --help       Show this help message
+
+Environment Variables:
+  KUBECONFIG_KCP   Path to KCP kubeconfig file
+  KCP_SERVER       KCP server URL (alternative to KUBECONFIG_KCP)
+
+Examples:
+  # List all resources (names only)
+  $0
+
+  # List all resources with details
+  $0 --details
+
+  # Use specific kubeconfig
+  KUBECONFIG_KCP=~/.kube/kcp-config $0
+EOF
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            -d|--details)
+                SHOW_DETAILS=true
+                shift
+                ;;
+            -h|--help)
+                show_help
+                exit 0
+                ;;
+            *)
+                log_error "Unknown option: $1"
+                show_help
+                exit 1
+                ;;
+        esac
+    done
+}
+
+main() {
+    parse_args "$@"
+
+    log_header "KCP APIResourceSchemas & AuthorizationModels Inventory"
+    echo ""
+
+    check_dependencies
+
+    log_info "Scanning all workspaces for APIExports and AuthorizationModels..."
+    if [ "$SHOW_DETAILS" = "true" ]; then
+        log_info "Detailed mode enabled"
+    fi
+    echo ""
+
+    # Start from root workspace
+    list_apiexports_in_workspace ":root" "" "$SHOW_DETAILS"
+
+    # Return to root workspace
+    kcp_kubectl ws : &>/dev/null || true
+
+    echo ""
+    log_info "Scan complete"
+}
+
+###############################################################################
+# Entry point
+###############################################################################
+
+main "$@"

--- a/docs/migration-0.2.0/migration-release-0.2.0.md
+++ b/docs/migration-0.2.0/migration-release-0.2.0.md
@@ -1,0 +1,375 @@
+# Migration guide for update to release-0.2.0
+
+This guide describes the in-place migration procedure from release-0.1.1 to release-0.2.0.
+
+For backup and restore procedures, see the [Backup and Restore Guide](backup-restore.md).
+
+---
+
+## 1. Version Matrix
+
+| Component | Source Version | Target Version | Notes |
+|-----------|----------------|----------------|-------|
+| **Core Control Plane** | | | |
+| platform-mesh-operator | v0.26.3 | v0.47.5 | minor version bump but actually a major KCP configuration change |
+| KCP | v0.29.0 | v0.30.0 | minor version update |
+| etcd | v0.6.0 | v0.6.0 | |
+| etcd-druid | v0.31.0 | v0.34.0 | operator minor version update |
+| **Identity & Authorization** | | | |
+| Keycloak | 26.3.3-debian-12-r0 | 26.5.2-debian-12-r0 | Helm chart minor version update |
+| OpenFGA | v1.9.0 | v1.11.2 | Helm chart patch version update 0.2.38 -> 0.2.51 |
+| **Databases** | | | |
+| PostgreSQL (Keycloak) | 17.6.0-debian-12-r4 | 17.6.0-debian-12-r4 | |
+| PostgreSQL (OpenFGA) | 15.4.0-debian-11-r45 | 17.6.0-debian-12-r4 | major update |
+| **Supporting Infrastructure** | | | |
+| cert-manager | v1.19.1 | v1.19.2 | patch update |
+| Traefik | v3.6.0 | v3.6.7 | patch update |
+| Gateway API | v1.4.0 | v1.4.1 | patch update |
+
+---
+
+## 2. Pre-migration
+
+Before starting the migration, create a full backup of all data stores by following the [Backup and Restore Guide](backup-restore.md#backup).
+
+---
+
+## 3. Migration procedure
+
+### 3.1 Remove existing Platform-Mesh resources
+
+Delete the PlatformMesh custom resource, the ResourceGraphDefinition, and the operator:
+
+```shell
+kubectl -n platform-mesh-system delete PlatformMesh platform-mesh
+kubectl --namespace default delete resourcegraphdefinition platform-mesh-operator
+kubectl -n default delete platformmeshoperator platform-mesh-operator
+```
+
+### 3.2 Remove HelmReleases
+
+Suspend, delete, and clean up all Platform-Mesh HelmReleases:
+
+```shell
+flux suspend helmrelease platform-mesh-operator-components -n default
+kubectl -n default delete HelmRelease infra
+flux resume helmrelease platform-mesh-operator-components -n default
+```
+
+Delete the remaining HelmReleases. You may need to manually remove their finalizers:
+
+```shell
+kubectl -n default delete HelmRelease platform-mesh-operator-components
+kubectl -n default delete HelmRelease platform-mesh-operator-infra-components
+kubectl -n default delete HelmRelease default-idp
+```
+
+> **Note:** If deletion hangs, manually remove the finalizers from the `platform-mesh-operator-components`, `infra`, and `default-idp` HelmRelease resources.
+
+Delete the stale Helm release secrets and kcp kubeconfig secrets:
+
+```shell
+kubectl delete secrets -n default sh.helm.release.v1.default-idp.v1 sh.helm.release.v1.infra.v1
+```
+
+### 3.3 Remove FluxCD
+
+```shell
+helm uninstall -n flux-system flux
+```
+
+### 3.4 Deploy release-0.2.0
+
+Deploy the release-0.2.0 version of the platform-mesh stack using the standard installation procedure for your environment.
+
+### 3.5 Restore Keycloak database credentials
+
+Restore the PostgreSQL passwords in the `keycloak-postgresql-keycloak` secret from the backup and restart Keycloak so it picks up the restored credentials:
+
+```shell
+kubectl -n platform-mesh-system patch secret keycloak-postgresql-keycloak \
+  -p "$(yq '{"data": .data}' backup/keycloak/postgres/keycloak-postgresql-keycloak.yaml -o json)"
+kubectl -n platform-mesh-system delete pod keycloak-0
+```
+
+### 3.6 Restore OpenFGA database
+
+Restore the OpenFGA PostgreSQL database from the backup. See the [Restore OpenFGA](backup-restore.md#restore-openfga) section for details.
+
+### 3.7 Fix the APIExport
+
+The operator may fail to update the APIExport in `root:platform-mesh-system`. Delete it and restart the operator so it gets recreated:
+
+```shell
+docs/migration-0.2.0/fix_apiexport.sh
+```
+
+### 3.8 Patch APIBindings
+
+Fix stale APIBindings across workspaces:
+
+```shell
+KUBECONFIG_PATH=<kcp-admin-kubeconfig> docs/migration-0.2.0/fix_apibindings.sh
+```
+
+### 3.9 Create the IdentityProviderConfiguration resource
+
+Create the IDP resource in all org workspaces. Adjust the redirect URIs and secret references to match your environment:
+
+```shell
+KUBECONFIG_KCP=<kcp-admin-kubeconfig> PORTAL_HOST=<portal-host> docs/migration-0.2.0/create_identityprovider_config.sh
+```
+
+For a dry run to preview the changes:
+
+```shell
+KUBECONFIG_KCP=<kcp-admin-kubeconfig> PORTAL_HOST=<portal-host> docs/migration-0.2.0/create_identityprovider_config.sh --dry-run
+```
+
+For more options:
+
+```shell
+docs/migration-0.2.0/create_identityprovider_config.sh --help
+```
+
+### 3.10 Invite organization owners
+
+Create Invite resources for organization owners in their respective org workspaces. The script looks up the creator email from the Account resources and creates Invites:
+
+```shell
+KUBECONFIG_KCP=<kcp-admin-kubeconfig> docs/migration-0.2.0/invite_org_owners.sh
+```
+
+For a dry run to preview the invites:
+
+```shell
+KUBECONFIG_KCP=<kcp-admin-kubeconfig> docs/migration-0.2.0/invite_org_owners.sh --dry-run
+```
+
+For more options:
+
+```shell
+docs/migration-0.2.0/invite_org_owners.sh --help
+```
+
+### 3.11 Reconcile Keycloak clients
+
+Delete the `default` and `kubectl` clients from user-created realms in Keycloak, then restart the security-operator pods so they re-create them with the updated configuration:
+
+```shell
+docs/migration-0.2.0/reconcile_keycloak_clients.sh
+```
+
+### 3.12 Patch AccountInfo OIDC fields
+
+Update the `spec.oidc` field and client IDs on AccountInfo objects to match the ones currently in Keycloak:
+
+```shell
+docs/migration-0.2.0/fix_accountinfo.sh
+```
+
+### 3.13 Update FGA store models
+
+Edit the user-created store FGA models to match the one from the `security-operator` chart and clear stale `authorizationModelId` from their status:
+
+```shell
+docs/migration-0.2.0/fix_stores.sh
+```
+
+### 3.14 Fix WorkspaceAuthenticationConfiguration
+
+```shell
+docs/migration-0.2.0/fix_workspaceauthenticationconfiguration.sh
+```
+
+! NOTE: Make sure the `orgs-authentication` WorkspaceAuthenticationConfiguration resource is also updated in the `:root` workspace!
+
+### 3.15 Restart security-operator
+
+```shell
+kubectl -n platform-mesh-system delete pod -l app=security-operator
+kubectl -n platform-mesh-system delete pod -l service=security-operator-generator
+kubectl -n platform-mesh-system delete pod -l service=security-operator-initializer
+```
+
+### 3.17 Final deployment pass
+
+Re-run the deployment procedure for your environment and wait for the PlatformMesh resource to report a ready status.
+
+---
+
+## 4. Post-upgrade checks
+
+- PlatformMesh resource status is OK
+- Gateway, HTTPRoutes, and TLSRoutes resources are in ready state
+- security-operator pods have no errors in logs
+- Users can login, navigate to accounts and HttpBin resources
+- Users can onboard new organisations, accounts, and managed resources
+- Browser GraphQL requests to the gateway return no errors
+- New FGA stores for onboarded organisations contain 27 (not 22) types
+- Store, Account resources in kcp are READY
+- For additional checks run `docs/validate_kcp_resources.sh`
+- check logs in security-operator
+- check if accounts and members UIs in the portal are working
+
+---
+
+## 5. Troubleshooting
+
+### HelmRelease stuck or not getting ready
+
+**Cause:** Stale Helm state preventing reconciliation.
+
+**Fix:** Delete the stuck HelmRelease and its corresponding Helm secret, then reapply it:
+
+```shell
+kubectl -n <namespace> delete HelmRelease <name>
+kubectl -n <namespace> delete secret sh.helm.release.v1.<name>.v1
+```
+
+### APIExport not updating
+
+**Cause:** The platform-mesh-operator cannot update the APIExport in `root:platform-mesh-system` after the upgrade.
+
+**Fix:** Delete the APIExport and restart the operator (see [step 3.7](#37-fix-the-apiexport)).
+
+### api-syncagent pods crashing
+
+**Cause:** Stale URL in the `APIExportEndpointSlice` resource from the previous installation.
+
+**Fix:** Delete the old APIExportEndpointSlice resource -- it will be automatically recreated:
+
+```shell
+KUBECONFIG=<kcp-admin-kubeconfig> kubectl ws :root:platform-mesh-system
+KUBECONFIG=<kcp-admin-kubeconfig> kubectl delete apiexportendpointslice <name>
+```
+
+### Store resources not ready
+
+**Cause:** The `authorizationModelId` field in a Store resource's status does not match the current model in OpenFGA.
+
+**Fix:** Remove the stale field and let the security-operator reconcile it (see [step 3.13](#313-update-fga-store-models)):
+
+```shell
+kubectl patch store <store-name> --type=json \
+  -p '[{"op": "remove", "path": "/status/authorizationModelId"}]' --subresource=status
+```
+
+### GraphQL gateway returns unauthorized
+
+**Cause:** Incorrect client IDs in the `audiences` field of `WorkspaceAuthenticationConfiguration` resources.
+
+**Fix:** Run `docs/migration-0.2.0/fix_workspaceauthenticationconfiguration.sh` or manually patch the `audiences` to use the correct client IDs from Keycloak (see [step 3.14](#314-fix-workspaceauthenticationconfiguration)).
+
+### Cannot query Accounts via GraphQL
+
+**Cause:** Invalid or stale `ContentConfiguration` resources in the `root:platform-mesh-system` workspace.
+
+**Fix:** Delete the invalid ContentConfigurations and restart the platform-mesh-operator:
+
+```shell
+KUBECONFIG=<kcp-admin-kubeconfig> kubectl ws :root:platform-mesh-system
+KUBECONFIG=<kcp-admin-kubeconfig> kubectl delete contentconfiguration <name>
+kubectl -n platform-mesh-system delete pod -l app=platform-mesh-operator
+```
+
+### KCP resources to verify after migration
+
+If issues persist, inspect the following resource types in the relevant kcp workspaces:
+
+- `AccountInfo` -- ensure `spec.oidc` and client IDs are correct
+- `Store` -- ensure `status.authorizationModelId` is cleared or matches OpenFGA
+- `APIBinding` -- ensure bindings point to the updated APIExport
+- `WorkspaceAuthenticationConfiguration` -- ensure `audiences` contain the correct client IDs
+- `ContentConfiguration` -- ensure no stale entries with an invalid `VALID` flag exist in `root:platform-mesh-system`
+
+### domain-certificate-ca secret not found by the operator
+
+If it doesn't exist, create the secret using existing orchestration tools.
+
+### Keycloak not sending emails
+
+Missing configuration for realm.
+
+
+### kcp 'failed to verify' keycloak endpoint
+
+Wrong data in the `domain-certificate-ca` 'tls.key' must actually contain to CA!
+
+### invite users to orgnization
+
+Create Invite resources in the respective org workspace:
+```yaml
+apiVersion: core.platform-mesh.io/v1alpha1
+kind: Invite
+metadata:
+  name: username
+spec:
+  email: username@sap.com
+```
+
+Then set password, verify email and remove 'Required user actions' in keycloak.
+
+## kubernetes-graphql-gateway Unauthorized responses
+
+Cause: missing or incorrect `audiences` in orgs-authentication WorkspaceAuthenticationConfiguration resource in the ':root' kcp workspace.
+
+## kubernetes-graphql-gateway certificate verifycation issue
+https://rebac-authz-webhook.platform-mesh-system.svc.cluster.local:9443/authz?timeout=30s\\\": tls: failed to verify certificate: x509: certificate signed by unknown authority\") has prevented the request from succeeding (get accounts.core.platform-mesh.io
+
+Fix: restart the `kubernetes-graphql-gateway` and `root-kcp` pod
+
+## store resources not ready
+## security-operator logs: duplicate type definitions
+
+Symptop: Some APIBindings exist which have errors in status. Should be deleted or fixed, otherwise store reconcile issues remain with duplicate type definitions.
+
+Solution: Resolved by removing duplicate AuthorizationModels and APIResourceSchemas from kcp provider workspaces.
+
+## iam-service UI missing
+
+GraphQL response:
+```gql
+{
+    "errors": [
+        {
+            "message": "failed to test if action is allowed: failed to check permission with openfga: rpc error: code = Code(2000) desc = relation 'core_platform-mesh_io_account#get_iam_users' not found",
+            "path": [
+                "users"
+            ]
+        }
+    ],
+    "data": null
+}
+```
+
+Fixes:
+- update iam-service version to `v0.13.3`
+
+
+## add marketplace feature toggles to platform-mesh
+
+```yaml
+  featureToggles:
+  - name: feature-enable-marketplace-account
+  - name: feature-enable-marketplace-org
+```
+
+## remove Kustomization which overrides the ContentConfigurations
+
+Issue: externally deployed ContentConfiguration are overriding the ones deployed by the operator.
+Symptop: UI issues.
+
+Fix: remove Kustomization resource `ui-configs` from the showroom-mcp chart.
+
+## remove store-tuples which grant access to every logged in user to the org (owner should invite them explicitely)
+
+Previously, all logged-in users were members in any org, due to tuples configured in the `Store` resource.
+
+Fix: remove the tuples from store resources.
+
+After that, all new users must be explicitely added via the Members UI.
+
+## iam-service graphql unauthorized
+
+cause: stale secrets. In kcp's `:root:orgs` the WorkspaceAuthenticationConfiguration orgs-authentication should have '.spec.jwt[0].issuer.certificateAuthority' matching the **domain-certificate** ca.crt field. It usually get's it from **domain-certificate-ca** tls.crt. Those must be up-to-date. With newer versions of the operator this will be configurable not not neceserrily to sync.

--- a/docs/migration-0.2.0/reconcile_keycloak_clients.sh
+++ b/docs/migration-0.2.0/reconcile_keycloak_clients.sh
@@ -1,0 +1,303 @@
+#!/bin/bash
+#
+# Script to reconcile Keycloak clients for the 0.2.0 migration.
+# For each user-created realm, deletes the realm-named client (matching
+# the kcp workspace name under :root:orgs) and the 'kubectl' client,
+# then restarts the security-operator pods so they re-create them with
+# the updated configuration.
+#
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Keycloak configuration (KEYCLOAK_URL derived from PlatformMesh if not set)
+KEYCLOAK_URL="${KEYCLOAK_URL:-}"
+KEYCLOAK_USER="${KEYCLOAK_USER:-keycloak-admin}"
+KEYCLOAK_PASSWORD="${KEYCLOAK_PASSWORD:-admin}"
+
+# Built-in realms to skip
+BUILTIN_REALMS=("master")
+
+# Global variables
+ADMIN_TOKEN=""
+DRY_RUN=false
+NAMESPACE="platform-mesh-system"
+KUBECONFIG_K8S="${KUBECONFIG_K8S:-}"
+
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Derive Keycloak URL from the PlatformMesh resource in the cluster
+get_keycloak_url_from_cluster() {
+    local base_domain port
+    base_domain=$(kubectl -n platform-mesh-system get platformmesh platform-mesh \
+        -o jsonpath='{.spec.exposure.baseDomain}' 2>/dev/null) || return 1
+    port=$(kubectl -n platform-mesh-system get platformmesh platform-mesh \
+        -o jsonpath='{.spec.exposure.port}' 2>/dev/null) || return 1
+
+    if [ -z "$base_domain" ] || [ -z "$port" ]; then
+        return 1
+    fi
+
+    echo "https://${base_domain}:${port}/keycloak"
+}
+
+# Check for required tools
+check_dependencies() {
+    local missing=()
+
+    for tool in kubectl curl jq; do
+        if ! command -v "$tool" &> /dev/null; then
+            missing+=("$tool")
+        fi
+    done
+
+    if [ ${#missing[@]} -ne 0 ]; then
+        log_error "Missing required tools: ${missing[*]}"
+        exit 1
+    fi
+}
+
+# Get Keycloak admin token
+get_admin_token() {
+    curl -sk -X POST "${KEYCLOAK_URL}/realms/master/protocol/openid-connect/token" \
+        -H "Content-Type: application/x-www-form-urlencoded" \
+        -d "username=${KEYCLOAK_USER}" \
+        -d "password=${KEYCLOAK_PASSWORD}" \
+        -d "grant_type=password" \
+        -d "client_id=admin-cli" | jq -r '.access_token'
+}
+
+# List all realms
+get_realms() {
+    local token="$1"
+
+    curl -sk -X GET "${KEYCLOAK_URL}/admin/realms" \
+        -H "Authorization: Bearer ${token}" | jq -r '.[].realm'
+}
+
+# Get the internal UUID of a client by its display name in a realm.
+# The security-operator creates clients with UUIDs as clientId and the
+# human-readable identifier in the 'name' field, so we match on .name.
+get_client_uuid() {
+    local token="$1"
+    local realm="$2"
+    local client_name="$3"
+
+    curl -sk -X GET "${KEYCLOAK_URL}/admin/realms/${realm}/clients" \
+        -H "Authorization: Bearer ${token}" \
+        | jq -r --arg name "$client_name" '[.[] | select(.name == $name)] | .[0].id // empty'
+}
+
+# Delete a client by its internal UUID
+delete_client() {
+    local token="$1"
+    local realm="$2"
+    local client_uuid="$3"
+
+    local http_code
+    http_code=$(curl -sk -o /dev/null -w "%{http_code}" -X DELETE \
+        "${KEYCLOAK_URL}/admin/realms/${realm}/clients/${client_uuid}" \
+        -H "Authorization: Bearer ${token}")
+
+    if [ "$http_code" = "204" ]; then
+        return 0
+    else
+        log_error "  Delete returned HTTP $http_code"
+        return 1
+    fi
+}
+
+# Check if a realm is built-in
+is_builtin_realm() {
+    local realm="$1"
+    for builtin in "${BUILTIN_REALMS[@]}"; do
+        if [ "$realm" = "$builtin" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Restart security-operator pods
+restart_security_operator() {
+    log_info "Restarting security-operator pods..."
+
+    if [ "$DRY_RUN" = "true" ]; then
+        log_warn "Dry run - would delete pods:"
+        log_warn "  kubectl -n $NAMESPACE delete pod -l app=security-operator"
+        log_warn "  kubectl -n $NAMESPACE delete pod -l service=security-operator-generator"
+        log_warn "  kubectl -n $NAMESPACE delete pod -l service=security-operator-initializer"
+        return 0
+    fi
+
+    kubectl -n "$NAMESPACE" delete pod -l app=security-operator
+    kubectl -n "$NAMESPACE" delete pod -l service=security-operator-generator
+    kubectl -n "$NAMESPACE" delete pod -l service=security-operator-initializer
+
+    log_info "Security-operator pods restarted"
+}
+
+# Main function
+main() {
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --dry-run)
+                DRY_RUN=true
+                shift
+                ;;
+            --keycloak-user)
+                KEYCLOAK_USER="$2"
+                shift 2
+                ;;
+            --keycloak-password)
+                KEYCLOAK_PASSWORD="$2"
+                shift 2
+                ;;
+            --namespace)
+                NAMESPACE="$2"
+                shift 2
+                ;;
+            --kubeconfig)
+                KUBECONFIG_K8S="$2"
+                shift 2
+                ;;
+            -h|--help)
+                echo "Usage: $0 [OPTIONS]"
+                echo ""
+                echo "Delete the realm-named client and 'kubectl' client from each"
+                echo "user-created realm in Keycloak, then restart security-operator"
+                echo "pods to reconcile."
+                echo ""
+                echo "Options:"
+                echo "  --dry-run              Show what would be done without making changes"
+                echo "  --keycloak-user USER   Keycloak admin username (default: \$KEYCLOAK_USER or keycloak-admin)"
+                echo "  --keycloak-password PW Keycloak admin password (default: \$KEYCLOAK_PASSWORD or admin)"
+                echo "  --namespace NS         Kubernetes namespace (default: platform-mesh-system)"
+                echo "  --kubeconfig PATH      Kubeconfig for the Kubernetes cluster (default: \$KUBECONFIG_K8S or \$KUBECONFIG)"
+                echo "  -h, --help             Show this help message"
+                echo ""
+                echo "Environment variables:"
+                echo "  KEYCLOAK_URL           Keycloak base URL"
+                echo "  KEYCLOAK_USER          Keycloak admin username"
+                echo "  KEYCLOAK_PASSWORD      Keycloak admin password"
+                echo "  KUBECONFIG_K8S         Kubeconfig for the Kubernetes cluster"
+                exit 0
+                ;;
+            *)
+                log_error "Unknown option: $1"
+                exit 1
+                ;;
+        esac
+    done
+
+    check_dependencies
+
+    if [ -n "$KUBECONFIG_K8S" ]; then
+        export KUBECONFIG="$KUBECONFIG_K8S"
+        log_info "Using kubeconfig: $KUBECONFIG_K8S"
+    fi
+
+    if [ "$DRY_RUN" = "true" ]; then
+        log_warn "Running in dry-run mode - no changes will be applied"
+    fi
+
+    # Derive Keycloak URL from PlatformMesh resource if not explicitly set
+    if [ -z "$KEYCLOAK_URL" ]; then
+        log_info "KEYCLOAK_URL not set, reading from PlatformMesh resource..."
+        KEYCLOAK_URL=$(get_keycloak_url_from_cluster) || true
+        if [ -z "$KEYCLOAK_URL" ]; then
+            log_error "Failed to derive Keycloak URL from PlatformMesh resource."
+            log_error "Set KEYCLOAK_URL explicitly."
+            exit 1
+        fi
+        log_info "Derived Keycloak URL: $KEYCLOAK_URL"
+    fi
+
+    # Get Keycloak admin token
+    log_info "Fetching Keycloak admin token from $KEYCLOAK_URL..."
+    ADMIN_TOKEN=$(get_admin_token)
+    if [ -z "$ADMIN_TOKEN" ] || [ "$ADMIN_TOKEN" = "null" ]; then
+        log_error "Failed to get Keycloak admin token. Check your credentials."
+        exit 1
+    fi
+    log_info "Successfully obtained Keycloak admin token"
+
+    # List all realms
+    log_info "Listing Keycloak realms..."
+    local realms
+    realms=$(get_realms "$ADMIN_TOKEN")
+
+    if [ -z "$realms" ]; then
+        log_warn "No realms found"
+        exit 0
+    fi
+
+    local deleted_count=0
+    local skipped_count=0
+
+    # Process each realm
+    while IFS= read -r realm; do
+        if is_builtin_realm "$realm"; then
+            log_info "Skipping built-in realm: $realm"
+            continue
+        fi
+
+        log_info "Processing realm: $realm"
+
+        # The realm-named client matches the kcp workspace name (e.g. realm
+        # "myorg1" has a client called "myorg1"). 'kubectl' is always fixed.
+        local clients_to_delete=("$realm" "kubectl")
+
+        for client_name in "${clients_to_delete[@]}"; do
+            local client_uuid
+            client_uuid=$(get_client_uuid "$ADMIN_TOKEN" "$realm" "$client_name")
+
+            if [ -z "$client_uuid" ]; then
+                log_info "  Client '$client_name' not found in realm '$realm', skipping"
+                ((skipped_count++))
+                continue
+            fi
+
+            if [ "$DRY_RUN" = "true" ]; then
+                log_warn "  Dry run - would delete client '$client_name' (id: $client_uuid) from realm '$realm'"
+                ((deleted_count++))
+            else
+                log_info "  Deleting client '$client_name' (id: $client_uuid) from realm '$realm'..."
+                if delete_client "$ADMIN_TOKEN" "$realm" "$client_uuid"; then
+                    log_info "  Successfully deleted client '$client_name' from realm '$realm'"
+                    ((deleted_count++))
+                else
+                    log_error "  Failed to delete client '$client_name' from realm '$realm'"
+                fi
+            fi
+        done
+    done <<< "$realms"
+
+    echo ""
+    log_info "Summary: Deleted $deleted_count clients, Skipped $skipped_count"
+    echo ""
+
+    # Restart security-operator pods
+    restart_security_operator
+
+    echo ""
+    log_info "=== Keycloak client reconciliation complete ==="
+}
+
+main "$@"

--- a/docs/migration-0.2.0/validate_kcp_resources.sh
+++ b/docs/migration-0.2.0/validate_kcp_resources.sh
@@ -1,0 +1,1447 @@
+#!/bin/bash
+#
+# Validates that KCP resources are correct and consistent with Keycloak,
+# OpenFGA, and the Kubernetes cluster.
+#
+# Checks performed:
+#   1.  PlatformMesh resource is ready (K8s cluster)
+#   2.  APIExport exists in :root:platform-mesh-system
+#   3.  APIBindings have secrets permission claims
+#   4.  Account resources are Ready
+#   5.  AccountInfo has valid OIDC config with client IDs matching Keycloak
+#   6.  Store resources have correct coreModule (27 types) and authorizationModelId
+#   7.  IdentityProviderConfiguration exists per org workspace
+#   8.  Invite resources exist for org owners
+#   9.  WorkspaceAuthenticationConfiguration audiences contain UUID client IDs
+#  10.  ContentConfiguration has no stale entries
+#  11.  Keycloak realms and clients match KCP state
+#  12.  OpenFGA stores and authorization models are consistent
+#  13.  Gateway / HTTPRoute / TLSRoute readiness (K8s cluster)
+#  14.  Operator pods are running (K8s cluster)
+#
+
+set -euo pipefail
+
+###############################################################################
+# Configuration
+###############################################################################
+
+KEYCLOAK_URL="${KEYCLOAK_URL:-}"
+KEYCLOAK_USER="${KEYCLOAK_USER:-keycloak-admin}"
+KEYCLOAK_PASSWORD="${KEYCLOAK_PASSWORD:-admin}"
+OPENFGA_API_URL="${OPENFGA_API_URL:-http://localhost:8080}"
+KUBECONFIG_KCP="${KUBECONFIG_KCP:-}"
+KUBECONFIG_K8S="${KUBECONFIG_K8S:-}"
+KUBECTL_CONTEXT="${KUBECTL_CONTEXT:-}"
+KCP_SERVER="${KCP_SERVER:-}"
+NAMESPACE="${NAMESPACE:-platform-mesh-system}"
+APIBINDING_PREFIX="${APIBINDING_PREFIX:-core.platform-mesh.io-}"
+EXPECTED_FGA_TYPE_COUNT="${EXPECTED_FGA_TYPE_COUNT:-27}"
+BUILTIN_REALMS=("master")
+VERBOSE="${VERBOSE:-false}"
+
+###############################################################################
+# Counters and state
+###############################################################################
+
+PASS_COUNT=0
+FAIL_COUNT=0
+WARN_COUNT=0
+SKIP_COUNT=0
+ADMIN_TOKEN=""
+ORIGINAL_KUBECONFIG="${KUBECONFIG:-}"
+
+###############################################################################
+# Colors
+###############################################################################
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+###############################################################################
+# Logging helpers
+###############################################################################
+
+log_header() {
+    echo ""
+    echo -e "${BOLD}${CYAN}════════════════════════════════════════════════════════════════${NC}"
+    echo -e "${BOLD}${CYAN}  $1${NC}"
+    echo -e "${BOLD}${CYAN}════════════════════════════════════════════════════════════════${NC}"
+}
+
+log_section() {
+    echo ""
+    echo -e "${BOLD}${BLUE}── $1${NC}"
+}
+
+log_pass() {
+    echo -e "  ${GREEN}[PASS]${NC} $1"
+    ((PASS_COUNT++)) || true
+}
+
+log_fail() {
+    echo -e "  ${RED}[FAIL]${NC} $1"
+    ((FAIL_COUNT++)) || true
+}
+
+log_warn() {
+    echo -e "  ${YELLOW}[WARN]${NC} $1"
+    ((WARN_COUNT++)) || true
+}
+
+log_skip() {
+    echo -e "  ${YELLOW}[SKIP]${NC} $1"
+    ((SKIP_COUNT++)) || true
+}
+
+log_info() {
+    echo -e "  ${BLUE}[INFO]${NC} $1"
+}
+
+log_verbose() {
+    if [ "$VERBOSE" = "true" ]; then
+        echo -e "  ${BLUE}[VERB]${NC} $1"
+    fi
+}
+
+###############################################################################
+# Utility helpers
+###############################################################################
+
+is_uuid() {
+    echo "$1" | grep -qE '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+}
+
+is_builtin_realm() {
+    local realm="$1"
+    for builtin in "${BUILTIN_REALMS[@]}"; do
+        if [ "$realm" = "$builtin" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# kubectl ws (the kcp workspace plugin) reads KUBECONFIG from the environment
+# and ignores --kubeconfig, so we must export it for the duration of the call.
+kcp_kubectl() {
+    if [ -n "$KUBECONFIG_KCP" ]; then
+        KUBECONFIG="$KUBECONFIG_KCP" kubectl "$@"
+    else
+        kubectl "$@"
+    fi
+}
+
+k8s_kubectl() {
+    local args=()
+    if [ -n "$KUBECONFIG_K8S" ]; then
+        args+=(--kubeconfig "$KUBECONFIG_K8S")
+    fi
+    if [ -n "$KUBECTL_CONTEXT" ]; then
+        args+=(--context "$KUBECTL_CONTEXT")
+    fi
+    kubectl "${args[@]}" "$@"
+}
+
+###############################################################################
+# Dependency checks
+###############################################################################
+
+check_dependencies() {
+    local missing=()
+
+    for tool in kubectl curl jq; do
+        if ! command -v "$tool" &>/dev/null; then
+            missing+=("$tool")
+        fi
+    done
+
+    if [ ${#missing[@]} -ne 0 ]; then
+        echo -e "${RED}[ERROR] Missing required tools: ${missing[*]}${NC}"
+        exit 1
+    fi
+
+    # Optional tools
+    if ! command -v yq &>/dev/null; then
+        log_info "yq not found -- some YAML checks will be skipped"
+    fi
+}
+
+###############################################################################
+# Derive configuration from PlatformMesh if not set
+###############################################################################
+
+derive_config_from_cluster() {
+    if [ -z "$KEYCLOAK_URL" ]; then
+        log_info "KEYCLOAK_URL not set, deriving from PlatformMesh resource..."
+        local base_domain port
+        base_domain=$(k8s_kubectl -n "$NAMESPACE" get platformmesh platform-mesh \
+            -o jsonpath='{.spec.exposure.baseDomain}' 2>/dev/null) || true
+        port=$(k8s_kubectl -n "$NAMESPACE" get platformmesh platform-mesh \
+            -o jsonpath='{.spec.exposure.port}' 2>/dev/null) || true
+
+        if [ -n "$base_domain" ] && [ -n "$port" ]; then
+            KEYCLOAK_URL="https://${base_domain}:${port}/keycloak"
+            log_info "Derived KEYCLOAK_URL: $KEYCLOAK_URL"
+        else
+            log_warn "Could not derive KEYCLOAK_URL -- Keycloak checks will be skipped"
+        fi
+    fi
+}
+
+###############################################################################
+# Keycloak helpers
+###############################################################################
+
+keycloak_get_admin_token() {
+    curl -sk --max-time 3000 -X POST "${KEYCLOAK_URL}/realms/master/protocol/openid-connect/token" \
+        -H "Content-Type: application/x-www-form-urlencoded" \
+        -d "username=${KEYCLOAK_USER}" \
+        -d "password=${KEYCLOAK_PASSWORD}" \
+        -d "grant_type=password" \
+        -d "client_id=admin-cli" | jq -r '.access_token'
+}
+
+keycloak_refresh_token() {
+    if [ -n "$KEYCLOAK_URL" ]; then
+        ADMIN_TOKEN=$(keycloak_get_admin_token 2>/dev/null || echo "")
+        if [ -z "$ADMIN_TOKEN" ] || [ "$ADMIN_TOKEN" = "null" ]; then
+            ADMIN_TOKEN=""
+        fi
+    fi
+}
+
+keycloak_get_realms() {
+    curl -sk -X GET "${KEYCLOAK_URL}/admin/realms" \
+        -H "Authorization: Bearer ${ADMIN_TOKEN}" | jq -r '.[].realm'
+}
+
+keycloak_get_clients() {
+    local realm="$1"
+    curl -sk -X GET "${KEYCLOAK_URL}/admin/realms/${realm}/clients" \
+        -H "Authorization: Bearer ${ADMIN_TOKEN}"
+}
+
+keycloak_get_client_id_by_name() {
+    local realm="$1"
+    local client_name="$2"
+    curl -sk -X GET "${KEYCLOAK_URL}/admin/realms/${realm}/clients" \
+        -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+        | jq -r --arg name "$client_name" '[.[] | select(.name == $name)] | .[0].clientId // empty'
+}
+
+###############################################################################
+# OpenFGA helpers
+###############################################################################
+
+openfga_get_stores() {
+    curl -sk -X GET "${OPENFGA_API_URL}/stores" 2>/dev/null | jq -r '.stores // []'
+}
+
+openfga_get_auth_models() {
+    local store_id="$1"
+    curl -sk -X GET "${OPENFGA_API_URL}/stores/${store_id}/authorization-models" 2>/dev/null
+}
+
+openfga_count_types_in_model() {
+    local store_id="$1"
+    local model_id="$2"
+    curl -sk -X GET "${OPENFGA_API_URL}/stores/${store_id}/authorization-models/${model_id}" 2>/dev/null \
+        | jq '.authorization_model.type_definitions | length'
+}
+
+###############################################################################
+# 1. Validate PlatformMesh resource (K8s cluster)
+###############################################################################
+
+validate_platformmesh() {
+    log_header "1. PlatformMesh Resource (K8s cluster)"
+
+    local pm_json
+    pm_json=$(k8s_kubectl -n "$NAMESPACE" get platformmesh platform-mesh -o json 2>/dev/null) || {
+        log_fail "PlatformMesh 'platform-mesh' not found in namespace $NAMESPACE"
+        return
+    }
+
+    log_pass "PlatformMesh 'platform-mesh' exists"
+
+    # Check status conditions
+    local conditions
+    conditions=$(echo "$pm_json" | jq -r '.status.conditions // []')
+    local condition_count
+    condition_count=$(echo "$conditions" | jq 'length')
+
+    if [ "$condition_count" -eq 0 ]; then
+        log_warn "PlatformMesh has no status conditions"
+        return
+    fi
+
+    local all_ready=true
+    for i in $(seq 0 $((condition_count - 1))); do
+        local ctype cstatus
+        ctype=$(echo "$conditions" | jq -r ".[$i].type")
+        cstatus=$(echo "$conditions" | jq -r ".[$i].status")
+        if [ "$cstatus" = "True" ]; then
+            log_pass "PlatformMesh condition '$ctype' is True"
+        else
+            log_fail "PlatformMesh condition '$ctype' is $cstatus (expected True)"
+            all_ready=false
+        fi
+    done
+
+    # Validate exposure config
+    local base_domain port protocol
+    base_domain=$(echo "$pm_json" | jq -r '.spec.exposure.baseDomain // empty')
+    port=$(echo "$pm_json" | jq -r '.spec.exposure.port // empty')
+    protocol=$(echo "$pm_json" | jq -r '.spec.exposure.protocol // empty')
+
+    if [ -n "$base_domain" ]; then
+        log_pass "PlatformMesh baseDomain: $base_domain"
+    else
+        log_fail "PlatformMesh baseDomain is not set"
+    fi
+
+    log_verbose "PlatformMesh port=$port protocol=$protocol"
+}
+
+###############################################################################
+# 2. Validate APIExport in :root:platform-mesh-system
+###############################################################################
+
+validate_apiexport() {
+    log_header "2. APIExport (KCP)"
+
+    kcp_kubectl ws :root:platform-mesh-system &>/dev/null || {
+        log_fail "Cannot navigate to :root:platform-mesh-system workspace"
+        return
+    }
+
+    local apiexport_json
+    apiexport_json=$(kcp_kubectl get apiexport core.platform-mesh.io -o json 2>/dev/null) || {
+        log_fail "APIExport 'core.platform-mesh.io' not found in :root:platform-mesh-system"
+        kcp_kubectl ws :root &>/dev/null || true
+        return
+    }
+
+    log_pass "APIExport 'core.platform-mesh.io' exists"
+
+    # Check that it has the expected APIResourceSchemas
+    local schemas
+    schemas=$(echo "$apiexport_json" | jq -r '.spec.latestResourceSchemas // [] | .[]' 2>/dev/null)
+
+    if [ -n "$schemas" ]; then
+        local schema_count
+        schema_count=$(echo "$schemas" | wc -l)
+        log_pass "APIExport declares $schema_count resource schemas"
+        for schema in $schemas; do
+            log_verbose "  Schema: $schema"
+        done
+    else
+        log_warn "APIExport has no latestResourceSchemas"
+    fi
+
+    # Check permission claims
+    local perm_claims
+    perm_claims=$(echo "$apiexport_json" | jq '.spec.permissionClaims // [] | length')
+    if [ "$perm_claims" -gt 0 ]; then
+        log_pass "APIExport has $perm_claims permission claims"
+    else
+        log_warn "APIExport has no permission claims"
+    fi
+
+    kcp_kubectl ws :root &>/dev/null || true
+}
+
+###############################################################################
+# 3. Validate APIBindings across workspaces
+###############################################################################
+
+validate_apibindings_in_workspace() {
+    local ws_path="$1"
+    local indent="${2:-}"
+
+    kcp_kubectl ws "$ws_path" &>/dev/null || {
+        log_warn "${indent}Cannot navigate to workspace $ws_path"
+        return
+    }
+
+    # Get APIBindings with the expected prefix
+    local bindings
+    bindings=$(kcp_kubectl get apibindings -o json 2>/dev/null || echo '{"items":[]}')
+    local matching
+    matching=$(echo "$bindings" | jq -r \
+        --arg prefix "$APIBINDING_PREFIX" \
+        '.items[] | select(.metadata.name | startswith($prefix)) | .metadata.name')
+
+    for binding_name in $matching; do
+        [ -z "$binding_name" ] && continue
+
+        # Check for secrets permission claim
+        local has_secrets
+        has_secrets=$(echo "$bindings" | jq -r \
+            --arg name "$binding_name" \
+            '.items[] | select(.metadata.name == $name) | .spec.permissionClaims // [] | map(select(.resource == "secrets")) | length')
+
+        if [ "$has_secrets" -gt 0 ]; then
+            log_pass "${indent}APIBinding '$binding_name' in $ws_path has secrets claim"
+        else
+            log_fail "${indent}APIBinding '$binding_name' in $ws_path missing secrets permission claim"
+        fi
+
+        # Check binding phase
+        local phase
+        phase=$(echo "$bindings" | jq -r \
+            --arg name "$binding_name" \
+            '.items[] | select(.metadata.name == $name) | .status.phase // "Unknown"')
+        if [ "$phase" = "Bound" ]; then
+            log_pass "${indent}APIBinding '$binding_name' in $ws_path is Bound"
+        else
+            log_fail "${indent}APIBinding '$binding_name' in $ws_path phase is '$phase' (expected Bound)"
+        fi
+    done
+
+    # Recurse into child workspaces
+    local children
+    children=$(kcp_kubectl get workspaces -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
+    for child in $children; do
+        [ -z "$child" ] && continue
+        validate_apibindings_in_workspace "${ws_path}:${child}" "${indent}  "
+    done
+}
+
+validate_apibindings() {
+    log_header "3. APIBindings (KCP)"
+    validate_apibindings_in_workspace ":root"
+}
+
+###############################################################################
+# 4. Validate Account resources
+###############################################################################
+
+validate_accounts() {
+    log_header "4. Account Resources (KCP)"
+
+    kcp_kubectl ws :root:orgs &>/dev/null || {
+        log_fail "Cannot navigate to :root:orgs workspace"
+        return
+    }
+
+    local accounts_json
+    accounts_json=$(kcp_kubectl get accounts -o json 2>/dev/null || echo '{"items":[]}')
+    local account_count
+    account_count=$(echo "$accounts_json" | jq '.items | length')
+
+    if [ "$account_count" -eq 0 ]; then
+        log_warn "No Account resources found in :root:orgs"
+        kcp_kubectl ws :root &>/dev/null || true
+        return
+    fi
+
+    log_info "Found $account_count Account resource(s)"
+
+    while IFS= read -r account; do
+        local name acc_type creator
+        name=$(echo "$account" | jq -r '.metadata.name')
+        acc_type=$(echo "$account" | jq -r '.spec.type // "unknown"')
+        creator=$(echo "$account" | jq -r '.spec.creator // "unset"')
+
+        log_verbose "Account: $name (type=$acc_type, creator=$creator)"
+
+        # Check Ready condition
+        local ready_status
+        ready_status=$(echo "$account" | jq -r '
+            .status.conditions // [] | map(select(.type == "Ready")) | .[0].status // "Unknown"')
+
+        if [ "$ready_status" = "True" ]; then
+            log_pass "Account '$name' is Ready"
+        else
+            log_fail "Account '$name' is NOT Ready (status=$ready_status)"
+        fi
+
+        # Validate creator is set
+        if [ "$creator" = "unset" ] || [ "$creator" = "null" ] || [ -z "$creator" ]; then
+            log_warn "Account '$name' has no creator email"
+        fi
+    done < <(echo "$accounts_json" | jq -c '.items[]')
+
+    kcp_kubectl ws :root &>/dev/null || true
+}
+
+###############################################################################
+# 5. Validate AccountInfo OIDC + cross-check with Keycloak
+###############################################################################
+
+validate_accountinfo_in_workspace() {
+    local ws_path="$1"
+
+    kcp_kubectl ws "$ws_path" &>/dev/null || {
+        log_warn "Cannot navigate to workspace $ws_path"
+        return
+    }
+
+    if ! kcp_kubectl get accountinfo account &>/dev/null; then
+        log_verbose "No AccountInfo 'account' in $ws_path"
+        # Recurse into children
+        local children
+        children=$(kcp_kubectl get workspaces -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
+        for child in $children; do
+            [ -z "$child" ] && continue
+            validate_accountinfo_in_workspace "${ws_path}:${child}"
+        done
+        return
+    fi
+
+    local ai_json
+    ai_json=$(kcp_kubectl get accountinfo account -o json 2>/dev/null)
+
+    # The OIDC clients map uses the org name as key (e.g. clients.msp)
+    # and "kubectl" as the other key. Extract the org name from the workspace
+    # path (last segment after :root:orgs:, with nested colons replaced by dashes).
+    local org_name
+    org_name=$(echo "$ws_path" | sed 's/.*:orgs://' | sed 's/:.*$//')
+
+    local issuer_url org_client_id kubectl_client_id fga_store_id
+    issuer_url=$(echo "$ai_json" | jq -r '.spec.oidc.issuerUrl // empty')
+    org_client_id=$(echo "$ai_json" | jq -r --arg org "$org_name" '.spec.oidc.clients[$org].clientId // empty')
+    kubectl_client_id=$(echo "$ai_json" | jq -r '.spec.oidc.clients.kubectl.clientId // empty')
+    fga_store_id=$(echo "$ai_json" | jq -r '.spec.fga.store.id // empty')
+
+    log_section "AccountInfo in $ws_path"
+
+    # Check OIDC issuerUrl
+    if [ -n "$issuer_url" ]; then
+        log_pass "AccountInfo issuerUrl is set: $issuer_url"
+    else
+        log_fail "AccountInfo in $ws_path has no issuerUrl"
+    fi
+
+    # Check org-named client ID (e.g. clients.<org>.clientId)
+    if [ -n "$org_client_id" ]; then
+        if is_uuid "$org_client_id"; then
+            log_pass "AccountInfo '$org_name' clientId is a UUID: $org_client_id"
+        else
+            log_fail "AccountInfo '$org_name' clientId is NOT a UUID: $org_client_id"
+        fi
+    else
+        log_fail "AccountInfo in $ws_path missing '$org_name' clientId"
+    fi
+
+    # Check kubectl client ID
+    if [ -n "$kubectl_client_id" ]; then
+        if is_uuid "$kubectl_client_id"; then
+            log_pass "AccountInfo kubectl clientId is a UUID: $kubectl_client_id"
+        else
+            log_fail "AccountInfo kubectl clientId is NOT a UUID: $kubectl_client_id"
+        fi
+    else
+        log_fail "AccountInfo in $ws_path missing kubectl clientId"
+    fi
+
+    # Check FGA store ID
+    if [ -n "$fga_store_id" ]; then
+        log_pass "AccountInfo FGA store ID is set: $fga_store_id"
+    else
+        log_warn "AccountInfo in $ws_path has no FGA store ID"
+    fi
+
+    # Cross-check with Keycloak if token is available
+    if [ -n "$ADMIN_TOKEN" ] && [ -n "$issuer_url" ]; then
+        # Refresh token to prevent expiration during long-running validation
+        keycloak_refresh_token
+
+        local realm
+        realm=$(echo "$issuer_url" | sed -E 's|.*/realms/([^/]+).*|\1|')
+
+        if [ -n "$realm" ]; then
+            # Check that the realm exists in Keycloak
+            local realm_check
+            realm_check=$(curl -sk -o /dev/null -w "%{http_code}" \
+                "${KEYCLOAK_URL}/admin/realms/${realm}" \
+                -H "Authorization: Bearer ${ADMIN_TOKEN}")
+
+            if [ "$realm_check" = "200" ]; then
+                log_pass "Keycloak realm '$realm' exists"
+            else
+                log_fail "Keycloak realm '$realm' not found (HTTP $realm_check)"
+            fi
+
+            # Verify org-named client ID matches Keycloak
+            if [ -n "$org_client_id" ]; then
+                local kc_org_id
+                kc_org_id=$(keycloak_get_client_id_by_name "$realm" "$realm")
+                if [ "$kc_org_id" = "$org_client_id" ]; then
+                    log_pass "Keycloak '$org_name' client ID matches AccountInfo ($org_client_id)"
+                elif [ -z "$kc_org_id" ]; then
+                    log_fail "Keycloak client '$realm' not found in realm '$realm'"
+                else
+                    log_fail "Keycloak '$org_name' client ID mismatch: Keycloak=$kc_org_id, AccountInfo=$org_client_id"
+                fi
+            fi
+
+            # Verify kubectl client ID matches Keycloak
+            if [ -n "$kubectl_client_id" ]; then
+                local kc_kubectl_id
+                kc_kubectl_id=$(keycloak_get_client_id_by_name "$realm" "kubectl")
+                if [ "$kc_kubectl_id" = "$kubectl_client_id" ]; then
+                    log_pass "Keycloak kubectl client ID matches AccountInfo ($kubectl_client_id)"
+                elif [ -z "$kc_kubectl_id" ]; then
+                    log_fail "Keycloak client 'kubectl' not found in realm '$realm'"
+                else
+                    log_fail "Keycloak kubectl client ID mismatch: Keycloak=$kc_kubectl_id, AccountInfo=$kubectl_client_id"
+                fi
+            fi
+        fi
+    fi
+
+    # Check account and org URLs are populated
+    local account_url org_url
+    account_url=$(echo "$ai_json" | jq -r '.spec.account.url // empty')
+    org_url=$(echo "$ai_json" | jq -r '.spec.organization.url // empty')
+
+    if [ -n "$account_url" ]; then
+        log_pass "AccountInfo account.url is set: $account_url"
+    else
+        log_warn "AccountInfo in $ws_path has no account.url"
+    fi
+
+    if [ -n "$org_url" ]; then
+        log_pass "AccountInfo organization.url is set: $org_url"
+    else
+        log_warn "AccountInfo in $ws_path has no organization.url"
+    fi
+
+    # Recurse into children
+    local children
+    children=$(kcp_kubectl get workspaces -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
+    for child in $children; do
+        [ -z "$child" ] && continue
+        validate_accountinfo_in_workspace "${ws_path}:${child}"
+    done
+}
+
+validate_accountinfos() {
+    log_header "5. AccountInfo Resources + Keycloak Cross-Check (KCP)"
+
+    kcp_kubectl ws :root:orgs &>/dev/null || {
+        log_fail "Cannot navigate to :root:orgs workspace"
+        return
+    }
+
+    local orgs
+    orgs=$(kcp_kubectl get workspaces -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
+
+    if [ -z "$orgs" ]; then
+        log_warn "No workspaces found under :root:orgs"
+        return
+    fi
+
+    for org in $orgs; do
+        validate_accountinfo_in_workspace ":root:orgs:${org}"
+    done
+
+    kcp_kubectl ws :root &>/dev/null || true
+}
+
+###############################################################################
+# 6. Validate Store resources + OpenFGA cross-check
+###############################################################################
+
+validate_stores() {
+    log_header "6. Store Resources + OpenFGA Cross-Check (KCP)"
+
+    kcp_kubectl ws :root:orgs &>/dev/null || {
+        log_fail "Cannot navigate to :root:orgs workspace"
+        return
+    }
+
+    local stores_json
+    stores_json=$(kcp_kubectl get stores -o json 2>/dev/null || echo '{"items":[]}')
+    local store_count
+    store_count=$(echo "$stores_json" | jq '.items | length')
+
+    if [ "$store_count" -eq 0 ]; then
+        log_warn "No Store resources found in :root:orgs"
+        kcp_kubectl ws :root &>/dev/null || true
+        return
+    fi
+
+    log_info "Found $store_count Store resource(s)"
+
+    while IFS= read -r store; do
+        local name auth_model_id core_module
+        name=$(echo "$store" | jq -r '.metadata.name')
+        auth_model_id=$(echo "$store" | jq -r '.status.authorizationModelId // empty')
+        core_module=$(echo "$store" | jq -r '.spec.coreModule // empty')
+
+        log_section "Store: $name"
+
+        # Check Ready condition
+        local ready_status
+        ready_status=$(echo "$store" | jq -r '
+            .status.conditions // [] | map(select(.type == "Ready")) | .[0].status // "Unknown"')
+
+        if [ "$ready_status" = "True" ]; then
+            log_pass "Store '$name' is Ready"
+        else
+            log_fail "Store '$name' is NOT Ready (status=$ready_status)"
+        fi
+
+        # Check authorizationModelId
+        if [ -n "$auth_model_id" ]; then
+            log_pass "Store '$name' has authorizationModelId: $auth_model_id"
+        else
+            log_fail "Store '$name' has no authorizationModelId (not reconciled)"
+        fi
+
+        # Check coreModule is present (type count here is only the user-defined
+        # subset; the full count including dynamically added types is checked
+        # against OpenFGA in section 12)
+        if [ -n "$core_module" ]; then
+            local cr_type_count
+            cr_type_count=$(echo "$core_module" | grep -c '^type ' || true)
+            log_pass "Store '$name' coreModule is set ($cr_type_count user-defined types)"
+        else
+            log_fail "Store '$name' has no coreModule"
+        fi
+    done < <(echo "$stores_json" | jq -c '.items[]')
+
+    kcp_kubectl ws :root &>/dev/null || true
+}
+
+###############################################################################
+# 7. Validate IdentityProviderConfiguration per org
+###############################################################################
+
+validate_identity_provider_configs() {
+    log_header "7. IdentityProviderConfiguration (KCP)"
+
+    kcp_kubectl ws :root:orgs &>/dev/null || {
+        log_fail "Cannot navigate to :root:orgs workspace"
+        return
+    }
+
+    local orgs
+    orgs=$(kcp_kubectl get workspaces -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
+
+    if [ -z "$orgs" ]; then
+        log_warn "No workspaces found under :root:orgs"
+        return
+    fi
+
+    for org in $orgs; do
+        kcp_kubectl ws ":root:orgs:${org}" &>/dev/null || {
+            log_warn "Cannot navigate to :root:orgs:${org}"
+            continue
+        }
+
+        if kcp_kubectl get identityproviderconfiguration "$org" &>/dev/null; then
+            log_pass "IdentityProviderConfiguration '$org' exists in :root:orgs:${org}"
+
+            # Check that it has clients defined
+            local ipc_json
+            ipc_json=$(kcp_kubectl get identityproviderconfiguration "$org" -o json 2>/dev/null)
+            local client_count
+            client_count=$(echo "$ipc_json" | jq '.spec.clients // [] | length')
+
+            if [ "$client_count" -ge 2 ]; then
+                log_pass "IdentityProviderConfiguration '$org' has $client_count clients (default + kubectl)"
+            else
+                log_warn "IdentityProviderConfiguration '$org' has only $client_count client(s) (expected >= 2)"
+            fi
+        else
+            log_fail "IdentityProviderConfiguration '$org' missing in :root:orgs:${org}"
+        fi
+    done
+
+    kcp_kubectl ws :root &>/dev/null || true
+}
+
+###############################################################################
+# 8. Validate Invite resources for org owners
+###############################################################################
+
+validate_invites() {
+    log_header "8. Invite Resources for Org Owners (KCP)"
+
+    kcp_kubectl ws :root:orgs &>/dev/null || {
+        log_fail "Cannot navigate to :root:orgs workspace"
+        return
+    }
+
+    local orgs
+    orgs=$(kcp_kubectl get workspaces -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
+
+    if [ -z "$orgs" ]; then
+        log_warn "No workspaces found under :root:orgs"
+        return
+    fi
+
+    for org in $orgs; do
+        # Get creator email from Account
+        kcp_kubectl ws :root:orgs &>/dev/null
+        local creator_email
+        creator_email=$(kcp_kubectl get account "$org" -o jsonpath='{.spec.creator}' 2>/dev/null || echo "")
+
+        if [ -z "$creator_email" ] || [ "$creator_email" = "null" ]; then
+            log_warn "Account '$org' has no creator -- cannot check Invite"
+            continue
+        fi
+
+        # Switch to org workspace
+        kcp_kubectl ws ":root:orgs:${org}" &>/dev/null || {
+            log_warn "Cannot navigate to :root:orgs:${org}"
+            continue
+        }
+
+        local invites
+        invites=$(kcp_kubectl get invites -o jsonpath='{.items[*].spec.email}' 2>/dev/null || echo "")
+
+        if [[ " $invites " == *" $creator_email "* ]]; then
+            log_pass "Invite for owner '$creator_email' exists in :root:orgs:${org}"
+        else
+            # Check if any invite exists at all
+            local invite_count
+            invite_count=$(kcp_kubectl get invites -o json 2>/dev/null | jq '.items | length' 2>/dev/null || echo "0")
+            if [ "$invite_count" -gt 0 ]; then
+                log_warn "Org '$org' has $invite_count invite(s) but none for creator '$creator_email'"
+            else
+                log_fail "No Invite for owner '$creator_email' in :root:orgs:${org}"
+            fi
+        fi
+    done
+
+    kcp_kubectl ws :root &>/dev/null || true
+}
+
+###############################################################################
+# 9. Validate WorkspaceAuthenticationConfiguration
+###############################################################################
+
+validate_workspace_auth_configs() {
+    log_header "9. WorkspaceAuthenticationConfiguration (KCP)"
+
+    # Check in :root workspace first (orgs-authentication)
+    kcp_kubectl ws :root &>/dev/null || {
+        log_fail "Cannot navigate to :root workspace"
+        return
+    }
+
+    local wac_list
+    wac_list=$(kcp_kubectl get workspaceauthenticationconfiguration \
+        -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
+
+    if [ -z "$wac_list" ]; then
+        log_warn "No WorkspaceAuthenticationConfiguration in :root"
+    else
+        for wac_name in $wac_list; do
+            validate_single_wac "$wac_name" ":root"
+        done
+    fi
+
+    # Check in org workspaces
+    kcp_kubectl ws :root:orgs &>/dev/null || return
+    local orgs
+    orgs=$(kcp_kubectl get workspaces -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
+
+    for org in $orgs; do
+        [ -z "$org" ] && continue
+        kcp_kubectl ws ":root:orgs:${org}" &>/dev/null || continue
+
+        local org_wacs
+        org_wacs=$(kcp_kubectl get workspaceauthenticationconfiguration \
+            -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
+
+        for wac_name in $org_wacs; do
+            [ -z "$wac_name" ] && continue
+            validate_single_wac "$wac_name" ":root:orgs:${org}"
+        done
+    done
+
+    kcp_kubectl ws :root &>/dev/null || true
+}
+
+validate_single_wac() {
+    local name="$1"
+    local ws_path="$2"
+
+    local wac_json
+    wac_json=$(kcp_kubectl get workspaceauthenticationconfiguration "$name" -o json 2>/dev/null) || {
+        log_fail "WAC '$name' not found in $ws_path"
+        return
+    }
+
+    log_section "WAC '$name' in $ws_path"
+
+    # Check issuer URL
+    local issuer_url
+    issuer_url=$(echo "$wac_json" | jq -r '.spec.jwt[0].issuer.url // empty')
+    if [ -n "$issuer_url" ]; then
+        log_pass "WAC '$name' has issuer URL: $issuer_url"
+    else
+        log_fail "WAC '$name' in $ws_path has no issuer URL"
+    fi
+
+    # Check audiences contain UUIDs (not old-style names)
+    local audiences
+    audiences=$(echo "$wac_json" | jq -r '.spec.jwt[0].issuer.audiences // [] | .[]' 2>/dev/null)
+
+    if [ -z "$audiences" ]; then
+        log_fail "WAC '$name' in $ws_path has no audiences"
+        return
+    fi
+
+    local all_uuid=true
+    local audience_count=0
+    for aud in $audiences; do
+        ((audience_count++)) || true
+        if is_uuid "$aud"; then
+            log_pass "WAC '$name' audience '$aud' is a valid UUID"
+        else
+            log_fail "WAC '$name' audience '$aud' is NOT a UUID (old-style name?)"
+            all_uuid=false
+        fi
+    done
+
+    if [ "$audience_count" -eq 0 ]; then
+        log_fail "WAC '$name' in $ws_path has empty audiences array"
+    fi
+
+    # Cross-check audiences with Keycloak
+    if [ -n "$ADMIN_TOKEN" ] && [ -n "$issuer_url" ]; then
+        local realm
+        realm=$(echo "$issuer_url" | sed -E 's|.*/realms/([^/]+).*|\1|')
+
+        if [ -n "$realm" ]; then
+            # Get all UUID client IDs from Keycloak for this realm
+            local kc_clients_json
+            kc_clients_json=$(keycloak_get_clients "$realm" 2>/dev/null || echo "[]")
+            local kc_uuid_clients
+            kc_uuid_clients=$(echo "$kc_clients_json" | jq -r \
+                '.[] | select(.clientId | test("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")) | .clientId')
+
+            for aud in $audiences; do
+                if is_uuid "$aud"; then
+                    if echo "$kc_uuid_clients" | grep -q "^${aud}$"; then
+                        log_pass "WAC audience '$aud' exists as Keycloak client in realm '$realm'"
+                    else
+                        log_fail "WAC audience '$aud' NOT found as Keycloak client in realm '$realm'"
+                    fi
+                fi
+            done
+        fi
+    fi
+}
+
+###############################################################################
+# 10. Validate ContentConfiguration (no stale entries)
+###############################################################################
+
+validate_content_configurations() {
+    log_header "10. ContentConfiguration (KCP)"
+
+    kcp_kubectl ws :root:platform-mesh-system &>/dev/null || {
+        log_warn "Cannot navigate to :root:platform-mesh-system"
+        return
+    }
+
+    local cc_json
+    cc_json=$(kcp_kubectl get contentconfiguration -o json 2>/dev/null || echo '{"items":[]}')
+    local cc_count
+    cc_count=$(echo "$cc_json" | jq '.items | length')
+
+    if [ "$cc_count" -eq 0 ]; then
+        log_info "No ContentConfiguration resources in :root:platform-mesh-system"
+        kcp_kubectl ws :root &>/dev/null || true
+        return
+    fi
+
+    log_info "Found $cc_count ContentConfiguration resource(s)"
+
+    while IFS= read -r cc; do
+        local name
+        name=$(echo "$cc" | jq -r '.metadata.name')
+
+        # Check Ready condition
+        local ready_status
+        ready_status=$(echo "$cc" | jq -r '
+            .status.conditions // [] | map(select(.type == "Ready")) | .[0].status // "Unknown"')
+
+        if [ "$ready_status" = "True" ]; then
+            log_pass "ContentConfiguration '$name' is Ready"
+        elif [ "$ready_status" = "Unknown" ]; then
+            log_warn "ContentConfiguration '$name' has no Ready condition"
+        else
+            log_fail "ContentConfiguration '$name' is NOT Ready (status=$ready_status)"
+        fi
+    done < <(echo "$cc_json" | jq -c '.items[]')
+
+    kcp_kubectl ws :root &>/dev/null || true
+}
+
+###############################################################################
+# 11. Validate Keycloak realms match KCP orgs
+###############################################################################
+
+validate_keycloak_realms() {
+    log_header "11. Keycloak Realms vs KCP Orgs"
+
+    if [ -z "$ADMIN_TOKEN" ]; then
+        log_skip "Keycloak token not available -- skipping"
+        return
+    fi
+
+    # Refresh token to ensure it's valid for the duration of this check
+    keycloak_refresh_token
+
+    # Get KCP orgs
+    kcp_kubectl ws :root:orgs &>/dev/null || {
+        log_fail "Cannot navigate to :root:orgs"
+        return
+    }
+
+    local kcp_orgs
+    kcp_orgs=$(kcp_kubectl get workspaces -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
+
+    # Get Keycloak realms
+    local kc_realms
+    kc_realms=$(keycloak_get_realms)
+
+    # Check that each KCP org has a corresponding Keycloak realm
+    for org in $kcp_orgs; do
+        [ -z "$org" ] && continue
+        if echo "$kc_realms" | grep -q "^${org}$"; then
+            log_pass "KCP org '$org' has corresponding Keycloak realm"
+
+            # Check that the realm has default + kubectl clients
+            local default_id kubectl_id
+            default_id=$(keycloak_get_client_id_by_name "$org" "$org")
+            kubectl_id=$(keycloak_get_client_id_by_name "$org" "kubectl")
+
+            if [ -n "$default_id" ]; then
+                log_pass "Keycloak realm '$org' has default client (clientId=$default_id)"
+            else
+                log_fail "Keycloak realm '$org' missing default client (named '$org')"
+            fi
+
+            if [ -n "$kubectl_id" ]; then
+                log_pass "Keycloak realm '$org' has kubectl client (clientId=$kubectl_id)"
+            else
+                log_fail "Keycloak realm '$org' missing kubectl client"
+            fi
+        else
+            log_fail "KCP org '$org' has no corresponding Keycloak realm"
+        fi
+    done
+
+    # Check for orphaned Keycloak realms (realms without corresponding KCP org)
+    for realm in $kc_realms; do
+        [ -z "$realm" ] && continue
+        is_builtin_realm "$realm" && continue
+
+        if ! echo "$kcp_orgs" | grep -q "^${realm}$"; then
+            log_warn "Keycloak realm '$realm' has no corresponding KCP org (orphaned?)"
+        fi
+    done
+
+    kcp_kubectl ws :root &>/dev/null || true
+}
+
+###############################################################################
+# 12. Validate OpenFGA stores match KCP
+###############################################################################
+
+validate_openfga_stores() {
+    log_header "12. OpenFGA Stores Cross-Check"
+
+    local fga_stores_json
+    fga_stores_json=$(openfga_get_stores 2>/dev/null || echo "")
+
+    if [ -z "$fga_stores_json" ] || [ "$fga_stores_json" = "[]" ] || [ "$fga_stores_json" = "null" ]; then
+        log_skip "Cannot reach OpenFGA API at $OPENFGA_API_URL -- skipping"
+        return
+    fi
+
+    local fga_store_count
+    fga_store_count=$(echo "$fga_stores_json" | jq 'length')
+    log_info "Found $fga_store_count store(s) in OpenFGA"
+
+    # For each FGA store, check the latest authorization model type count
+    while IFS= read -r fga_store; do
+        local store_id store_name
+        store_id=$(echo "$fga_store" | jq -r '.id')
+        store_name=$(echo "$fga_store" | jq -r '.name // "unnamed"')
+
+        log_section "OpenFGA Store: $store_name ($store_id)"
+
+        local models_json
+        models_json=$(openfga_get_auth_models "$store_id" 2>/dev/null || echo "")
+
+        if [ -z "$models_json" ] || [ "$models_json" = "null" ]; then
+            log_warn "Cannot fetch authorization models for store $store_id"
+            continue
+        fi
+
+        local model_count
+        model_count=$(echo "$models_json" | jq '.authorization_models | length')
+
+        if [ "$model_count" -eq 0 ]; then
+            log_fail "OpenFGA store '$store_name' has no authorization models"
+            continue
+        fi
+
+        log_pass "OpenFGA store '$store_name' has $model_count authorization model(s)"
+
+        # Check latest model type count
+        local latest_model_id type_count
+        latest_model_id=$(echo "$models_json" | jq -r '.authorization_models[0].id')
+        type_count=$(echo "$models_json" | jq '.authorization_models[0].type_definitions | length')
+
+        if [ "$type_count" -ge "$EXPECTED_FGA_TYPE_COUNT" ]; then
+            log_pass "Latest model has $type_count types (expected >= $EXPECTED_FGA_TYPE_COUNT)"
+        else
+            log_fail "Latest model has $type_count types (expected >= $EXPECTED_FGA_TYPE_COUNT)"
+        fi
+    done < <(echo "$fga_stores_json" | jq -c '.[]')
+}
+
+###############################################################################
+# 13. Validate Gateway / HTTPRoute / TLSRoute (K8s cluster)
+###############################################################################
+
+validate_gateway_routes() {
+    log_header "13. Gateway, HTTPRoutes, TLSRoutes (K8s cluster)"
+
+    # Gateways
+    local gw_json
+    gw_json=$(k8s_kubectl get gateways -A -o json 2>/dev/null || echo '{"items":[]}')
+    local gw_count
+    gw_count=$(echo "$gw_json" | jq '.items | length')
+
+    if [ "$gw_count" -eq 0 ]; then
+        log_warn "No Gateway resources found in the cluster"
+    else
+        while IFS= read -r gw; do
+            local gw_name gw_ns
+            gw_name=$(echo "$gw" | jq -r '.metadata.name')
+            gw_ns=$(echo "$gw" | jq -r '.metadata.namespace')
+
+            local accepted programmed
+            accepted=$(echo "$gw" | jq -r '
+                .status.conditions // [] | map(select(.type == "Accepted")) | .[0].status // "Unknown"')
+            programmed=$(echo "$gw" | jq -r '
+                .status.conditions // [] | map(select(.type == "Programmed")) | .[0].status // "Unknown"')
+
+            if [ "$accepted" = "True" ] && [ "$programmed" = "True" ]; then
+                log_pass "Gateway '$gw_ns/$gw_name' is Accepted and Programmed"
+            else
+                log_fail "Gateway '$gw_ns/$gw_name' Accepted=$accepted Programmed=$programmed"
+            fi
+        done < <(echo "$gw_json" | jq -c '.items[]')
+    fi
+
+    # HTTPRoutes
+    local hr_json
+    hr_json=$(k8s_kubectl get httproutes -A -o json 2>/dev/null || echo '{"items":[]}')
+    local hr_count
+    hr_count=$(echo "$hr_json" | jq '.items | length')
+
+    if [ "$hr_count" -eq 0 ]; then
+        log_info "No HTTPRoute resources found"
+    else
+        while IFS= read -r hr; do
+            local hr_name hr_ns
+            hr_name=$(echo "$hr" | jq -r '.metadata.name')
+            hr_ns=$(echo "$hr" | jq -r '.metadata.namespace')
+
+            local accepted
+            accepted=$(echo "$hr" | jq -r '
+                .status.parents // [] | .[0].conditions // [] | map(select(.type == "Accepted")) | .[0].status // "Unknown"')
+
+            if [ "$accepted" = "True" ]; then
+                log_pass "HTTPRoute '$hr_ns/$hr_name' is Accepted"
+            else
+                log_fail "HTTPRoute '$hr_ns/$hr_name' Accepted=$accepted"
+            fi
+        done < <(echo "$hr_json" | jq -c '.items[]')
+    fi
+
+    # TLSRoutes
+    local tls_json
+    tls_json=$(k8s_kubectl get tlsroutes -A -o json 2>/dev/null || echo '{"items":[]}')
+    local tls_count
+    tls_count=$(echo "$tls_json" | jq '.items | length')
+
+    if [ "$tls_count" -eq 0 ]; then
+        log_info "No TLSRoute resources found"
+    else
+        while IFS= read -r tlsr; do
+            local tls_name tls_ns
+            tls_name=$(echo "$tlsr" | jq -r '.metadata.name')
+            tls_ns=$(echo "$tlsr" | jq -r '.metadata.namespace')
+
+            local accepted
+            accepted=$(echo "$tlsr" | jq -r '
+                .status.parents // [] | .[0].conditions // [] | map(select(.type == "Accepted")) | .[0].status // "Unknown"')
+
+            if [ "$accepted" = "True" ]; then
+                log_pass "TLSRoute '$tls_ns/$tls_name' is Accepted"
+            else
+                log_fail "TLSRoute '$tls_ns/$tls_name' Accepted=$accepted"
+            fi
+        done < <(echo "$tls_json" | jq -c '.items[]')
+    fi
+}
+
+###############################################################################
+# 14. Validate operator pods (K8s cluster)
+###############################################################################
+
+validate_operator_pods() {
+    log_header "14. Operator Pods (K8s cluster)"
+
+    local expected_labels=(
+        "app=platform-mesh-operator"
+        "app=security-operator"
+        "service=security-operator-generator"
+        "service=security-operator-initializer"
+        "app=account-operator"
+    )
+
+    for label in "${expected_labels[@]}"; do
+        local pods_json
+        pods_json=$(k8s_kubectl -n "$NAMESPACE" get pods -l "$label" -o json 2>/dev/null || echo '{"items":[]}')
+        local pod_count
+        pod_count=$(echo "$pods_json" | jq '.items | length')
+
+        if [ "$pod_count" -eq 0 ]; then
+            log_warn "No pods found with label '$label' in $NAMESPACE"
+            continue
+        fi
+
+        while IFS= read -r pod; do
+            local pod_name phase
+            pod_name=$(echo "$pod" | jq -r '.metadata.name')
+            phase=$(echo "$pod" | jq -r '.status.phase')
+
+            # Check container readiness
+            local ready_containers total_containers
+            ready_containers=$(echo "$pod" | jq '[.status.containerStatuses // [] | .[] | select(.ready == true)] | length')
+            total_containers=$(echo "$pod" | jq '[.status.containerStatuses // [] | .[]] | length')
+
+            if [ "$phase" = "Running" ] && [ "$ready_containers" = "$total_containers" ]; then
+                log_pass "Pod '$pod_name' is Running ($ready_containers/$total_containers ready)"
+            else
+                log_fail "Pod '$pod_name' phase=$phase ($ready_containers/$total_containers ready)"
+            fi
+
+            # Check for restart count
+            local restarts
+            restarts=$(echo "$pod" | jq '[.status.containerStatuses // [] | .[].restartCount] | add // 0')
+            if [ "$restarts" -gt 5 ]; then
+                log_warn "Pod '$pod_name' has $restarts restarts"
+            fi
+        done < <(echo "$pods_json" | jq -c '.items[]')
+    done
+}
+
+###############################################################################
+# Summary
+###############################################################################
+
+print_summary() {
+    echo ""
+    echo -e "${BOLD}${CYAN}════════════════════════════════════════════════════════════════${NC}"
+    echo -e "${BOLD}${CYAN}  VALIDATION SUMMARY${NC}"
+    echo -e "${BOLD}${CYAN}════════════════════════════════════════════════════════════════${NC}"
+    echo ""
+    echo -e "  ${GREEN}PASS:${NC} $PASS_COUNT"
+    echo -e "  ${RED}FAIL:${NC} $FAIL_COUNT"
+    echo -e "  ${YELLOW}WARN:${NC} $WARN_COUNT"
+    echo -e "  ${YELLOW}SKIP:${NC} $SKIP_COUNT"
+    echo ""
+
+    if [ "$FAIL_COUNT" -gt 0 ]; then
+        echo -e "  ${RED}${BOLD}Result: FAILED${NC} -- $FAIL_COUNT check(s) failed"
+        echo ""
+        echo -e "  Refer to the migration guide at docs/migration-release-0.2.0.md"
+        echo -e "  and the troubleshooting section for remediation steps."
+    elif [ "$WARN_COUNT" -gt 0 ]; then
+        echo -e "  ${YELLOW}${BOLD}Result: PASSED with warnings${NC}"
+    else
+        echo -e "  ${GREEN}${BOLD}Result: ALL CHECKS PASSED${NC}"
+    fi
+    echo ""
+}
+
+###############################################################################
+# Help
+###############################################################################
+
+show_help() {
+    cat <<EOF
+Usage: $0 [OPTIONS]
+
+Validates KCP resources and their consistency with Keycloak, OpenFGA,
+and the Kubernetes cluster.
+
+Options:
+  --kubeconfig-kcp PATH       Kubeconfig for kcp (default: \$KUBECONFIG_KCP)
+  --kubeconfig PATH           Kubeconfig for K8s cluster (default: \$KUBECONFIG_K8S)
+  --context NAME              kubectl context to use for K8s cluster (default: \$KUBECTL_CONTEXT)
+  --keycloak-url URL          Keycloak base URL (default: derived from PlatformMesh)
+  --keycloak-user USER        Keycloak admin user (default: \$KEYCLOAK_USER or keycloak-admin)
+  --keycloak-password PW      Keycloak admin password (default: \$KEYCLOAK_PASSWORD or admin)
+  --openfga-url URL           OpenFGA API URL (default: \$OPENFGA_API_URL or http://localhost:8080)
+  --kcp-server URL            KCP API server URL (default: \$KCP_SERVER)
+  --namespace NS              K8s namespace (default: platform-mesh-system)
+  --expected-fga-types N      Expected FGA type count (default: 27)
+  --verbose                   Show detailed output
+  -h, --help                  Show this help message
+
+Environment variables:
+  KEYCLOAK_URL                Keycloak base URL
+  KEYCLOAK_USER               Keycloak admin username
+  KEYCLOAK_PASSWORD           Keycloak admin password
+  OPENFGA_API_URL             OpenFGA HTTP API base URL
+  KUBECONFIG_KCP              Kubeconfig for kcp
+  KUBECONFIG_K8S              Kubeconfig for the Kubernetes cluster
+  KUBECTL_CONTEXT             kubectl context to use for K8s cluster
+  KCP_SERVER                  KCP API server URL
+  NAMESPACE                   Kubernetes namespace
+  EXPECTED_FGA_TYPE_COUNT     Expected FGA type count per store model
+  VERBOSE                     Set to "true" for verbose output
+
+Examples:
+  # Basic validation (derives Keycloak URL from PlatformMesh)
+  $0
+
+  # With explicit kubeconfigs
+  $0 --kubeconfig-kcp /path/to/kcp.kubeconfig --kubeconfig /path/to/k8s.kubeconfig
+
+  # With OpenFGA port-forwarded to localhost:8080
+  kubectl -n platform-mesh-system port-forward svc/openfga 8080 &
+  $0 --openfga-url http://localhost:8080
+
+  # Verbose output
+  $0 --verbose
+EOF
+}
+
+###############################################################################
+# Main
+###############################################################################
+
+main() {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --kubeconfig-kcp)
+                KUBECONFIG_KCP="$2"
+                shift 2
+                ;;
+            --kubeconfig)
+                KUBECONFIG_K8S="$2"
+                shift 2
+                ;;
+            --context)
+                KUBECTL_CONTEXT="$2"
+                shift 2
+                ;;
+            --keycloak-url)
+                KEYCLOAK_URL="$2"
+                shift 2
+                ;;
+            --keycloak-user)
+                KEYCLOAK_USER="$2"
+                shift 2
+                ;;
+            --keycloak-password)
+                KEYCLOAK_PASSWORD="$2"
+                shift 2
+                ;;
+            --openfga-url)
+                OPENFGA_API_URL="$2"
+                shift 2
+                ;;
+            --kcp-server)
+                KCP_SERVER="$2"
+                shift 2
+                ;;
+            --namespace)
+                NAMESPACE="$2"
+                shift 2
+                ;;
+            --expected-fga-types)
+                EXPECTED_FGA_TYPE_COUNT="$2"
+                shift 2
+                ;;
+            --verbose)
+                VERBOSE=true
+                shift
+                ;;
+            -h|--help)
+                show_help
+                exit 0
+                ;;
+            *)
+                echo "Unknown option: $1"
+                show_help
+                exit 1
+                ;;
+        esac
+    done
+
+    echo ""
+    echo -e "${BOLD}${CYAN}  KCP Resource Validation Script${NC}"
+    echo -e "${BOLD}${CYAN}  platform-mesh / helm-charts${NC}"
+    echo ""
+
+    check_dependencies
+    derive_config_from_cluster
+
+    # Obtain Keycloak admin token if possible
+    if [ -n "$KEYCLOAK_URL" ]; then
+        log_info "Authenticating with Keycloak at $KEYCLOAK_URL..."
+        ADMIN_TOKEN=$(keycloak_get_admin_token 2>/dev/null || echo "")
+        if [ -n "$ADMIN_TOKEN" ] && [ "$ADMIN_TOKEN" != "null" ]; then
+            log_info "Keycloak admin token obtained"
+        else
+            ADMIN_TOKEN=""
+            log_warn "Failed to obtain Keycloak admin token -- Keycloak cross-checks will be skipped"
+        fi
+    fi
+
+    # Run all validations
+    validate_platformmesh
+    validate_apiexport
+    validate_apibindings
+    validate_accounts
+    validate_accountinfos
+    validate_stores
+    validate_identity_provider_configs
+    validate_invites
+    validate_workspace_auth_configs
+    validate_content_configurations
+    validate_keycloak_realms
+    validate_openfga_stores
+    validate_gateway_routes
+    validate_operator_pods
+
+    # Restore original kubeconfig
+    if [ -n "$ORIGINAL_KUBECONFIG" ]; then
+        export KUBECONFIG="$ORIGINAL_KUBECONFIG"
+    fi
+
+    print_summary
+
+    # Exit with non-zero if any checks failed
+    if [ "$FAIL_COUNT" -gt 0 ]; then
+        exit 1
+    fi
+}
+
+main "$@"

--- a/docs/migration-0.3/export-kcp-resources.sh
+++ b/docs/migration-0.3/export-kcp-resources.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Export all KCP resources from all workspaces as YAML.
+#
+# Usage:
+#   docs/migration-0.3/export-kcp-resources.sh <output-dir>
+#
+# Example:
+#   docs/migration-0.3/export-kcp-resources.sh docs/migration-0.3/kcp-exports/v0.2
+
+OUTDIR="${1:?Usage: $0 <output-dir>}"
+KUBECONFIG_KCP="${KUBECONFIG_KCP:-.secret/kcp/admin.kubeconfig}"
+KCP_SERVER="${KCP_SERVER:-https://localhost:8443}"
+
+if [[ ! -f "$KUBECONFIG_KCP" ]]; then
+  echo "Error: KCP admin kubeconfig not found at $KUBECONFIG_KCP" >&2
+  echo "Run 'local-setup/scripts/createKcpAdminKubeconfig.sh' first." >&2
+  exit 1
+fi
+
+KC="kubectl --kubeconfig=$KUBECONFIG_KCP"
+
+kcp_get() {
+  local ws="$1" resource="$2"
+  $KC get "$resource" --server "${KCP_SERVER}/clusters/${ws}" -o yaml 2>/dev/null || true
+}
+
+kcp_api_resources() {
+  local ws="$1"
+  $KC api-resources --server "${KCP_SERVER}/clusters/${ws}" 2>/dev/null || true
+}
+
+discover_workspaces() {
+  local parent="$1"
+  echo "$parent"
+  local children
+  children=$($KC get workspace --server "${KCP_SERVER}/clusters/${parent}" \
+    -o jsonpath='{.items[*].metadata.name}' 2>/dev/null) || true
+  for child in $children; do
+    discover_workspaces "${parent}:${child}"
+  done
+}
+
+has_items() {
+  local yaml="$1"
+  [[ -n "$yaml" ]] && echo "$yaml" | grep -q '^kind:' && ! echo "$yaml" | grep -q '^items: \[\]$'
+}
+
+KCP_RESOURCES=(
+  apiexports.apis.kcp.io
+  apiexportendpointslices.apis.kcp.io
+  apiresourceschemas.apis.kcp.io
+  apibindings.apis.kcp.io
+  apiconversions.apis.kcp.io
+  workspaces.tenancy.kcp.io
+  workspacetypes.tenancy.kcp.io
+  logicalclusters.core.kcp.io
+  shards.core.kcp.io
+  clusterroles
+  clusterrolebindings
+)
+
+PLATFORM_MESH_RESOURCES=(
+  accounts.core.platform-mesh.io
+  accountinfos.core.platform-mesh.io
+  identityproviderconfigurations.core.platform-mesh.io
+  stores.core.platform-mesh.io
+  authorizationmodels.core.platform-mesh.io
+  invites.core.platform-mesh.io
+  apiexportpolicies.core.platform-mesh.io
+  httpbins.orchestrate.platform-mesh.io
+)
+
+echo "=== Discovering workspaces ==="
+WORKSPACES=()
+while IFS= read -r ws; do
+  WORKSPACES+=("$ws")
+done < <(discover_workspaces "root")
+
+echo "Found ${#WORKSPACES[@]} workspaces:"
+printf "  %s\n" "${WORKSPACES[@]}"
+
+mkdir -p "$OUTDIR"
+
+echo ""
+echo "=== Exporting KCP resources ==="
+
+for ws in "${WORKSPACES[@]}"; do
+  ws_dir="$OUTDIR/${ws//:/_}"
+  mkdir -p "$ws_dir"
+
+  echo "--- Workspace: $ws ---"
+
+  echo "  api-resources"
+  kcp_api_resources "$ws" > "$ws_dir/api-resources.txt"
+
+  for resource in "${KCP_RESOURCES[@]}" "${PLATFORM_MESH_RESOURCES[@]}"; do
+    short="${resource%%.*}"
+    result=$(kcp_get "$ws" "$resource")
+    if has_items "$result"; then
+      echo "  $short"
+      echo "$result" > "$ws_dir/${short}.yaml"
+    fi
+  done
+done
+
+echo ""
+echo "=== Exporting K8s-side resources ==="
+
+K8S_DIR="$OUTDIR/k8s"
+mkdir -p "$K8S_DIR"
+
+for resource in helmreleases.helm.toolkit.fluxcd.io components.delivery.ocm.software \
+  resourcegraphdefinitions.kro.run platformmeshes.core.platform-mesh.io \
+  resources.delivery.ocm.software; do
+  short="${resource%%.*}"
+  echo "  $short"
+  kubectl get "$resource" -A -o yaml > "$K8S_DIR/${short}.yaml" 2>/dev/null || true
+done
+
+kubectl get pods -n platform-mesh-system -o wide > "$K8S_DIR/pods.txt" 2>/dev/null || true
+kubectl get helmrelease -A > "$K8S_DIR/helmrelease-status.txt" 2>/dev/null || true
+
+echo ""
+echo "=== Export complete ==="
+echo "Output directory: $OUTDIR"
+find "$OUTDIR" -type f | wc -l | xargs -I{} echo "Total files: {}"

--- a/docs/migration-0.3/migrate-openfga-tuples.sh
+++ b/docs/migration-0.3/migrate-openfga-tuples.sh
@@ -1,0 +1,342 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Migrate OpenFGA tuples from a backup directory by replacing old KCP cluster IDs
+# with current ones from the live KCP state.
+#
+# The script discovers all workspaces, extracts LogicalCluster IDs, then builds a
+# mapping from old IDs (found in the backup tuples) to new IDs (from the current KCP).
+# It identifies workspaces by matching workspace names referenced in tuples to the
+# current workspace tree.
+#
+# Usage:
+#   docs/migration-0.3/migrate-openfga-tuples.sh <backup-dir> [output-dir]
+#
+# Environment:
+#   KUBECONFIG_KCP  - path to KCP admin kubeconfig (default: .secret/kcp/admin.kubeconfig)
+#   KCP_SERVER      - KCP API server URL (default: https://localhost:8443)
+#   DRY_RUN         - set to "true" to only print the mapping without writing files
+
+usage() {
+  cat <<'EOF'
+Migrate OpenFGA tuples from a backup by replacing old KCP cluster IDs with
+current ones from the live KCP state.
+
+USAGE:
+  migrate-openfga-tuples.sh <backup-dir> [output-dir]
+
+ARGUMENTS:
+  backup-dir    Directory containing *-tuples.json files exported from OpenFGA.
+  output-dir    Where to write migrated files (default: <backup-dir>/migrated).
+
+ENVIRONMENT VARIABLES:
+  KUBECONFIG_KCP  Path to KCP admin kubeconfig (default: .secret/kcp/admin.kubeconfig)
+  KCP_SERVER      KCP API server URL (default: https://localhost:8443)
+  FGA_SERVER_URL  OpenFGA API URL (default: http://localhost:8080)
+  DRY_RUN         Set to "true" to print the ID mapping without writing or applying.
+
+HOW IT WORKS:
+  1. Discovers all KCP workspaces recursively from root.
+  2. Reads the LogicalCluster ID (kcp.io/cluster annotation) for each workspace.
+  3. Extracts old 16-char cluster IDs from *-tuples.json files in backup-dir.
+  4. Matches each old ID to a workspace by checking which workspace's children
+     correspond to the workspace names that follow the ID in tuples
+     (pattern: CLUSTER_ID/WORKSPACE_NAME).
+  5. Falls back to APIExport matching for IDs referencing
+     apis_kcp_io_apiexport:CLUSTER_ID/export-name.
+  6. Replaces old IDs with new IDs in all tuple files and writes to output-dir.
+  7. Writes the migrated tuples to OpenFGA via the fga CLI, matching store names
+     from filenames (e.g. default-tuples.json → store "default").
+
+EXAMPLES:
+  # Standard migration
+  docs/migration-0.3/migrate-openfga-tuples.sh local-setup/backup/openfga
+
+  # Custom output directory
+  docs/migration-0.3/migrate-openfga-tuples.sh local-setup/backup/openfga /tmp/migrated-tuples
+
+  # Dry run — inspect the mapping without writing anything
+  DRY_RUN=true docs/migration-0.3/migrate-openfga-tuples.sh local-setup/backup/openfga
+
+  # Use a remote KCP server
+  KCP_SERVER=https://kcp.example.com:8443 \
+    docs/migration-0.3/migrate-openfga-tuples.sh local-setup/backup/openfga
+
+PREREQUISITES:
+  - kubectl with access to the KCP API server
+  - KCP admin kubeconfig (generate with local-setup/scripts/createKcpAdminKubeconfig.sh)
+  - fga CLI (OpenFGA CLI) with access to the OpenFGA server
+  - jq for JSON transformation
+  - grep with PCRE support (-P flag)
+  - python3 (for JSON pretty-printing in diff output)
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+BACKUP_DIR="${1:?Usage: $0 <backup-dir> [output-dir]. Run with --help for details.}"
+OUTPUT_DIR="${2:-${BACKUP_DIR}/migrated}"
+KUBECONFIG_KCP="${KUBECONFIG_KCP:-.secret/kcp/admin.kubeconfig}"
+KCP_SERVER="${KCP_SERVER:-https://localhost:8443}"
+DRY_RUN="${DRY_RUN:-false}"
+
+if [[ ! -d "$BACKUP_DIR" ]]; then
+  echo "Error: Backup directory not found: $BACKUP_DIR" >&2
+  exit 1
+fi
+
+if [[ ! -f "$KUBECONFIG_KCP" ]]; then
+  echo "Error: KCP admin kubeconfig not found at $KUBECONFIG_KCP" >&2
+  echo "Run 'local-setup/scripts/createKcpAdminKubeconfig.sh' first." >&2
+  exit 1
+fi
+
+KC="kubectl --kubeconfig=$KUBECONFIG_KCP"
+
+get_logical_cluster_id() {
+  local ws="$1"
+  $KC get logicalclusters --server "${KCP_SERVER}/clusters/${ws}" \
+    -o jsonpath='{.items[0].metadata.annotations.kcp\.io/cluster}' 2>/dev/null || true
+}
+
+discover_workspaces() {
+  local parent="$1"
+  echo "$parent"
+  local children
+  children=$($KC get workspace --server "${KCP_SERVER}/clusters/${parent}" \
+    -o jsonpath='{.items[*].metadata.name}' 2>/dev/null) || true
+  for child in $children; do
+    discover_workspaces "${parent}:${child}"
+  done
+}
+
+echo "=== Discovering KCP workspaces ==="
+WORKSPACES=()
+while IFS= read -r ws; do
+  WORKSPACES+=("$ws")
+done < <(discover_workspaces "root")
+
+echo "Found ${#WORKSPACES[@]} workspaces:"
+printf "  %s\n" "${WORKSPACES[@]}"
+
+echo ""
+echo "=== Building workspace → cluster ID mapping ==="
+
+declare -A WS_TO_CLUSTER_ID
+for ws in "${WORKSPACES[@]}"; do
+  cluster_id=$(get_logical_cluster_id "$ws")
+  if [[ -n "$cluster_id" ]]; then
+    WS_TO_CLUSTER_ID["$ws"]="$cluster_id"
+    echo "  $ws → $cluster_id"
+  fi
+done
+
+echo ""
+echo "=== Extracting old cluster IDs from backup tuples ==="
+
+# Cluster IDs in tuples follow these patterns:
+#   core_platform-mesh_io_account:CLUSTER_ID/WORKSPACE_NAME
+#   role:core_platform-mesh_io_account/CLUSTER_ID/WORKSPACE_NAME/ROLE
+#   apis_kcp_io_apiexport:CLUSTER_ID/EXPORT_NAME
+OLD_CLUSTER_IDS=()
+for f in "$BACKUP_DIR"/*-tuples.json; do
+  [[ -f "$f" ]] || continue
+  # Extract IDs: alphanumeric strings of 16 chars that appear after / or : in tuple values
+  ids=$(grep -oP '(?<=[:/])[a-z0-9]{16}(?=/)' "$f" | sort -u || true)
+  for id in $ids; do
+    if [[ ! " ${OLD_CLUSTER_IDS[*]:-} " =~ " $id " ]]; then
+      OLD_CLUSTER_IDS+=("$id")
+    fi
+  done
+done
+
+echo "Found old cluster IDs:"
+printf "  %s\n" "${OLD_CLUSTER_IDS[@]}"
+
+echo ""
+echo "=== Matching old IDs to workspaces ==="
+
+# For each old cluster ID, find which workspace name follows it in the tuples.
+# Pattern: CLUSTER_ID/WORKSPACE_NAME — the workspace name tells us which parent
+# workspace the ID belongs to.
+declare -A OLD_TO_NEW_MAPPING
+
+for old_id in "${OLD_CLUSTER_IDS[@]}"; do
+  # Find workspace names that follow this cluster ID in tuples
+  ws_names=()
+  for f in "$BACKUP_DIR"/*-tuples.json; do
+    [[ -f "$f" ]] || continue
+    # Extract names after CLUSTER_ID/ (the workspace name part)
+    names=$(grep -oP "(?<=${old_id}/)[a-zA-Z0-9_.-]+" "$f" | sort -u || true)
+    for name in $names; do
+      if [[ ! " ${ws_names[*]:-} " =~ " $name " ]]; then
+        ws_names+=("$name")
+      fi
+    done
+  done
+
+  if [[ ${#ws_names[@]} -eq 0 ]]; then
+    echo "  WARNING: No workspace names found after $old_id — skipping" >&2
+    continue
+  fi
+
+  echo "  Old ID $old_id has child workspaces: ${ws_names[*]}"
+
+  # Find which current workspace path contains these child workspaces.
+  # The old_id is the cluster ID of the parent workspace.
+  matched=false
+  for ws in "${WORKSPACES[@]}"; do
+    # Check if this workspace has the expected children
+    children=$($KC get workspace --server "${KCP_SERVER}/clusters/${ws}" \
+      -o jsonpath='{.items[*].metadata.name}' 2>/dev/null) || true
+
+    match_count=0
+    for name in "${ws_names[@]}"; do
+      if [[ " $children " =~ " $name " ]]; then
+        ((match_count++)) || true
+      fi
+    done
+
+    if [[ $match_count -eq ${#ws_names[@]} && $match_count -gt 0 ]]; then
+      new_id="${WS_TO_CLUSTER_ID[$ws]:-}"
+      if [[ -n "$new_id" ]]; then
+        OLD_TO_NEW_MAPPING["$old_id"]="$new_id"
+        echo "    → Matched to workspace $ws (new ID: $new_id)"
+        matched=true
+        break
+      fi
+    fi
+  done
+
+  if [[ "$matched" == "false" ]]; then
+    # Fallback: check if the ID is an APIExport provider workspace
+    # (these appear as apis_kcp_io_apiexport:CLUSTER_ID/export-name)
+    for ws in "${WORKSPACES[@]}"; do
+      ws_cluster_id="${WS_TO_CLUSTER_ID[$ws]:-}"
+      if [[ -z "$ws_cluster_id" ]]; then continue; fi
+
+      # Check if this workspace has APIExports matching the names
+      for name in "${ws_names[@]}"; do
+        has_export=$($KC get apiexport "$name" \
+          --server "${KCP_SERVER}/clusters/${ws}" \
+          -o name 2>/dev/null) || true
+        if [[ -n "$has_export" ]]; then
+          OLD_TO_NEW_MAPPING["$old_id"]="$ws_cluster_id"
+          echo "    → Matched to APIExport workspace $ws (new ID: $ws_cluster_id)"
+          matched=true
+          break 2
+        fi
+      done
+    done
+  fi
+
+  if [[ "$matched" == "false" ]]; then
+    echo "    → WARNING: Could not match old ID $old_id to any workspace" >&2
+  fi
+done
+
+echo ""
+echo "=== Cluster ID migration mapping ==="
+for old_id in "${!OLD_TO_NEW_MAPPING[@]}"; do
+  echo "  $old_id → ${OLD_TO_NEW_MAPPING[$old_id]}"
+done
+
+if [[ ${#OLD_TO_NEW_MAPPING[@]} -eq 0 ]]; then
+  echo "No IDs to migrate. Either the IDs already match or no mapping could be established."
+  exit 0
+fi
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo ""
+  echo "DRY_RUN=true — not writing output files."
+  exit 0
+fi
+
+echo ""
+echo "=== Applying migrations ==="
+
+mkdir -p "$OUTPUT_DIR"
+
+for f in "$BACKUP_DIR"/*-tuples.json; do
+  [[ -f "$f" ]] || continue
+  filename=$(basename "$f")
+  output_file="$OUTPUT_DIR/$filename"
+
+  content=$(cat "$f")
+  for old_id in "${!OLD_TO_NEW_MAPPING[@]}"; do
+    new_id="${OLD_TO_NEW_MAPPING[$old_id]}"
+    if [[ "$old_id" != "$new_id" ]]; then
+      content="${content//$old_id/$new_id}"
+    fi
+  done
+
+  echo "$content" > "$output_file"
+  echo "  Written: $output_file"
+
+  # Show what changed
+  diff_output=$(diff <(python3 -m json.tool "$f") <(python3 -m json.tool "$output_file") || true)
+  if [[ -n "$diff_output" ]]; then
+    echo "$diff_output" | head -20
+  else
+    echo "    (no changes)"
+  fi
+done
+
+echo ""
+echo "=== Writing migrated tuples to OpenFGA ==="
+
+FGA_SERVER_URL="${FGA_SERVER_URL:-http://localhost:8080}"
+
+store_list=$(fga store list --server-url "$FGA_SERVER_URL" 2>/dev/null) || true
+if [[ -z "$store_list" ]]; then
+  echo "ERROR: Could not list OpenFGA stores at $FGA_SERVER_URL" >&2
+  echo "Migrated files are in $OUTPUT_DIR — apply manually with:"
+  echo "  fga tuple write --store-id=<ID> --file <file> --max-tuples-per-write 10"
+  exit 1
+fi
+
+for f in "$OUTPUT_DIR"/*-tuples.json; do
+  [[ -f "$f" ]] || continue
+  filename=$(basename "$f")
+  store_name="${filename%-tuples.json}"
+
+  store_id=$(echo "$store_list" | jq -r ".stores[] | select(.name==\"${store_name}\") | .id")
+  if [[ -z "$store_id" ]]; then
+    echo "  WARNING: No store named '$store_name' found — skipping $filename" >&2
+    continue
+  fi
+
+  # Delete existing tuples
+  existing=$(fga tuple read --store-id="$store_id" --server-url "$FGA_SERVER_URL" \
+    --max-pages 0 --output-format json 2>/dev/null) || true
+  existing_count=$(echo "$existing" | jq '.tuples | length' 2>/dev/null || echo "0")
+  if [[ "$existing_count" -gt 0 ]]; then
+    echo "  Store '$store_name' ($store_id): deleting $existing_count existing tuples..."
+    tmp_delete=$(mktemp --suffix=.json)
+    echo "$existing" | jq '[.tuples[].key | {user, relation, object}]' > "$tmp_delete"
+    fga tuple delete --store-id="$store_id" --server-url "$FGA_SERVER_URL" \
+        --file "$tmp_delete" --max-tuples-per-write 1 || true
+    rm -f "$tmp_delete"
+    echo "    deleted."
+  fi
+
+  # Write migrated tuples one at a time to avoid "duplicate tuple in write" rejections
+  # when multiple tuples share the same (object, relation) within a batch.
+  tuple_count=$(jq '.tuples | length' "$f")
+  echo "  Store '$store_name' ($store_id): writing $tuple_count tuples..."
+
+  tmp_file=$(mktemp --suffix=.json)
+  jq '[.tuples[].key | {user, relation, object}] | unique' "$f" > "$tmp_file"
+  fga tuple write --store-id="$store_id" --server-url "$FGA_SERVER_URL" \
+      --file "$tmp_file" --max-tuples-per-write 1 || true
+  rm -f "$tmp_file"
+
+  echo "    done."
+done
+
+echo ""
+echo "=== Migration complete ==="
+echo "Output directory: $OUTPUT_DIR"

--- a/docs/migration-0.3/migration-guide.md
+++ b/docs/migration-0.3/migration-guide.md
@@ -1,0 +1,173 @@
+# Migration Guide: 0.2.0 → 0.3.0
+
+## Strategy
+
+This is a **hybrid migration**. KCP state (etcd) is wiped and rebuilt from scratch because in-place schema upgrades are unreliable. Keycloak and OpenFGA databases are preserved in place — their data is migrated without a full delete/restore cycle. Only the OpenFGA tuples need ID fixups to match the new KCP cluster IDs.
+
+| Component | Migration approach |
+|---|---|
+| KCP | Wipe etcd, fresh install, recreate workspaces, restore user resources |
+| Keycloak | In-place — restore PostgreSQL secret, restart |
+| OpenFGA | In-place — migrate tuples with updated cluster IDs |
+
+---
+
+## 1. Version matrix
+
+| Component | 0.2.0 | 0.3.0 | Notes |
+|---|---|---|---|
+| OCM component | `0.2.0` | `0.3.0-build.1249` | drives all sub-component versions |
+| OCM install method | Kustomization + GitRepository | HelmRelease (`ocm-k8s-toolkit`) | breaking change |
+| platform-mesh-operator | 0.18.x | 0.19.x | |
+| security-operator | 0.23.x | 0.29.x | new FGA `bind`/`bind_inherited` types |
+| account-operator | — | 0.1.x | new; manages account lifecycle and FGA tuples |
+| OpenFGA | 0.2.51 | 0.2.54 | |
+| Keycloak | 25.x | 25.3.0 | |
+| KCP | v0.29/v0.30 | 097afc12c | custom image; new `system.platform-mesh.io` APIExport |
+| portal | 0.10.x | 0.10.145 | CRD gateway URL path changed |
+| marketplace-ui | disabled | enabled | |
+| init-agent | — | 0.2.0 | new component |
+
+---
+
+## 2. Pre-migration (on 0.2 cluster)
+
+### 2.1 Create test data
+
+Resources not covered by `task test:portal-e2e`:
+
+- Account `testaccount` under `default` org
+- HttpBin `test1` in `:root:orgs:default:testaccount` (namespace `default`)
+
+### 2.2 Backup
+
+```shell
+local-setup/scripts/keycloak_backup.sh
+local-setup/scripts/keycloak_export_realms.sh
+local-setup/scripts/fga_backup.sh
+local-setup/scripts/etcd_backup.sh
+docs/migration-0.3/export-kcp-resources.sh local-setup/backup/kcp/0.2-userdata
+docs/migration-0.3/export-kcp-resources.sh local-setup/backup/kcp-exports/pre-migration
+```
+
+---
+
+## 3. Install 0.3
+
+### 3.1 Tear down 0.2
+
+```shell
+kind delete cluster --name platform-mesh
+```
+
+If preserving the Kind cluster:
+
+```shell
+kubectl -n platform-mesh-system delete PlatformMesh platform-mesh
+kubectl delete components platform-mesh
+kubectl delete repositories platform-mesh
+kubectl delete PlatformMeshOperator platform-mesh-operator
+kubectl delete ResourceGraphDefinition platform-mesh-operator
+kubectl delete Resource --all
+kubectl delete OCIRepository --all
+kubectl delete Etcd etcd-kcp -n platform-mesh-system
+kubectl delete HelmRelease --all
+kubectl delete secret --all -n platform-mesh-system
+kubectl delete kustomizations ocm-k8s-toolkit
+kubectl delete persistentvolumeclaims etcd-kcp-etcd-kcp-0 -n platform-mesh-system
+```
+
+### 3.2 Deploy 0.3
+
+```shell
+git checkout feat/migration-0.3
+task local-setup:example-data:iterate
+```
+
+Wait for readiness:
+
+```shell
+kubectl get helmrelease -A
+kubectl get platformmesh -n platform-mesh-system
+```
+
+---
+
+## 4. Restore Keycloak
+
+```shell
+kubectl apply -f local-setup/backup/keycloak/postgres/keycloak-postgresql-keycloak.yaml
+local-setup/scripts/keycloak_restore.sh
+kubectl rollout restart statefulset/keycloak -n platform-mesh-system
+kubectl rollout status statefulset/keycloak -n platform-mesh-system
+```
+
+Delete stale Keycloak clients (named after old GUIDs) from the `default` realm in the admin console.
+
+---
+
+## 5. Restore KCP and OpenFGA
+
+### 5.1 Disable the IPC webhook
+
+```shell
+KUBECONFIG=.secret/kcp/admin.kubeconfig kubectl \
+  --server="https://localhost:8443/clusters/root:platform-mesh-system" \
+  delete ValidatingWebhookConfiguration \
+  identityproviderconfiguration-validator.webhooks.core.platform-mesh.io
+```
+
+### 5.2 Recreate organizations and accounts
+
+Create organizations and accounts via the browser (e.g., `default` org and its sub-accounts). The operator provisions workspace infrastructure — this must complete before restoring data.
+
+### 5.3 Migrate OpenFGA tuples
+
+Stop operators that reconcile tuples:
+
+```shell
+kubectl scale deployment/security-operator -n platform-mesh-system --replicas=0
+kubectl scale deployment/account-operator -n platform-mesh-system --replicas=0
+```
+
+Run the migration (replaces old KCP cluster IDs with current ones, writes to OpenFGA):
+
+```shell
+docs/migration-0.3/migrate-openfga-tuples.sh <backup-dir> [output-dir]
+```
+
+Restore operators:
+
+```shell
+kubectl scale deployment/account-operator -n platform-mesh-system --replicas=1
+kubectl scale deployment/security-operator -n platform-mesh-system --replicas=1
+```
+
+### 5.4 Restore HttpBin resources
+
+```shell
+docs/migration-0.3/restore-kcp-resources.sh <export-dir>
+```
+
+### 5.5 Re-enable the IPC webhook
+
+The operator recreates it on next reconciliation, or restart the security-operator.
+
+---
+
+## 6. Post-restore
+
+```shell
+kubectl rollout restart deployment/rebac-authz-webhook -n platform-mesh-system
+kubectl rollout status deployment/rebac-authz-webhook -n platform-mesh-system
+kubectl -n platform-mesh-system rollout restart deployment/kubernetes-graphql-gateway-listener
+kubectl -n platform-mesh-system rollout status deployment/kubernetes-graphql-gateway-listener
+```
+
+---
+
+## 7. Verification
+
+```shell
+task test:portal-e2e
+```

--- a/docs/migration-0.3/restore-kcp-resources.sh
+++ b/docs/migration-0.3/restore-kcp-resources.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Selectively restore KCP user data from a YAML export into a fresh 0.3 cluster.
+# Skips operator-managed resources (APIExports, APIResourceSchemas, APIBindings, WorkspaceTypes).
+#
+# Usage:
+#   docs/migration-0.3/restore-kcp-resources.sh <export-dir>
+#
+# Example:
+#   docs/migration-0.3/restore-kcp-resources.sh docs/migration-0.3/kcp-exports/pre-migration
+
+EXPORT_DIR="${1:?Usage: $0 <export-dir>}"
+KUBECONFIG_KCP="${KUBECONFIG_KCP:-.secret/kcp/admin.kubeconfig}"
+KCP_SERVER="${KCP_SERVER:-https://localhost:8443}"
+
+if [[ ! -f "$KUBECONFIG_KCP" ]]; then
+  echo "Error: KCP admin kubeconfig not found at $KUBECONFIG_KCP" >&2
+  exit 1
+fi
+
+if [[ ! -d "$EXPORT_DIR" ]]; then
+  echo "Error: Export directory not found: $EXPORT_DIR" >&2
+  exit 1
+fi
+
+KC="kubectl --kubeconfig=$KUBECONFIG_KCP"
+
+kcp_apply() {
+  local ws="$1" file="$2"
+  sed -e '/^\s*resourceVersion:/d' \
+      -e '/^\s*uid:/d' \
+      -e '/^\s*creationTimestamp:/d' \
+      -e '/^\s*generation:/d' \
+    < "$file" | \
+  $KC apply --server-side --force-conflicts --server "${KCP_SERVER}/clusters/${ws}" -f - 2>&1
+}
+
+has_items() {
+  local file="$1"
+  [[ -f "$file" ]] && ! grep -q '^items: \[\]$' "$file" && grep -q '  name:' "$file"
+}
+
+USER_DATA_RESOURCES=(
+  httpbins
+  # stores
+  # identityproviderconfigurations
+  # accounts
+  # accountinfos
+  # authorizationmodels
+  # invites
+)
+
+echo "=== Restoring KCP user data from $EXPORT_DIR ==="
+
+for ws_dir in "$EXPORT_DIR"/root*; do
+  [[ -d "$ws_dir" ]] || continue
+  ws_name=$(basename "$ws_dir")
+  ws="${ws_name//_/:}"
+
+  [[ "$ws_name" == "k8s" ]] && continue
+
+  echo ""
+  echo "--- Workspace: $ws ---"
+
+  for resource in "${USER_DATA_RESOURCES[@]}"; do
+    file="$ws_dir/${resource}.yaml"
+    if has_items "$file"; then
+      echo "  Restoring $resource..."
+      kcp_apply "$ws" "$file" || echo "  WARNING: failed to restore $resource in $ws"
+    fi
+  done
+done
+
+echo ""
+echo "=== Restore complete ==="

--- a/local-setup/scripts/createKcpAdminKubeconfig.sh
+++ b/local-setup/scripts/createKcpAdminKubeconfig.sh
@@ -6,11 +6,6 @@ KCP_URL=https://localhost:8443
 #KCP_URL=https://kcp.api.portal.cc-one.showroom.apeirora.eu
 
 mkdir -p $PWD/.secret/kcp
-kubectl get secret $KCP_CA_SECRET -n platform-mesh-system -o=jsonpath='{.data.ca\.crt}' | base64 -d > $PWD/.secret/kcp/ca.crt
-kubectl --kubeconfig=$PWD/.secret/kcp/admin.kubeconfig config set-cluster --embed-certs  workspace.kcp.io/current --server $KCP_URL/clusters/root --certificate-authority=$PWD/.secret/kcp/ca.crt
-kubectl get secret $KCP_ADMIN_SECRET -n platform-mesh-system -o=jsonpath='{.data.tls\.crt}' | base64 -d > $PWD/.secret/kcp/client.crt
-kubectl get secret $KCP_ADMIN_SECRET -n platform-mesh-system -o=jsonpath='{.data.tls\.key}' | base64 -d > $PWD/.secret/kcp/client.key
-chmod 600 .secret/kcp/client.crt .secret/kcp/client.key
-kubectl --kubeconfig=$PWD/.secret/kcp/admin.kubeconfig config set-credentials --embed-certs kcp-admin --client-certificate=.secret/kcp/client.crt --client-key=$PWD/.secret/kcp/client.key
-kubectl --kubeconfig=$PWD/.secret/kcp/admin.kubeconfig config set-context workspace.kcp.io/current --cluster=workspace.kcp.io/current --user=kcp-admin
-kubectl --kubeconfig=$PWD/.secret/kcp/admin.kubeconfig config use-context workspace.kcp.io/current
+kubectl --context kind-platform-mesh get secret kubeconfig-kcp-admin -n platform-mesh-system -o=jsonpath='{.data.kubeconfig}'|base64 -d > $PWD/.secret/kcp/admin.kubeconfig
+# kubectl --kubeconfig=$PWD/.secret/kcp/admin.kubeconfig config set-context workspace.kcp.io/current --cluster=workspace.kcp.io/current --user=kcp-admin
+# kubectl --kubeconfig=$PWD/.secret/kcp/admin.kubeconfig config use-context workspace.kcp.io/current

--- a/local-setup/scripts/etcd_backup.sh
+++ b/local-setup/scripts/etcd_backup.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -e
+
+NAMESPACE="platform-mesh-system"
+POD="etcd-kcp-0"
+PVC_CLAIM="etcd-kcp-etcd-kcp-0"
+COPY_POD="etcd-backup-copy"
+LOCAL_BACKUP_DIR="./local-setup/backup/etcd"
+
+echo "--- Setting up local backup directory: $LOCAL_BACKUP_DIR ---"
+mkdir -p "$LOCAL_BACKUP_DIR"
+
+echo "--- Taking etcd snapshot ---"
+SNAP_FILE=$(kubectl -n "$NAMESPACE" exec "$POD" -c backup-restore -- \
+    /etcdbrctl snapshot \
+    --storage-provider=Local \
+    --store-container=../../var/etcd/data/backup \
+    --endpoints=http://localhost:2379 \
+    --schedule='0 0 31 2 *' \
+    --delta-snapshot-period=0s 2>&1 | tee /dev/stderr | grep "saved full snapshot at" | grep -o 'Full-[^"]*')
+
+if [ -z "$SNAP_FILE" ]; then
+    echo "Error: could not determine snapshot filename"
+    exit 1
+fi
+
+echo "--- Snapshot saved: $SNAP_FILE ---"
+
+echo "--- Spinning up copy pod ---"
+kubectl run -n "$NAMESPACE" "$COPY_POD" \
+    --image=busybox --restart=Never \
+    --overrides="{
+      \"spec\": {
+        \"containers\": [{
+          \"name\": \"copy\",
+          \"image\": \"busybox\",
+          \"command\": [\"sleep\", \"300\"],
+          \"volumeMounts\": [{\"mountPath\": \"/data\", \"name\": \"etcd-kcp\"}]
+        }],
+        \"volumes\": [{\"name\": \"etcd-kcp\", \"persistentVolumeClaim\": {\"claimName\": \"$PVC_CLAIM\"}}]
+      }
+    }"
+
+kubectl wait -n "$NAMESPACE" pod/"$COPY_POD" --for=condition=Ready --timeout=60s
+
+echo "--- Copying snapshot to host ---"
+kubectl cp "$NAMESPACE/$COPY_POD:/data/backup/v2/$SNAP_FILE" "$LOCAL_BACKUP_DIR/$SNAP_FILE"
+
+echo "--- Cleaning up copy pod ---"
+kubectl delete pod -n "$NAMESPACE" "$COPY_POD"
+
+echo "--- Backup complete: $LOCAL_BACKUP_DIR/$SNAP_FILE ---"

--- a/local-setup/scripts/fga_backup.sh
+++ b/local-setup/scripts/fga_backup.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKUP_DIR="$SCRIPT_DIR/../backup/openfga"
+POSTGRES_BACKUP_DIR="$BACKUP_DIR/postgres"
+
+echo "=== OpenFGA Backup Script ==="
+
+# Create backup directories
+mkdir -p "$BACKUP_DIR"
+mkdir -p "$POSTGRES_BACKUP_DIR"
+
+# Step 1: PostgreSQL dump
+echo "Step 1: Creating PostgreSQL dump..."
+TIMESTAMP=$(date +%F-%T)
+BACKUP_FILE="$POSTGRES_BACKUP_DIR/backup-$TIMESTAMP.sql"
+
+kubectl -n platform-mesh-system exec pod/openfga-postgres-0 -- \
+    env PGPASSWORD='password' pg_dumpall -U postgres > "$BACKUP_FILE"
+
+echo "PostgreSQL backup saved to: $BACKUP_FILE"
+
+# Step 2: Export FGA stores using CLI
+echo "Step 2: Exporting FGA stores..."
+fga store list > "$BACKUP_DIR/store-list.json"
+echo "Store list saved to: $BACKUP_DIR/store-list.json"
+
+# Step 3: Export each store
+echo "Step 3: Exporting individual stores..."
+"$SCRIPT_DIR/export-stores.sh"
+
+echo "=== OpenFGA Backup Complete ==="

--- a/local-setup/scripts/fix_keycloak_pg_password.sh
+++ b/local-setup/scripts/fix_keycloak_pg_password.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-platform-mesh-system}"
+POD="${POD:-keycloak-postgresql-keycloak-0}"
+SECRET="${SECRET:-keycloak-postgresql-keycloak}"
+PG_DATA="/bitnami/postgresql/data"
+PG_HBA="${PG_DATA}/pg_hba.conf"
+
+PASSWORD=$(kubectl get secret "$SECRET" -n "$NAMESPACE" -o jsonpath='{.data.password}' | base64 -d)
+
+# Prepend trust rule so we can connect without a password
+kubectl exec -n "$NAMESPACE" "$POD" -- bash -c "
+  cp ${PG_HBA} ${PG_HBA}.bak
+  printf 'local all all trust\n' | cat - ${PG_HBA}.bak > /tmp/pg_hba_new.conf
+  cp /tmp/pg_hba_new.conf ${PG_HBA}
+  pg_ctl reload -D ${PG_DATA}
+"
+
+# Reset the keycloak user password to match the secret, then restore pg_hba
+kubectl exec -n "$NAMESPACE" "$POD" -- bash -c "
+  psql -U postgres -c \"ALTER USER keycloak PASSWORD '${PASSWORD}';\"
+  cp ${PG_HBA}.bak ${PG_HBA}
+  pg_ctl reload -D ${PG_DATA}
+"
+
+# Verify
+kubectl exec -n "$NAMESPACE" "$POD" -- bash -c \
+  "PGPASSWORD=${PASSWORD} psql -U keycloak -d bitnami_keycloak -c '\conninfo'"
+
+echo "keycloak PostgreSQL password synced successfully"

--- a/local-setup/scripts/keycloak_backup.sh
+++ b/local-setup/scripts/keycloak_backup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BACKUP_DIR="${BACKUP_DIR:-local-setup/backup/keycloak/postgres}"
+TIMESTAMP=$(date +%Y-%m-%d-%H:%M:%S)
+
+mkdir -p "$BACKUP_DIR"
+
+PGPASSWORD=$(kubectl get secret keycloak-postgresql-keycloak \
+  -n platform-mesh-system \
+  -o jsonpath='{.data.password}' | base64 -d)
+
+kubectl exec -n platform-mesh-system keycloak-postgresql-keycloak-0 -- \
+  bash -c "PGPASSWORD=$PGPASSWORD pg_dump -U keycloak bitnami_keycloak" \
+  > "$BACKUP_DIR/backup-${TIMESTAMP}.sql"
+
+kubectl get secret keycloak-postgresql-keycloak -n platform-mesh-system -o yaml \
+  > "$BACKUP_DIR/keycloak-postgresql-keycloak.yaml"
+
+echo "Keycloak backup saved to $BACKUP_DIR/backup-${TIMESTAMP}.sql"

--- a/local-setup/scripts/keycloak_export_realms.sh
+++ b/local-setup/scripts/keycloak_export_realms.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EXPORT_DIR="${EXPORT_DIR:-local-setup/backup/keycloak/realms}"
+TIMESTAMP=$(date +%Y-%m-%d-%H:%M:%S)
+DEST="$EXPORT_DIR/$TIMESTAMP"
+
+mkdir -p "$DEST"
+
+# ADMIN_PASSWORD=$(kubectl get secret keycloak-admin \
+#   -n platform-mesh-system \
+#   -o jsonpath='{.data.admin-password}' | base64 -d)
+# echo "Admin password: $ADMIN_PASSWORD"
+ADMIN_PASSWORD=admin
+
+KCADM_BIN=/opt/bitnami/keycloak/bin/kcadm.sh
+KC_EXEC="kubectl exec -n platform-mesh-system keycloak-0 --"
+KC_CONFIG=/tmp/kcadm.config
+
+$KC_EXEC $KCADM_BIN config credentials \
+  --config $KC_CONFIG \
+  --server http://localhost:8080/keycloak \
+  --realm master \
+  --user keycloak-admin \
+  --password "$ADMIN_PASSWORD"
+
+REALMS=$($KC_EXEC $KCADM_BIN get realms \
+  --config $KC_CONFIG \
+  --fields realm --format csv --noquotes | tail -n +1)
+
+for REALM in $REALMS; do
+  echo "Exporting realm: $REALM"
+  $KC_EXEC $KCADM_BIN get realms/"$REALM" --config $KC_CONFIG > "$DEST/${REALM}.json"
+  $KC_EXEC $KCADM_BIN get clients -r "$REALM" --config $KC_CONFIG > "$DEST/${REALM}-clients.json"
+done
+
+echo "Realm exports saved to $DEST"

--- a/local-setup/scripts/keycloak_restore.sh
+++ b/local-setup/scripts/keycloak_restore.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BACKUP_DIR="${BACKUP_DIR:-local-setup/backup/keycloak/postgres}"
+
+# Use the most recent backup unless BACKUP_FILE is set explicitly
+BACKUP_FILE="${BACKUP_FILE:-$(ls -t "$BACKUP_DIR"/backup-*.sql | head -1)}"
+
+if [[ -z "$BACKUP_FILE" || ! -f "$BACKUP_FILE" ]]; then
+  echo "Error: no backup file found in $BACKUP_DIR" >&2
+  echo "Set BACKUP_FILE=<path> to specify one explicitly." >&2
+  exit 1
+fi
+
+echo "=== Keycloak Restore Script ==="
+echo "Backup file: $BACKUP_FILE"
+
+echo "Step 1: Waiting for Keycloak PostgreSQL pod..."
+kubectl wait pod/keycloak-postgresql-keycloak-0 \
+  -n platform-mesh-system \
+  --for=condition=Ready \
+  --timeout=120s
+
+PGPASSWORD=$(kubectl get secret keycloak-postgresql-keycloak \
+  -n platform-mesh-system \
+  -o jsonpath='{.data.password}' | base64 -d)
+
+echo "Step 2: Terminating active connections to bitnami_keycloak..."
+kubectl exec -n platform-mesh-system keycloak-postgresql-keycloak-0 -- \
+  bash -c "PGPASSWORD='$PGPASSWORD' psql -U keycloak -d postgres -c \
+    \"SELECT pg_terminate_backend(pid) FROM pg_stat_activity \
+      WHERE datname = 'bitnami_keycloak' AND pid <> pg_backend_pid();\""
+
+echo "Step 3: Dropping and recreating database..."
+kubectl exec -n platform-mesh-system keycloak-postgresql-keycloak-0 -- \
+  bash -c "PGPASSWORD='$PGPASSWORD' dropdb -U keycloak bitnami_keycloak"
+kubectl exec -n platform-mesh-system keycloak-postgresql-keycloak-0 -- \
+  bash -c "PGPASSWORD='$PGPASSWORD' createdb -U keycloak -O keycloak bitnami_keycloak"
+
+echo "Step 4: Restoring from backup..."
+kubectl exec -i -n platform-mesh-system keycloak-postgresql-keycloak-0 -- \
+  bash -c "PGPASSWORD='$PGPASSWORD' psql -U keycloak bitnami_keycloak" \
+  < "$BACKUP_FILE"
+
+echo "Step 5: Restarting Keycloak..."
+kubectl rollout restart statefulset/keycloak -n platform-mesh-system
+kubectl rollout status statefulset/keycloak -n platform-mesh-system --timeout=120s
+
+echo "=== Keycloak Restore Complete ==="
+echo "Backup restored from: $BACKUP_FILE"


### PR DESCRIPTION
## Adds migration docs and scripts for 0.2 and 0.3. Migration to 0.3 requires 0.2 as starting point.

The type of migration for 0.3 is a hybred, where kcp state is wiped and rebuild, while openfga and keycloak data is migrated. This is due to braking changes in 0.3 where apiexports/apibindings and workspacetypes are updated, so all user resources pointing to them must be deleted.

## Changes:
- adds separate folder with docs and scripts for each migrated version
- adds scripts in local-setup/scripts that can be reused
- procedure has been validated in local-setup
- add version matrix for updated components