### PR TITLE
chore: bump kcp version to 0.31.1

### DIFF
--- a/charts/platform-mesh-operator-components/Chart.yaml
+++ b/charts/platform-mesh-operator-components/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: platform-mesh-operator-components
 description: A Helm chart for Kubernetes
 type: application
-version: 0.58.0
+version: 0.58.1
 appVersion: "0.0.0"

--- a/charts/platform-mesh-operator-components/README.md
+++ b/charts/platform-mesh-operator-components/README.md
@@ -261,7 +261,7 @@ Produces `referencePath: [{name: compref1}, {name: compref2}]`.
 | services.infra.values.istio.passThrough.gateway.name | string | `"pass-https"` |  |
 | services.infra.values.istio.passThrough.gateway.port | string | `"{{ .Values.port }}"` |  |
 | services.infra.values.istio.passThrough.gateway.protocol | string | `"HTTPS"` |  |
-| services.infra.values.kcp.image.tag | string | `"v0.29.0"` |  |
+| services.infra.values.kcp.image.tag | string | `"v0.31.1"` |  |
 | services.infra.values.kcp.rootShard.extraArgs[0] | string | `"--feature-gates=WorkspaceAuthentication=true"` |  |
 | services.infra.values.kcp.webhook.enabled | bool | `true` |  |
 | services.infra.values.keycloak.istio.virtualservice.hosts[0] | string | `"{{ .Values.baseDomain }}"` |  |

--- a/charts/platform-mesh-operator-components/tests/__snapshot__/application_test.yaml.snap
+++ b/charts/platform-mesh-operator-components/tests/__snapshot__/application_test.yaml.snap
@@ -136,7 +136,7 @@ it should render the application manifests:
               protocol: HTTPS
         kcp:
           image:
-            tag: v0.29.0
+            tag: v0.31.1
           rootShard:
             extraArgs:
               - --feature-gates=WorkspaceAuthentication=true

--- a/charts/platform-mesh-operator-components/tests/__snapshot__/helmreleases_test.yaml.snap
+++ b/charts/platform-mesh-operator-components/tests/__snapshot__/helmreleases_test.yaml.snap
@@ -136,7 +136,7 @@ HelmRelease snapshots:
               protocol: HTTPS
         kcp:
           image:
-            tag: v0.29.0
+            tag: v0.31.1
           rootShard:
             extraArgs:
               - --feature-gates=WorkspaceAuthentication=true
@@ -599,7 +599,7 @@ enable remote deployment of helmreleases:
               protocol: HTTPS
         kcp:
           image:
-            tag: v0.29.0
+            tag: v0.31.1
           rootShard:
             extraArgs:
               - --feature-gates=WorkspaceAuthentication=true

--- a/charts/platform-mesh-operator-components/values.yaml
+++ b/charts/platform-mesh-operator-components/values.yaml
@@ -126,7 +126,7 @@ services:
         enabled: true
       kcp:
         image:
-          tag: v0.29.0
+          tag: v0.31.1
         rootShard:
           extraArgs:
             - --feature-gates=WorkspaceAuthentication=true

--- a/local-setup/kustomize/components/platform-mesh-operator-resource/platform-mesh.yaml
+++ b/local-setup/kustomize/components/platform-mesh-operator-resource/platform-mesh.yaml
@@ -93,6 +93,8 @@ spec:
           auth:
             serviceAccount:
               enabled: true
+          image:
+            tag: "v0.31.1" # bump kcp image to work around WatchList issues
           shards: []
           frontProxy:
             clusterIP: "10.96.0.100"

--- a/local-setup/kustomize/components/platform-mesh-operator-resource/platform-mesh.yaml
+++ b/local-setup/kustomize/components/platform-mesh-operator-resource/platform-mesh.yaml
@@ -93,8 +93,6 @@ spec:
           auth:
             serviceAccount:
               enabled: true
-          image:
-            tag: "v0.31.0" # bump kcp image to work around WatchList issues
           shards: []
           frontProxy:
             clusterIP: "10.96.0.100"


### PR DESCRIPTION
On-behalf-of: SAP aleh.yarshou@sap.com

1. remove kcp version rewrite specifically for local-setup
2. bump kcp version in helm-chart 