### PR TITLE
feat: security-operator: support custom kubeconfig for system

### DIFF
--- a/charts/security-operator/Chart.yaml
+++ b/charts/security-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: security-operator
 description: A Helm chart for security-operator
 type: application
-version: 0.23.0
+version: 0.30.0
 appVersion: "v0.30.42"
 dependencies:
   - name: security-operator-crds

--- a/charts/security-operator/Chart.yaml
+++ b/charts/security-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: security-operator
 description: A Helm chart for security-operator
 type: application
-version: 0.29.63
+version: 0.23.0
 appVersion: "v0.30.42"
 dependencies:
   - name: security-operator-crds

--- a/charts/security-operator/README.md
+++ b/charts/security-operator/README.md
@@ -42,6 +42,7 @@ A Helm chart for security-operator
 | logLevel | string | `"info"` |  |
 | region | string | `"local"` | region indicator, used for logging and observability |
 | system.extraArgs | list | `[]` |  |
+| system.kubeconfigSecret | string | `""` |  |
 | terminator.extraArgs | list | `[]` |  |
 | terminator.kubeconfigSecret | string | `""` | The kubeconfig secret for the terminator |
 | webhooks.caDuration | string | `"8760h"` | CA certificate duration (default: 1 year) |

--- a/charts/security-operator/templates/system-deployment.yaml
+++ b/charts/security-operator/templates/system-deployment.yaml
@@ -1,3 +1,4 @@
+{{- $systemKubeconfigSecret := .Values.system.kubeconfigSecret | default .Values.kubeconfigSecret }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -32,7 +33,7 @@ spec:
           - --base-domain={{ . }}
           {{- end }}
           - --fga-target={{ .Values.fga.target }}
-          {{- if .Values.kubeconfigSecret }}
+          {{- if $systemKubeconfigSecret }}
           - --kcp-kubeconfig=/api-kubeconfig/kubeconfig
           {{- end }}
           {{- with .Values.system.extraArgs }}
@@ -65,10 +66,10 @@ spec:
           {{- end }}
       volumes:
         {{- include "common.extraVolumes" . | nindent 8 }}
-        {{- if .Values.kubeconfigSecret }}
+        {{- if $systemKubeconfigSecret }}
         - name: external-api-server
           secret:
-            secretName: {{ .Values.kubeconfigSecret }}
+            secretName: {{ $systemKubeconfigSecret }}
         {{- end }}
         {{- if .Values.keycloakSecret }}
         - name: keycloak-credentials

--- a/charts/security-operator/values.yaml
+++ b/charts/security-operator/values.yaml
@@ -100,6 +100,7 @@ initContainer:
 generator:
   extraArgs: []
 system:
+  kubeconfigSecret: ""
   extraArgs: []
 fga:
   target: openfga.platform-mesh-system.svc.cluster.local:8081


### PR DESCRIPTION
Support custom kubeconfig for system-operator but default to global kubeconfig

On-behalf-of: @SAP <simon@simontesar.com>