### PR TITLE
fix(gateway): skip duplicate health-port when it equals service-port

### DIFF
--- a/charts/kubernetes-graphql-gateway/Chart.yaml
+++ b/charts/kubernetes-graphql-gateway/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.38.14
+version: 0.38.15
 appVersion: v1.9.0
 name: kubernetes-graphql-gateway
 description: Basic helm chart that contains listener and gateway

--- a/charts/kubernetes-graphql-gateway/templates/deploy-gateway.yaml
+++ b/charts/kubernetes-graphql-gateway/templates/deploy-gateway.yaml
@@ -86,9 +86,11 @@ spec:
         - name: metrics
           containerPort: {{ .Values.gateway.metricsPort }}
           protocol: TCP
+        {{- if ne (int .Values.gateway.healthCheck.port) (int .Values.gateway.port) }}
         - name: health-port
           containerPort: {{ .Values.gateway.healthCheck.port }}
           protocol: TCP
+        {{- end }}
         - name: service-port
           containerPort: {{ .Values.gateway.port }}
           protocol: TCP

--- a/charts/kubernetes-graphql-gateway/tests/__snapshot__/snapshot_test.yaml.snap
+++ b/charts/kubernetes-graphql-gateway/tests/__snapshot__/snapshot_test.yaml.snap
@@ -46,9 +46,6 @@ match the Snapshot:
                   name: metrics
                   protocol: TCP
                 - containerPort: 8080
-                  name: health-port
-                  protocol: TCP
-                - containerPort: 8080
                   name: service-port
                   protocol: TCP
               readinessProbe:


### PR DESCRIPTION
## Summary

- Skip rendering the `health-port` container port entry in the gateway Deployment when `gateway.healthCheck.port` equals `gateway.port`
- Aligns the Deployment template with the Service template, which already has this guard
- Bumps chart version to 0.38.15

## Problem

The gateway Deployment template unconditionally renders both `health-port` and `service-port` container ports. With the default values (`gateway.port: 8080`, `gateway.healthCheck.port: 8080`), Kubernetes 1.25+ rejects the pod spec:

```
Duplicate value: core.ContainerPort{ContainerPort: 8080, Protocol:"TCP"}
```

The Service template already handles this correctly with `{{- if ne (int .Values.gateway.healthCheck.port) (int .Values.gateway.port) }}` — this PR applies the same conditional to the Deployment.