### PR TITLE
Change front-proxy port from 6443 to 8443

### DIFF
--- a/charts/platform-mesh-operator-components/Chart.yaml
+++ b/charts/platform-mesh-operator-components/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: platform-mesh-operator-components
 description: A Helm chart for Kubernetes
 type: application
-version: 0.59.2
+version: 0.59.3
 appVersion: "0.0.0"

--- a/charts/platform-mesh-operator-components/README.md
+++ b/charts/platform-mesh-operator-components/README.md
@@ -304,10 +304,10 @@ Produces `referencePath: [{name: compref1}, {name: compref2}]`.
 | services.kubernetes-graphql-gateway.values.kubeConfig.secretName | string | `"kubernetes-graphql-gateway-kubeconfig"` |  |
 | services.kubernetes-graphql-gateway.values.listener.virtualWorkspacesConfig.content.virtualWorkspaces[0].kubeconfig | string | `"/app/kubeconfig/kubeconfig"` |  |
 | services.kubernetes-graphql-gateway.values.listener.virtualWorkspacesConfig.content.virtualWorkspaces[0].name | string | `"contentconfigurations"` |  |
-| services.kubernetes-graphql-gateway.values.listener.virtualWorkspacesConfig.content.virtualWorkspaces[0].url | string | `"https://frontproxy-front-proxy.platform-mesh-system:6443/services/contentconfigurations"` |  |
+| services.kubernetes-graphql-gateway.values.listener.virtualWorkspacesConfig.content.virtualWorkspaces[0].url | string | `"https://frontproxy-front-proxy.platform-mesh-system:8443/services/contentconfigurations"` |  |
 | services.kubernetes-graphql-gateway.values.listener.virtualWorkspacesConfig.content.virtualWorkspaces[1].kubeconfig | string | `"/app/kubeconfig/kubeconfig"` |  |
 | services.kubernetes-graphql-gateway.values.listener.virtualWorkspacesConfig.content.virtualWorkspaces[1].name | string | `"marketplace"` |  |
-| services.kubernetes-graphql-gateway.values.listener.virtualWorkspacesConfig.content.virtualWorkspaces[1].url | string | `"https://frontproxy-front-proxy.platform-mesh-system:6443/services/marketplace"` |  |
+| services.kubernetes-graphql-gateway.values.listener.virtualWorkspacesConfig.content.virtualWorkspaces[1].url | string | `"https://frontproxy-front-proxy.platform-mesh-system:8443/services/marketplace"` |  |
 | services.kubernetes-graphql-gateway.values.listener.virtualWorkspacesConfig.enabled | bool | `true` |  |
 | services.kubernetes-graphql-gateway.values.tracing.enabled | bool | `false` |  |
 | services.kubernetes-graphql-gateway.values.trust.default.audience | string | `"default"` |  |
@@ -409,7 +409,7 @@ Produces `referencePath: [{name: compref1}, {name: compref2}]`.
 | services.virtual-workspaces.imageResources | list | `[{"annotations":{"artifact":"image","for":"virtual-workspaces","repo":"oci"}}]` | Allow the configuration of additional ocm resources |
 | services.virtual-workspaces.values.deployment.resourceSchemaName | string | `"v250704-6d57f16.contentconfigurations.ui.platform-mesh.io"` |  |
 | services.virtual-workspaces.values.deployment.resourceSchemaWorkspace | string | `"root:platform-mesh-system"` |  |
-| services.virtual-workspaces.values.deployment.serverUrl | string | `"https://frontproxy-front-proxy.platform-mesh-system:6443"` |  |
+| services.virtual-workspaces.values.deployment.serverUrl | string | `"https://frontproxy-front-proxy.platform-mesh-system:8443"` |  |
 | services.virtual-workspaces.values.virtualWorkspaceSecretName | string | `"virtual-workspaces-cert"` |  |
 | targetNamespace | string | `"platform-mesh-system"` |  |
 | timeout | string | `"30m"` |  |

--- a/charts/platform-mesh-operator-components/tests/__snapshot__/application_test.yaml.snap
+++ b/charts/platform-mesh-operator-components/tests/__snapshot__/application_test.yaml.snap
@@ -237,10 +237,10 @@ it should render the application manifests:
               virtualWorkspaces:
                 - kubeconfig: /app/kubeconfig/kubeconfig
                   name: contentconfigurations
-                  url: https://frontproxy-front-proxy.platform-mesh-system:6443/services/contentconfigurations
+                  url: https://frontproxy-front-proxy.platform-mesh-system:8443/services/contentconfigurations
                 - kubeconfig: /app/kubeconfig/kubeconfig
                   name: marketplace
-                  url: https://frontproxy-front-proxy.platform-mesh-system:6443/services/marketplace
+                  url: https://frontproxy-front-proxy.platform-mesh-system:8443/services/marketplace
             enabled: true
         tracing:
           enabled: false
@@ -408,7 +408,7 @@ it should render the application manifests:
         deployment:
           resourceSchemaName: v250704-6d57f16.contentconfigurations.ui.platform-mesh.io
           resourceSchemaWorkspace: root:platform-mesh-system
-          serverUrl: https://frontproxy-front-proxy.platform-mesh-system:6443
+          serverUrl: https://frontproxy-front-proxy.platform-mesh-system:8443
         virtualWorkspaceSecretName: virtual-workspaces-cert
   14: |
     apiVersion: delivery.ocm.software/v1alpha1

--- a/charts/platform-mesh-operator-components/tests/__snapshot__/helmreleases_test.yaml.snap
+++ b/charts/platform-mesh-operator-components/tests/__snapshot__/helmreleases_test.yaml.snap
@@ -237,10 +237,10 @@ HelmRelease snapshots:
               virtualWorkspaces:
                 - kubeconfig: /app/kubeconfig/kubeconfig
                   name: contentconfigurations
-                  url: https://frontproxy-front-proxy.platform-mesh-system:6443/services/contentconfigurations
+                  url: https://frontproxy-front-proxy.platform-mesh-system:8443/services/contentconfigurations
                 - kubeconfig: /app/kubeconfig/kubeconfig
                   name: marketplace
-                  url: https://frontproxy-front-proxy.platform-mesh-system:6443/services/marketplace
+                  url: https://frontproxy-front-proxy.platform-mesh-system:8443/services/marketplace
             enabled: true
         tracing:
           enabled: false
@@ -408,7 +408,7 @@ HelmRelease snapshots:
         deployment:
           resourceSchemaName: v250704-6d57f16.contentconfigurations.ui.platform-mesh.io
           resourceSchemaWorkspace: root:platform-mesh-system
-          serverUrl: https://frontproxy-front-proxy.platform-mesh-system:6443
+          serverUrl: https://frontproxy-front-proxy.platform-mesh-system:8443
         virtualWorkspaceSecretName: virtual-workspaces-cert
 enable remote deployment of helmreleases:
   1: |
@@ -681,10 +681,10 @@ enable remote deployment of helmreleases:
               virtualWorkspaces:
                 - kubeconfig: /app/kubeconfig/kubeconfig
                   name: contentconfigurations
-                  url: https://frontproxy-front-proxy.platform-mesh-system:6443/services/contentconfigurations
+                  url: https://frontproxy-front-proxy.platform-mesh-system:8443/services/contentconfigurations
                 - kubeconfig: /app/kubeconfig/kubeconfig
                   name: marketplace
-                  url: https://frontproxy-front-proxy.platform-mesh-system:6443/services/marketplace
+                  url: https://frontproxy-front-proxy.platform-mesh-system:8443/services/marketplace
             enabled: true
         tracing:
           enabled: false
@@ -872,5 +872,5 @@ enable remote deployment of helmreleases:
         deployment:
           resourceSchemaName: v250704-6d57f16.contentconfigurations.ui.platform-mesh.io
           resourceSchemaWorkspace: root:platform-mesh-system
-          serverUrl: https://frontproxy-front-proxy.platform-mesh-system:6443
+          serverUrl: https://frontproxy-front-proxy.platform-mesh-system:8443
         virtualWorkspaceSecretName: virtual-workspaces-cert

--- a/charts/platform-mesh-operator-components/values.yaml
+++ b/charts/platform-mesh-operator-components/values.yaml
@@ -254,10 +254,10 @@ services:
           content:
             virtualWorkspaces:
               - name: contentconfigurations
-                url: https://frontproxy-front-proxy.platform-mesh-system:6443/services/contentconfigurations
+                url: https://frontproxy-front-proxy.platform-mesh-system:8443/services/contentconfigurations
                 kubeconfig: /app/kubeconfig/kubeconfig
               - name: marketplace
-                url: https://frontproxy-front-proxy.platform-mesh-system:6443/services/marketplace
+                url: https://frontproxy-front-proxy.platform-mesh-system:8443/services/marketplace
                 kubeconfig: /app/kubeconfig/kubeconfig
   openfga:
     enabled: true
@@ -406,7 +406,7 @@ services:
     values:
       virtualWorkspaceSecretName: virtual-workspaces-cert
       deployment:
-        serverUrl: "https://frontproxy-front-proxy.platform-mesh-system:6443"
+        serverUrl: "https://frontproxy-front-proxy.platform-mesh-system:8443"
         resourceSchemaName: "v250704-6d57f16.contentconfigurations.ui.platform-mesh.io"
         resourceSchemaWorkspace: "root:platform-mesh-system"
   iam-service:

--- a/charts/virtual-workspaces/Chart.yaml
+++ b/charts/virtual-workspaces/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: virtual-workspaces
 description: A Helm chart to deploy platform-mesh virtual-workspaces
 type: application
-version: 0.4.8
+version: 0.4.9
 appVersion: "v0.12.0"
 dependencies:
   - name: common

--- a/charts/virtual-workspaces/README.md
+++ b/charts/virtual-workspaces/README.md
@@ -32,7 +32,7 @@ A Helm chart to deploy platform-mesh virtual-workspaces
 | deployment.resourceSchemaExportName | string | `"core.platform-mesh.io"` |  |
 | deployment.resourceSchemaName | string | `"v250704-6d57f16.contentconfigurations.ui.platform-mesh.io"` |  |
 | deployment.resourceSchemaWorkspace | string | `"root:platform-mesh-system"` |  |
-| deployment.serverUrl | string | `"https://frontproxy-front-proxy.platform-mesh-system:6443"` |  |
+| deployment.serverUrl | string | `"https://frontproxy-front-proxy.platform-mesh-system:8443"` |  |
 | image.name | string | `"ghcr.io/platform-mesh/virtual-workspaces"` | The image repository |
 | kubeconfigSecretName | string | `"account-operator-kubeconfig"` |  |
 | requestHeaderClientCASecretName | string | `"root-requestheader-client-ca"` |  |

--- a/charts/virtual-workspaces/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/virtual-workspaces/tests/__snapshot__/deployment_test.yaml.snap
@@ -75,7 +75,7 @@ virtual-workspaces match the snapshot:
                 - --secure-port=8443
                 - --entity-label=ui.platform-mesh.io/entity
                 - --content-for-label=ui.platform-mesh.io/content-for
-                - --server-url=https://frontproxy-front-proxy.platform-mesh-system:6443
+                - --server-url=https://frontproxy-front-proxy.platform-mesh-system:8443
                 - --resource-schema-name=v250704-6d57f16.contentconfigurations.ui.platform-mesh.io
                 - --resource-schema-workspace=root:platform-mesh-system
                 - --resource-apiexport-endpointslice-name=core.platform-mesh.io

--- a/charts/virtual-workspaces/values.yaml
+++ b/charts/virtual-workspaces/values.yaml
@@ -13,7 +13,7 @@ image:
 deployment:
   entityLabel: ui.platform-mesh.io/entity
   contentForLabel: ui.platform-mesh.io/content-for
-  serverUrl: https://frontproxy-front-proxy.platform-mesh-system:6443
+  serverUrl: https://frontproxy-front-proxy.platform-mesh-system:8443
   resourceSchemaName: "v250704-6d57f16.contentconfigurations.ui.platform-mesh.io"
   resourceSchemaWorkspace: root:platform-mesh-system
   resourceSchemaExportName: core.platform-mesh.io


### PR DESCRIPTION
## Summary
- Updated the frontproxy-front-proxy service URL port from 6443 to 8443 across platform-mesh-operator-components and virtual-workspaces charts
- Bumped chart versions accordingly