### PR TITLE
fix(charts): use externally sourced image for keycloak-operator

### DIFF
--- a/charts/keycloak-operator/Chart.yaml
+++ b/charts/keycloak-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: keycloak-operator
 description: Keycloak Operator for Kubernetes
 type: application
-version: 0.1.0
-appVersion: "26.6.0"
+version: 0.2.0
+appVersion: "0.0.0"
 dependencies:
   - name: common
     version: 0.12.2

--- a/charts/keycloak-operator/README.md
+++ b/charts/keycloak-operator/README.md
@@ -37,7 +37,7 @@ This fetches the CRD manifests from the [OperatorHub community-operators](https:
 | deployment.specTemplate.annotations | object | `{}` | Annotations for the pod template |
 | deployment.specTemplate.labels | object | `{}` | Labels for the pod template |
 | image.name | string | `"quay.io/keycloak/keycloak-operator"` | The image repository |
-| image.tag | string | `""` | The image tag (defaults to appVersion) |
+| image.tag | string | `"26.6.0"` | The image tag (defaults to appVersion) |
 | keycloakImage.repository | string | `"ghcr.io/platform-mesh/custom-images/keycloak"` | The Keycloak image repository |
 | keycloakImage.tag | string | `"v26.6.0"` | The Keycloak image tag (defaults to appVersion) |
 | watchNamespaces | string | `""` | Namespace to watch for Keycloak CRs. Defaults to the release namespace. |

--- a/charts/keycloak-operator/templates/deployment.yaml
+++ b/charts/keycloak-operator/templates/deployment.yaml
@@ -3,6 +3,7 @@ kind: Deployment
 metadata:
   name: {{ include "common.entity.name" . }}
 spec:
+  image: {{ .Values.image.name }}:{{ .Values.image.tag  }}
   {{- include "common.deploymentBasics" . | nindent 2 }}
   replicas: {{ .Values.deployment.replicas }}
   template:

--- a/charts/keycloak-operator/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/keycloak-operator/tests/__snapshot__/deployment_test.yaml.snap
@@ -5,6 +5,7 @@ deployment matches snapshot (defaults):
     metadata:
       name: keycloak-operator
     spec:
+      image: quay.io/keycloak/keycloak-operator:26.6.0
       replicas: 1
       revisionHistoryLimit: 3
       selector:
@@ -33,7 +34,7 @@ deployment matches snapshot (defaults):
                   value: JOSDK_WATCH_CURRENT
                 - name: QUARKUS_OPERATOR_SDK_CONTROLLERS_KEYCLOAKCONTROLLER_NAMESPACES
                   value: JOSDK_WATCH_CURRENT
-              image: quay.io/keycloak/keycloak-operator:0.0.0
+              image: quay.io/keycloak/keycloak-operator:26.6.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -411,6 +412,7 @@ deployment matches snapshot with custom resources:
     metadata:
       name: keycloak-operator
     spec:
+      image: quay.io/keycloak/keycloak-operator:26.6.0
       replicas: 1
       revisionHistoryLimit: 3
       selector:
@@ -439,7 +441,7 @@ deployment matches snapshot with custom resources:
                   value: JOSDK_WATCH_CURRENT
                 - name: QUARKUS_OPERATOR_SDK_CONTROLLERS_KEYCLOAKCONTROLLER_NAMESPACES
                   value: JOSDK_WATCH_CURRENT
-              image: quay.io/keycloak/keycloak-operator:0.0.0
+              image: quay.io/keycloak/keycloak-operator:26.6.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/keycloak-operator/tests/deployment_test.yaml
+++ b/charts/keycloak-operator/tests/deployment_test.yaml
@@ -13,7 +13,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: quay.io/keycloak/keycloak-operator:0.0.0
+          value: quay.io/keycloak/keycloak-operator:26.6.0
 
   - it: deployment uses custom watchNamespace
     template: templates/deployment.yaml

--- a/charts/keycloak-operator/values.yaml
+++ b/charts/keycloak-operator/values.yaml
@@ -2,7 +2,7 @@ image:
   # -- The image repository
   name: quay.io/keycloak/keycloak-operator
   # -- The image tag (defaults to appVersion)
-  tag: ""
+  tag: "26.6.0"
 
 keycloakImage:
   # -- The Keycloak image repository


### PR DESCRIPTION
Set
```yaml
appVersion: "0.0.0"
```
to build a chart-only service level component for keycloak-operator.