### PR TITLE
feat(kubernetes-graphql-gateway): allow per-deployment replica overrides

### DIFF
--- a/charts/kubernetes-graphql-gateway/Chart.yaml
+++ b/charts/kubernetes-graphql-gateway/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.38.23
+version: 0.39.0
 appVersion: v1.11.1
 name: kubernetes-graphql-gateway
 description: Basic helm chart that contains listener and gateway

--- a/charts/kubernetes-graphql-gateway/README.md
+++ b/charts/kubernetes-graphql-gateway/README.md
@@ -16,12 +16,10 @@ kubeConfig:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | crds.enabled | bool | `true` |  |
-| deployment.maxSurge | int | `5` |  |
-| deployment.maxUnavailable | int | `0` |  |
-| deployment.replicas | int | `1` |  |
-| deployment.revisionHistoryLimit | int | `3` |  |
+| deployment | object | `{"maxSurge":5,"maxUnavailable":0,"replicas":1,"revisionHistoryLimit":3}` | Default deployment settings applied to both the gateway and listener Deployments. Each setting can be overridden per-deployment via `gateway.deployment.<field>` or `listener.deployment.<field>` (see those blocks in this file). When a per-deployment override is unset, the value from this block is used. |
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |
+| gateway.deployment | object | `{}` | Per-deployment overrides for the gateway Deployment. Any field set here takes precedence over the matching field in the top-level `deployment` block. Unset fields fall back to the top-level defaults. Example:   gateway:     deployment:       replicas: 3 |
 | gateway.extraArgs | list | `[]` |  |
 | gateway.healthCheck.enabled | bool | `true` |  |
 | gateway.healthCheck.port | int | `8080` |  |
@@ -61,6 +59,7 @@ kubeConfig:
 | listener.apiExportEndpointSliceName | string | `"core.platform-mesh.io"` |  |
 | listener.cacheNamespaces | list | `[]` | Restrict the cache to these namespaces for namespaced resources (e.g. secrets, configmaps). Cluster-scoped resources are unaffected. When empty, all namespaces are cached. |
 | listener.clusterAccessControllerProviders | multi mode only | `"single"` | Comma-separated list of providers for the ClusterAccess controller. Valid values: "kcp", "single". Only valid when provider=multi. Requires enableClusterAccessController=true. |
+| listener.deployment | object | `{}` | Per-deployment overrides for the listener Deployment. Any field set here takes precedence over the matching field in the top-level `deployment` block. Unset fields fall back to the top-level defaults. Example:   listener:     deployment:       replicas: 1 |
 | listener.enableClusterAccessController | bool | `true` | Enable the ClusterAccess controller. |
 | listener.enableResourceController | bool | `true` | Enable the resource controller for watching the configured anchor resource and generating schemas. |
 | listener.extraArgs | list | `[]` |  |

--- a/charts/kubernetes-graphql-gateway/templates/deploy-gateway.yaml
+++ b/charts/kubernetes-graphql-gateway/templates/deploy-gateway.yaml
@@ -1,4 +1,6 @@
 {{- $noJson := include "common.getKeyValue" (dict "Values" .Values "key" "log.noJson") }}
+{{- $deploy := default dict .Values.deployment }}
+{{- $override := default dict .Values.gateway.deployment }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -7,12 +9,12 @@ metadata:
   labels:
     app: {{ include "common.entity.name" . }}
 spec:
-  replicas: {{ .Values.deployment.replicas }}
+  replicas: {{ if hasKey $override "replicas" }}{{ $override.replicas }}{{ else }}{{ $deploy.replicas }}{{ end }}
   strategy:
     rollingUpdate:
-      maxSurge: {{ .Values.deployment.maxSurge }}
-      maxUnavailable: {{ .Values.deployment.maxUnavailable }}
-  revisionHistoryLimit: {{ .Values.deployment.revisionHistoryLimit }}
+      maxSurge: {{ if hasKey $override "maxSurge" }}{{ $override.maxSurge }}{{ else }}{{ $deploy.maxSurge }}{{ end }}
+      maxUnavailable: {{ if hasKey $override "maxUnavailable" }}{{ $override.maxUnavailable }}{{ else }}{{ $deploy.maxUnavailable }}{{ end }}
+  revisionHistoryLimit: {{ if hasKey $override "revisionHistoryLimit" }}{{ $override.revisionHistoryLimit }}{{ else }}{{ $deploy.revisionHistoryLimit }}{{ end }}
   selector:
     matchLabels:
       app: {{ include "common.entity.name" . }}

--- a/charts/kubernetes-graphql-gateway/templates/deploy-listener.yaml
+++ b/charts/kubernetes-graphql-gateway/templates/deploy-listener.yaml
@@ -6,6 +6,8 @@
 {{- if and .Values.listener.clusterAccessControllerProviders (not .Values.listener.enableClusterAccessController) }}
 {{- fail "listener.clusterAccessControllerProviders requires listener.enableClusterAccessController=true" }}
 {{- end }}
+{{- $deploy := default dict .Values.deployment }}
+{{- $override := default dict .Values.listener.deployment }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -14,12 +16,12 @@ metadata:
   labels:
     app: {{ include "common.entity.name" . }}-listener
 spec:
-  replicas: {{ .Values.deployment.replicas }}
+  replicas: {{ if hasKey $override "replicas" }}{{ $override.replicas }}{{ else }}{{ $deploy.replicas }}{{ end }}
   strategy:
     rollingUpdate:
-      maxSurge: {{ .Values.deployment.maxSurge }}
-      maxUnavailable: {{ .Values.deployment.maxUnavailable }}
-  revisionHistoryLimit: {{ .Values.deployment.revisionHistoryLimit }}
+      maxSurge: {{ if hasKey $override "maxSurge" }}{{ $override.maxSurge }}{{ else }}{{ $deploy.maxSurge }}{{ end }}
+      maxUnavailable: {{ if hasKey $override "maxUnavailable" }}{{ $override.maxUnavailable }}{{ else }}{{ $deploy.maxUnavailable }}{{ end }}
+  revisionHistoryLimit: {{ if hasKey $override "revisionHistoryLimit" }}{{ $override.revisionHistoryLimit }}{{ else }}{{ $deploy.revisionHistoryLimit }}{{ end }}
   selector:
     matchLabels:
       app: {{ include "common.entity.name" . }}-listener

--- a/charts/kubernetes-graphql-gateway/tests/deployment_test.yaml
+++ b/charts/kubernetes-graphql-gateway/tests/deployment_test.yaml
@@ -80,3 +80,62 @@ tests:
       - deploy-listener.yaml
     asserts:
       - matchSnapshot: {}
+  - it: applies per-deployment override to gateway only
+    set:
+      gateway.deployment.replicas: 3
+      gateway.deployment.maxSurge: 1
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+        template: deploy-gateway.yaml
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 1
+        template: deploy-gateway.yaml
+      - equal:
+          path: spec.replicas
+          value: 1
+        template: deploy-listener.yaml
+  - it: applies per-deployment override to listener only
+    set:
+      listener.deployment.replicas: 2
+      listener.deployment.maxUnavailable: 1
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 2
+        template: deploy-listener.yaml
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 1
+        template: deploy-listener.yaml
+      - equal:
+          path: spec.replicas
+          value: 1
+        template: deploy-gateway.yaml
+  - it: honors zero values in per-deployment overrides
+    set:
+      gateway.deployment.replicas: 0
+      listener.deployment.revisionHistoryLimit: 0
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 0
+        template: deploy-gateway.yaml
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 0
+        template: deploy-listener.yaml
+  - it: falls back to top-level deployment defaults when override is unset
+    set:
+      deployment.replicas: 5
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 5
+        template: deploy-gateway.yaml
+      - equal:
+          path: spec.replicas
+          value: 5
+        template: deploy-listener.yaml

--- a/charts/kubernetes-graphql-gateway/values.yaml
+++ b/charts/kubernetes-graphql-gateway/values.yaml
@@ -43,6 +43,15 @@ gateway:
       cpu: 250m
       memory: 1000Mi
 
+  # -- Per-deployment overrides for the gateway Deployment. Any field set
+  # here takes precedence over the matching field in the top-level
+  # `deployment` block. Unset fields fall back to the top-level defaults.
+  # Example:
+  #   gateway:
+  #     deployment:
+  #       replicas: 3
+  deployment: {}
+
 listener:
   port: 8090
   grpcPort: 50051
@@ -85,6 +94,20 @@ listener:
       cpu: 250m
       memory: 500Mi
 
+  # -- Per-deployment overrides for the listener Deployment. Any field set
+  # here takes precedence over the matching field in the top-level
+  # `deployment` block. Unset fields fall back to the top-level defaults.
+  # Example:
+  #   listener:
+  #     deployment:
+  #       replicas: 1
+  deployment: {}
+
+# -- Default deployment settings applied to both the gateway and listener
+# Deployments. Each setting can be overridden per-deployment via
+# `gateway.deployment.<field>` or `listener.deployment.<field>` (see those
+# blocks in this file). When a per-deployment override is unset, the value
+# from this block is used.
 deployment:
   maxUnavailable: 0
   maxSurge: 5


### PR DESCRIPTION
## Summary

Today `deploy-gateway.yaml` and `deploy-listener.yaml` both read replicas (and `maxSurge` / `maxUnavailable` / `revisionHistoryLimit`) from a single top-level `deployment.*` block, so consumers cannot scale the gateway and listener independently. This PR adds optional `gateway.deployment.*` and `listener.deployment.*` override blocks; each field falls back to the top-level `deployment.*` value when unset. `hasKey` is used (not `default`) so explicit zero values (`replicas: 0`, `maxUnavailable: 0`, `revisionHistoryLimit: 0`) are honored.

## Why

A consuming chart that needs different replica counts for the listener and the gateway (e.g. listener=1 because it owns reconciliation state, gateway=N for HA reads) currently has no way to express that without forking the chart.

## Backward compatibility

Fully backward compatible. With both new override blocks left at their default `{}`, both deployments render byte-identically to the previous version (verified via `helm template` and the existing snapshot tests, which were not regenerated).

## Tests

Four new cases in `tests/deployment_test.yaml`:

- gateway override applied, listener untouched
- listener override applied, gateway untouched
- zero values in overrides honored
- top-level `deployment.*` still acts as fallback for both

`helm unittest` passes locally.

## Chart

Bumped `0.38.23` → `0.39.0` (minor — additive feature, no breakage).