### PR TITLE
fix: non "0.0.0" appVersions require an image

### DIFF
--- a/charts/observability/Chart.yaml
+++ b/charts/observability/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: observability
 description: OpenTelemetry-based observability stack for platform-mesh
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.2.0
+appVersion: "0.0.0"
 dependencies:
   - name: prometheus-operator-crds
     version: 19.1.0

--- a/charts/observability/README.md
+++ b/charts/observability/README.md
@@ -90,7 +90,7 @@ Example
 ```
 # observability
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
 
 OpenTelemetry-based observability stack for platform-mesh
 


### PR DESCRIPTION
This causes the observability service-level component to contain only chart and no image, which is what we want. All images are externally provided.