### PR TITLE
Finish initial observability setup

### DIFF
--- a/charts/observability/Chart.yaml
+++ b/charts/observability/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability
 description: OpenTelemetry-based observability stack for platform-mesh
 type: application
-version: 0.3.6
+version: 0.4.0
 appVersion: "0.0.0"
 dependencies:
   - name: prometheus

--- a/charts/observability/README.md
+++ b/charts/observability/README.md
@@ -88,7 +88,7 @@ Example
 ```
 # observability
 
-![Version: 0.3.6](https://img.shields.io/badge/Version-0.3.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
 
 OpenTelemetry-based observability stack for platform-mesh
 

--- a/charts/observability/README.md
+++ b/charts/observability/README.md
@@ -21,11 +21,9 @@ OpenTelemetry-based observability stack for platform-mesh
 | httproutes.prometheus.filters | list | `[]` | Optional filters (e.g., URLRewrite for path stripping) |
 | httproutes.prometheus.hostnames | list | `[]` | Hostnames for the Prometheus UI |
 | httproutes.prometheus.pathPrefix | string | `"/prometheus"` | Path prefix for Prometheus UI |
-| opentelemetry-operator | object | `{"enabled":true,"manager":{"collectorImage":{"repository":"otel/opentelemetry-collector-contrib"}}}` | ---------------------------------------------------------------------------- |
-| opentelemetry-operator.enabled | bool | `true` | Enable the OpenTelemetry Operator |
-| opentelemetry-operator.manager.collectorImage.repository | string | `"otel/opentelemetry-collector-contrib"` | Use the contrib image which includes the prometheus receiver |
-| otelCollector | object | `{"config":{"batchTimeout":"10s"},"mode":"statefulset","name":"otel-gateway","replicas":1}` | ---------------------------------------------------------------------------- |
+| otelCollector | object | `{"config":{"batchTimeout":"10s"},"image":"ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.153.0","mode":"statefulset","name":"otel-gateway","replicas":1}` | ---------------------------------------------------------------------------- |
 | otelCollector.config.batchTimeout | string | `"10s"` | Batch processor timeout before sending metrics |
+| otelCollector.image | string | `"ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.153.0"` | Collector image (use contrib for prometheusremotewrite exporter) |
 | otelCollector.mode | string | `"statefulset"` | Deployment mode (statefulset required for Target Allocator) |
 | otelCollector.name | string | `"otel-gateway"` | Name of the OpenTelemetryCollector CR |
 | otelCollector.replicas | int | `1` | Number of collector replicas |
@@ -52,10 +50,10 @@ OpenTelemetry-based observability stack for platform-mesh
 | serviceMonitors.kcp.kubeconfig.validity | string | `"8766h"` | Validity period of the client certificate |
 | serviceMonitors.kcp.labels | object | `{"app.kubernetes.io/component":"rootshard","app.kubernetes.io/name":"kcp"}` | Labels to select kcp service |
 | serviceMonitors.kcp.namespace | string | `"platform-mesh-system"` | Namespace where kcp runs |
-| serviceMonitors.kcp.path | string | `"/clusters/root/metrics"` | Path to metrics endpoint (kcp-specific path) |
+| serviceMonitors.kcp.path | string | `"/clusters/root/metrics"` | Path to metrics endpoint (as of kcp 0.32, /metrics and /clusters/root/metrics return the exact same data, but /clusters/root/metrics requires fewer permissions). |
 | serviceMonitors.kcp.port | string | `"https"` | Name of the port exposing metrics (same as API port) |
 | serviceMonitors.kcp.scheme | string | `"https"` | Use HTTPS scheme |
-| serviceMonitors.kcp.tlsInsecureSkipVerify | bool | `true` | Skip TLS certificate verification (required for self-signed certs) |
+| serviceMonitors.kcp.tlsInsecureSkipVerify | bool | `true` | Skip TLS certificate verification; unless you know what you're doing, this should be left to true, since OTel Collector will connect to each Pod in the target Service using its IP, which is never part of the certificate's SANs. |
 | serviceMonitors.kcp.tlsSecretName | string | `"kcp-metrics-client-cert"` | Name of the TLS secret containing client cert/key for authentication This secret is created by the kcp-metrics-cert-job from the kubeconfig |
 | serviceMonitors.openfga | object | `{"enabled":true,"labels":{"app.kubernetes.io/name":"openfga"},"namespace":"platform-mesh-system","path":"/metrics","port":"metrics"}` | OpenFGA metrics scraping |
 | serviceMonitors.openfga.enabled | bool | `true` | Enable scraping OpenFGA |
@@ -119,11 +117,9 @@ OpenTelemetry-based observability stack for platform-mesh
 | httproutes.prometheus.filters | list | `[]` | Optional filters (e.g., URLRewrite for path stripping) |
 | httproutes.prometheus.hostnames | list | `[]` | Hostnames for the Prometheus UI |
 | httproutes.prometheus.pathPrefix | string | `"/prometheus"` | Path prefix for Prometheus UI |
-| opentelemetry-operator | object | `{"enabled":true,"manager":{"collectorImage":{"repository":"otel/opentelemetry-collector-contrib"}}}` | ---------------------------------------------------------------------------- |
-| opentelemetry-operator.enabled | bool | `true` | Enable the OpenTelemetry Operator |
-| opentelemetry-operator.manager.collectorImage.repository | string | `"otel/opentelemetry-collector-contrib"` | Use the contrib image which includes the prometheus receiver |
-| otelCollector | object | `{"config":{"batchTimeout":"10s"},"mode":"statefulset","name":"otel-gateway","replicas":1}` | ---------------------------------------------------------------------------- |
+| otelCollector | object | `{"config":{"batchTimeout":"10s"},"image":"ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.153.0","mode":"statefulset","name":"otel-gateway","replicas":1}` | ---------------------------------------------------------------------------- |
 | otelCollector.config.batchTimeout | string | `"10s"` | Batch processor timeout before sending metrics |
+| otelCollector.image | string | `"ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.153.0"` | Collector image (use contrib for prometheusremotewrite exporter) |
 | otelCollector.mode | string | `"statefulset"` | Deployment mode (statefulset required for Target Allocator) |
 | otelCollector.name | string | `"otel-gateway"` | Name of the OpenTelemetryCollector CR |
 | otelCollector.replicas | int | `1` | Number of collector replicas |
@@ -150,10 +146,10 @@ OpenTelemetry-based observability stack for platform-mesh
 | serviceMonitors.kcp.kubeconfig.validity | string | `"8766h"` | Validity period of the client certificate |
 | serviceMonitors.kcp.labels | object | `{"app.kubernetes.io/component":"rootshard","app.kubernetes.io/name":"kcp"}` | Labels to select kcp service |
 | serviceMonitors.kcp.namespace | string | `"platform-mesh-system"` | Namespace where kcp runs |
-| serviceMonitors.kcp.path | string | `"/clusters/root/metrics"` | Path to metrics endpoint (kcp-specific path) |
+| serviceMonitors.kcp.path | string | `"/clusters/root/metrics"` | Path to metrics endpoint (as of kcp 0.32, /metrics and /clusters/root/metrics return the exact same data, but /clusters/root/metrics requires fewer permissions). |
 | serviceMonitors.kcp.port | string | `"https"` | Name of the port exposing metrics (same as API port) |
 | serviceMonitors.kcp.scheme | string | `"https"` | Use HTTPS scheme |
-| serviceMonitors.kcp.tlsInsecureSkipVerify | bool | `true` | Skip TLS certificate verification (required for self-signed certs) |
+| serviceMonitors.kcp.tlsInsecureSkipVerify | bool | `true` | Skip TLS certificate verification; unless you know what you're doing, this should be left to true, since OTel Collector will connect to each Pod in the target Service using its IP, which is never part of the certificate's SANs. |
 | serviceMonitors.kcp.tlsSecretName | string | `"kcp-metrics-client-cert"` | Name of the TLS secret containing client cert/key for authentication This secret is created by the kcp-metrics-cert-job from the kubeconfig |
 | serviceMonitors.openfga | object | `{"enabled":true,"labels":{"app.kubernetes.io/name":"openfga"},"namespace":"platform-mesh-system","path":"/metrics","port":"metrics"}` | OpenFGA metrics scraping |
 | serviceMonitors.openfga.enabled | bool | `true` | Enable scraping OpenFGA |

--- a/charts/observability/templates/otel-collector.yaml
+++ b/charts/observability/templates/otel-collector.yaml
@@ -11,21 +11,6 @@ spec:
   image: {{ .Values.otelCollector.image }}
   mode: {{ .Values.otelCollector.mode }}
   replicas: {{ .Values.otelCollector.replicas }}
-  {{- if .Values.serviceMonitors.kcp.tlsSecretName }}
-  volumes:
-    - name: kcp-metrics-certs
-      secret:
-        secretName: {{ .Values.serviceMonitors.kcp.tlsSecretName }}
-  volumeMounts:
-    - name: kcp-metrics-certs
-      mountPath: /etc/prometheus/certs/0_{{ .Release.Namespace }}_{{ .Values.serviceMonitors.kcp.tlsSecretName }}_tls.crt
-      subPath: tls.crt
-      readOnly: true
-    - name: kcp-metrics-certs
-      mountPath: /etc/prometheus/certs/0_{{ .Release.Namespace }}_{{ .Values.serviceMonitors.kcp.tlsSecretName }}_tls.key
-      subPath: tls.key
-      readOnly: true
-  {{- end }}
   targetAllocator:
     enabled: true
     prometheusCR:

--- a/charts/observability/templates/otel-collector.yaml
+++ b/charts/observability/templates/otel-collector.yaml
@@ -8,6 +8,7 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "10"
 spec:
+  image: {{ .Values.otelCollector.image }}
   mode: {{ .Values.otelCollector.mode }}
   replicas: {{ .Values.otelCollector.replicas }}
   {{- if .Values.serviceMonitors.kcp.tlsSecretName }}

--- a/charts/observability/templates/otel-collector.yaml
+++ b/charts/observability/templates/otel-collector.yaml
@@ -4,9 +4,6 @@ metadata:
   name: {{ .Values.otelCollector.name }}
   labels:
     {{- include "observability.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "10"
 spec:
   image: {{ .Values.otelCollector.image }}
   mode: {{ .Values.otelCollector.mode }}

--- a/charts/observability/templates/servicemonitors/account-operator.yaml
+++ b/charts/observability/templates/servicemonitors/account-operator.yaml
@@ -5,9 +5,6 @@ metadata:
   name: account-operator
   labels:
     {{- include "observability.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "5"
 spec:
   namespaceSelector:
     matchNames:

--- a/charts/observability/templates/servicemonitors/kcp.yaml
+++ b/charts/observability/templates/servicemonitors/kcp.yaml
@@ -5,9 +5,6 @@ metadata:
   name: kcp
   labels:
     {{- include "observability.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "5"
 spec:
   namespaceSelector:
     matchNames:

--- a/charts/observability/templates/servicemonitors/openfga.yaml
+++ b/charts/observability/templates/servicemonitors/openfga.yaml
@@ -5,9 +5,6 @@ metadata:
   name: openfga
   labels:
     {{- include "observability.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "5"
 spec:
   namespaceSelector:
     matchNames:

--- a/charts/observability/templates/servicemonitors/security-operator.yaml
+++ b/charts/observability/templates/servicemonitors/security-operator.yaml
@@ -5,9 +5,6 @@ metadata:
   name: security-operator
   labels:
     {{- include "observability.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "5"
 spec:
   namespaceSelector:
     matchNames:

--- a/charts/observability/values.yaml
+++ b/charts/observability/values.yaml
@@ -2,19 +2,6 @@
 createNamespace: false
 
 # ------------------------------------------------------------------------------
-# OpenTelemetry Operator
-# Manages the OTel Collector via CRDs
-# https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-operator
-# ------------------------------------------------------------------------------
-opentelemetry-operator:
-  # -- Enable the OpenTelemetry Operator
-  enabled: true
-  manager:
-    collectorImage:
-      # -- Use the contrib image which includes the prometheus receiver
-      repository: otel/opentelemetry-collector-contrib
-
-# ------------------------------------------------------------------------------
 # Prometheus
 # Metrics storage and query backend
 # https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus
@@ -54,6 +41,8 @@ otelCollector:
   mode: statefulset
   # -- Number of collector replicas
   replicas: 1
+  # -- Collector image (use contrib for prometheusremotewrite exporter)
+  image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.153.0
   config:
     # -- Batch processor timeout before sending metrics
     batchTimeout: 10s

--- a/charts/observability/values.yaml
+++ b/charts/observability/values.yaml
@@ -93,11 +93,15 @@ serviceMonitors:
       app.kubernetes.io/name: kcp
     # -- Name of the port exposing metrics (same as API port)
     port: https
-    # -- Path to metrics endpoint (kcp-specific path)
+    # -- Path to metrics endpoint (as of kcp 0.32, /metrics and /clusters/root/metrics
+    # return the exact same data, but /clusters/root/metrics requires fewer permissions).
     path: /clusters/root/metrics
     # -- Use HTTPS scheme
     scheme: https
-    # -- Skip TLS certificate verification (required for self-signed certs)
+    # -- Skip TLS certificate verification; unless you know what you're doing,
+    # this should be left to true, since OTel Collector will connect to each
+    # Pod in the target Service using its IP, which is never part of the
+    # certificate's SANs.
     tlsInsecureSkipVerify: true
     # -- Name of the TLS secret containing client cert/key for authentication
     # This secret is created by the kcp-metrics-cert-job from the kubeconfig

--- a/local-setup/kustomize/components/platform-mesh-operator-resource/default-profile.yaml
+++ b/local-setup/kustomize/components/platform-mesh-operator-resource/default-profile.yaml
@@ -612,10 +612,6 @@ data:
           - name: opentelemetry-operator
             namespace: platform-mesh-system
           values:
-            opentelemetry-operator:
-              manager:
-                collectorImage:
-                  repository: otel/opentelemetry-collector-contrib
             prometheus:
               server:
                 persistentVolume:

--- a/local-setup/kustomize/components/platform-mesh-operator-resource/default-profile.yaml
+++ b/local-setup/kustomize/components/platform-mesh-operator-resource/default-profile.yaml
@@ -604,7 +604,7 @@ data:
               kubeconfigSecret: terminal-controller-manager-kubeconfig
         observability:
           syncWave: 4
-          enabled: false
+          enabled: true
           targetNamespace: observability
           dependsOn:
           - name: prometheus-operator-crds

--- a/local-setup/scripts/ocm-build-component.sh
+++ b/local-setup/scripts/ocm-build-component.sh
@@ -24,7 +24,7 @@ REMOTE_REGISTRY="${REMOTE_REGISTRY:-ghcr.io/platform-mesh}"
 LOCAL_REGISTRY="${LOCAL_REGISTRY:-oci-registry-docker-registry.registry.svc.cluster.local}"
 
 # List of local component names (for version resolution)
-CUSTOM_LOCAL_COMPONENTS="account-operator,example-httpbin-operator,extension-manager-operator,iam-service,iam-ui,infra,keycloak-operator,kubernetes-graphql-gateway,platform-mesh-operator,platform-mesh-operator-components,platform-mesh-operator-infra-components,portal,rebac-authz-webhook,security-operator,terminal-controller-manager,virtual-workspaces"
+CUSTOM_LOCAL_COMPONENTS="account-operator,example-httpbin-operator,extension-manager-operator,iam-service,iam-ui,infra,keycloak-operator,kubernetes-graphql-gateway,observability,platform-mesh-operator,platform-mesh-operator-components,platform-mesh-operator-infra-components,portal,rebac-authz-webhook,security-operator,terminal-controller-manager,virtual-workspaces"
 
 # Fixed version overrides (empty by default)
 FIXED_VERSION_PAIRS=""

--- a/local-setup/scripts/ocm-build-local-charts.sh
+++ b/local-setup/scripts/ocm-build-local-charts.sh
@@ -27,6 +27,7 @@ CUSTOM_LOCAL_COMPONENTS_CHART_PATHS=(
     "infra:charts/infra"
     "keycloak-operator:charts/keycloak-operator"
     "kubernetes-graphql-gateway:charts/kubernetes-graphql-gateway"
+    "observability:charts/observability"
     "platform-mesh-operator:charts/platform-mesh-operator"
     "platform-mesh-operator-components:charts/platform-mesh-operator-components"
     "platform-mesh-operator-infra-components:charts/platform-mesh-operator-infra-components"


### PR DESCRIPTION
This PR is the last piece for installing the observability stack in Platform Mesh. Earlier PRs

* introduced the observability Helm chart, but installed it manually (with a `helm install` in the local-setup, rather than having the PM deal with it),
* tried to move the opentelemetry-operator and prometheus-crds into the PM Operator (via its profiles),
* failed because of incompatibility issues with the Helm hooks (they worked because in step 1 I used `helm install`),
* removed the hooks again, but ran into timing issues with the necessary CRDs
* hoisted the necessary dependencies for those CRDs out of the observability Helm chart and into the PM operator (i.e. otel-operator and prom-crds are *siblings* to the observability chart, not children or dependencies!),
* removed the dependencies that are now obsolete, yielding observability v0.3.6.

Now that all of this is done, this PR here is the final piece:

* It removes the last traces of unnecessary Helm hooks. These are simply not necessary anymore.
* Adds observability to the prerelease scripting logic.
* Enables observability in the PM profile, now that observability v0.3.6 will not fight with the otel-operator anymore.
* Overrides the default otel-collector image to gain support for Prometheus RemoteWrite (the OTel sink).
* And most importantly, does actual non-PM-related fixes:
  * The OTel Target Allocator does not expose the TLS client key in its output. So when the otel-collector connects to the allocator to retrieve the list of scraping targets, the JSON it receives will not contain the client key (PEM), but instead the string "<hidden>". This means the otel-collector would never get the TLS key used to speak with kcp.

    More recent (unreleased!) version of OTel have a new config flag to enable exposing secrets (like the key) over unencrypted HTTP, but since this has not been released yet, this PR instead configures OTel to enable its "mTLS" feature to deploy a certificate. This way, the target allocator listens on a HTTPS port and will expose the client key to the otel-collector.

    Since we are using dynamic (Secret-based) credentials in the ServiceMonitor, there is no need anymore to explicitly mount Secrets into the otel-collector; the Helm templating for that has been removed.

  * Unintuitively, we also need to enable `insecureSkipVerify` mode between otel-collector and kcp: Not because we're not using TLS (we are, it's how the otel-collector authenticates to kcp), but because due to the nature of Prometheus Service Discovery, we are always speaking to ports via their PodIP. These IPs are never in the serving certs for kcp and so we need to tell otel-collector to ignore that "issue".

With these changes in, observability finally works in the regular mode and in prerelease mode. From here we can then iterate normally, for example the OTel/Prometheus chart versions are aaaaaaancient and need to be bumped. Renovate tried opening PRs for that, but they failed, and I was waiting for this PR here to pass before embarking on updates.