### PR TITLE
ci: mirror appVersion semver bump onto chart version

### DIFF
--- a/.github/workflows/hack-tests.yml
+++ b/.github/workflows/hack-tests.yml
@@ -1,0 +1,34 @@
+name: hack/ script tests
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'hack/bump-chart-version.sh'
+      - 'hack/bump-chart-version.test.sh'
+      - '.github/workflows/hack-tests.yml'
+
+concurrency:
+  group: hack-tests-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  bump-chart-version:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Setup yq
+        run: |
+          if ! command -v yq >/dev/null 2>&1; then
+            mkdir -p "$HOME/.local/bin"
+            wget -q https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O "$HOME/.local/bin/yq"
+            chmod +x "$HOME/.local/bin/yq"
+            echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          fi
+      - name: Run bump-chart-version tests
+        run: bash hack/bump-chart-version.test.sh

--- a/.github/workflows/update-chart-parameters.yaml
+++ b/.github/workflows/update-chart-parameters.yaml
@@ -57,30 +57,67 @@ jobs:
           INPUT_CHART: ${{ inputs.chart }}
           INPUT_APP_VERSION: ${{ inputs.appVersion }}
         run: |
+          set -euo pipefail
           chart_file="charts/${INPUT_CHART}/Chart.yaml"
-          ls -al charts/
-          if [ -f "$chart_file" ]; then
-            echo "Chart.yaml file found at $chart_file"
-            yq e -i ".appVersion = \"${INPUT_APP_VERSION}\"" "$chart_file"
-            echo "Updated appVersion to ${INPUT_APP_VERSION} in $chart_file"
-
-            # bump version parameter in chart
-            CHART_VERSION=$(yq '.version' "$chart_file")
-            IFS='.' read -r -a VERSION_PARTS <<< "$CHART_VERSION"
-            MAJOR=${VERSION_PARTS[0]}
-            MINOR=${VERSION_PARTS[1]}
-            PATCH=${VERSION_PARTS[2]}
-            NEW_PATCH=$((PATCH + 1))
-            NEW_CHART_VERSION="$MAJOR.$MINOR.$NEW_PATCH"
-            yq e -i ".version = \"$NEW_CHART_VERSION\"" "$chart_file"
-            echo "Version bumped to $NEW_CHART_VERSION in $chart_file"
-
-            git add "$chart_file"
-            git commit -m "Set $NEW_CHART_VERSION / ${INPUT_APP_VERSION} in $chart_file" || echo "appVersion was already up to date"
-          else
-            echo "Chart.yaml file not found at $chart_file"
+          if [ ! -f "$chart_file" ]; then
+            echo "::error::Chart.yaml file not found at $chart_file"
             exit 1
           fi
+          echo "Chart.yaml file found at $chart_file"
+
+          OLD_APP_VERSION=$(yq '.appVersion' "$chart_file" | tr -d '"')
+          NEW_APP_VERSION="${INPUT_APP_VERSION}"
+
+          # Strip leading "v" and any pre-release/build suffix to compare clean MAJOR.MINOR.PATCH triplets.
+          strip() { v="${1#v}"; printf '%s' "${v%%[-+]*}"; }
+          OLD_CLEAN=$(strip "$OLD_APP_VERSION")
+          NEW_CLEAN=$(strip "$NEW_APP_VERSION")
+
+          if ! [[ "$OLD_CLEAN" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Existing appVersion ($OLD_APP_VERSION) is not a clean semver triplet"
+            exit 1
+          fi
+
+          IFS='.' read -r OLD_MAJOR OLD_MINOR OLD_PATCH <<<"$OLD_CLEAN"
+          IFS='.' read -r NEW_MAJOR NEW_MINOR NEW_PATCH <<<"$NEW_CLEAN"
+
+          if [ "$OLD_CLEAN" = "$NEW_CLEAN" ]; then
+            echo "appVersion unchanged ($OLD_APP_VERSION); nothing to do"
+            exit 0
+          fi
+
+          # Refuse downgrades — most likely a manual workflow_dispatch input mistake.
+          if [ "$NEW_MAJOR" -lt "$OLD_MAJOR" ] \
+            || { [ "$NEW_MAJOR" -eq "$OLD_MAJOR" ] && [ "$NEW_MINOR" -lt "$OLD_MINOR" ]; } \
+            || { [ "$NEW_MAJOR" -eq "$OLD_MAJOR" ] && [ "$NEW_MINOR" -eq "$OLD_MINOR" ] && [ "$NEW_PATCH" -lt "$OLD_PATCH" ]; }; then
+            echo "::error::appVersion downgrade refused: $OLD_APP_VERSION -> $NEW_APP_VERSION"
+            exit 1
+          fi
+
+          if   [ "$NEW_MAJOR" -gt "$OLD_MAJOR" ]; then BUMP=major
+          elif [ "$NEW_MINOR" -gt "$OLD_MINOR" ]; then BUMP=minor
+          else                                         BUMP=patch
+          fi
+          echo "Detected appVersion bump: $OLD_APP_VERSION -> $NEW_APP_VERSION ($BUMP)"
+
+          CHART_VERSION=$(yq '.version' "$chart_file")
+          if ! [[ "$CHART_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Existing chart version ($CHART_VERSION) is not a clean semver triplet"
+            exit 1
+          fi
+          IFS='.' read -r CM Cm Cp <<<"$CHART_VERSION"
+          case "$BUMP" in
+            major) NEW_CHART_VERSION="$((CM + 1)).0.0" ;;
+            minor) NEW_CHART_VERSION="$CM.$((Cm + 1)).0" ;;
+            patch) NEW_CHART_VERSION="$CM.$Cm.$((Cp + 1))" ;;
+          esac
+
+          yq e -i ".appVersion = \"${NEW_APP_VERSION}\"" "$chart_file"
+          yq e -i ".version    = \"${NEW_CHART_VERSION}\"" "$chart_file"
+          echo "Updated appVersion to ${NEW_APP_VERSION} and version to ${NEW_CHART_VERSION} in $chart_file"
+
+          git add "$chart_file"
+          git commit -m "Set $NEW_CHART_VERSION / ${NEW_APP_VERSION} in $chart_file" || echo "appVersion was already up to date"
       - name: Git push
         run: |
           git push origin main

--- a/.github/workflows/update-chart-parameters.yaml
+++ b/.github/workflows/update-chart-parameters.yaml
@@ -59,65 +59,17 @@ jobs:
         run: |
           set -euo pipefail
           chart_file="charts/${INPUT_CHART}/Chart.yaml"
-          if [ ! -f "$chart_file" ]; then
-            echo "::error::Chart.yaml file not found at $chart_file"
-            exit 1
-          fi
-          echo "Chart.yaml file found at $chart_file"
+          bash hack/bump-chart-version.sh "$chart_file" "${INPUT_APP_VERSION}"
 
-          OLD_APP_VERSION=$(yq '.appVersion' "$chart_file" | tr -d '"')
-          NEW_APP_VERSION="${INPUT_APP_VERSION}"
-
-          # Strip leading "v" and any pre-release/build suffix to compare clean MAJOR.MINOR.PATCH triplets.
-          strip() { v="${1#v}"; printf '%s' "${v%%[-+]*}"; }
-          OLD_CLEAN=$(strip "$OLD_APP_VERSION")
-          NEW_CLEAN=$(strip "$NEW_APP_VERSION")
-
-          if ! [[ "$OLD_CLEAN" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Existing appVersion ($OLD_APP_VERSION) is not a clean semver triplet"
-            exit 1
-          fi
-
-          IFS='.' read -r OLD_MAJOR OLD_MINOR OLD_PATCH <<<"$OLD_CLEAN"
-          IFS='.' read -r NEW_MAJOR NEW_MINOR NEW_PATCH <<<"$NEW_CLEAN"
-
-          if [ "$OLD_CLEAN" = "$NEW_CLEAN" ]; then
-            echo "appVersion unchanged ($OLD_APP_VERSION); nothing to do"
+          if git diff --quiet -- "$chart_file"; then
+            echo "Chart.yaml unchanged; nothing to commit"
             exit 0
           fi
 
-          # Refuse downgrades — most likely a manual workflow_dispatch input mistake.
-          if [ "$NEW_MAJOR" -lt "$OLD_MAJOR" ] \
-            || { [ "$NEW_MAJOR" -eq "$OLD_MAJOR" ] && [ "$NEW_MINOR" -lt "$OLD_MINOR" ]; } \
-            || { [ "$NEW_MAJOR" -eq "$OLD_MAJOR" ] && [ "$NEW_MINOR" -eq "$OLD_MINOR" ] && [ "$NEW_PATCH" -lt "$OLD_PATCH" ]; }; then
-            echo "::error::appVersion downgrade refused: $OLD_APP_VERSION -> $NEW_APP_VERSION"
-            exit 1
-          fi
-
-          if   [ "$NEW_MAJOR" -gt "$OLD_MAJOR" ]; then BUMP=major
-          elif [ "$NEW_MINOR" -gt "$OLD_MINOR" ]; then BUMP=minor
-          else                                         BUMP=patch
-          fi
-          echo "Detected appVersion bump: $OLD_APP_VERSION -> $NEW_APP_VERSION ($BUMP)"
-
-          CHART_VERSION=$(yq '.version' "$chart_file")
-          if ! [[ "$CHART_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Existing chart version ($CHART_VERSION) is not a clean semver triplet"
-            exit 1
-          fi
-          IFS='.' read -r CM Cm Cp <<<"$CHART_VERSION"
-          case "$BUMP" in
-            major) NEW_CHART_VERSION="$((CM + 1)).0.0" ;;
-            minor) NEW_CHART_VERSION="$CM.$((Cm + 1)).0" ;;
-            patch) NEW_CHART_VERSION="$CM.$Cm.$((Cp + 1))" ;;
-          esac
-
-          yq e -i ".appVersion = \"${NEW_APP_VERSION}\"" "$chart_file"
-          yq e -i ".version    = \"${NEW_CHART_VERSION}\"" "$chart_file"
-          echo "Updated appVersion to ${NEW_APP_VERSION} and version to ${NEW_CHART_VERSION} in $chart_file"
-
+          new_chart_version=$(yq '.version' "$chart_file")
+          new_app_version=$(yq '.appVersion' "$chart_file" | tr -d '"')
           git add "$chart_file"
-          git commit -m "Set $NEW_CHART_VERSION / ${NEW_APP_VERSION} in $chart_file" || echo "appVersion was already up to date"
+          git commit -m "Set $new_chart_version / $new_app_version in $chart_file"
       - name: Git push
         run: |
           git push origin main

--- a/hack/bump-chart-version.sh
+++ b/hack/bump-chart-version.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+#
+# Bump a Helm chart's `version` based on the semver delta between its current
+# `appVersion` and a new appVersion provided as input.
+#
+# Usage: bump-chart-version.sh <chart_file> <new_app_version>
+#
+# Mapping:
+#   appVersion major  -> chart major  ( (M+1).0.0 )
+#   appVersion minor  -> chart minor  ( M.(m+1).0 )
+#   appVersion patch  -> chart patch  ( M.m.(p+1) )
+#
+# Exit codes:
+#   0  chart updated, OR appVersion unchanged (no-op)
+#   1  invalid input, downgrade refused, or malformed existing versions
+#
+# On stdout the script prints `NEW_CHART_VERSION` on the first line of the
+# trailing "result" block so callers can grep it. Diagnostic messages go to
+# stderr (or use `::error::` prefix when run under GitHub Actions).
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <chart_file> <new_app_version>" >&2
+  exit 1
+}
+
+[ "$#" -eq 2 ] || usage
+CHART_FILE="$1"
+NEW_APP_VERSION="$2"
+
+if [ ! -f "$CHART_FILE" ]; then
+  echo "::error::Chart.yaml file not found at $CHART_FILE" >&2
+  exit 1
+fi
+
+if ! [[ "$NEW_APP_VERSION" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
+  echo "::error::Invalid appVersion format: $NEW_APP_VERSION" >&2
+  exit 1
+fi
+
+OLD_APP_VERSION=$(yq '.appVersion' "$CHART_FILE" | tr -d '"')
+
+# Strip leading "v" and any pre-release/build suffix to compare clean MAJOR.MINOR.PATCH triplets.
+strip() { local v="${1#v}"; printf '%s' "${v%%[-+]*}"; }
+OLD_CLEAN=$(strip "$OLD_APP_VERSION")
+NEW_CLEAN=$(strip "$NEW_APP_VERSION")
+
+if ! [[ "$OLD_CLEAN" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "::error::Existing appVersion ($OLD_APP_VERSION) is not a clean semver triplet" >&2
+  exit 1
+fi
+
+IFS='.' read -r OLD_MAJOR OLD_MINOR OLD_PATCH <<<"$OLD_CLEAN"
+IFS='.' read -r NEW_MAJOR NEW_MINOR NEW_PATCH <<<"$NEW_CLEAN"
+
+if [ "$OLD_CLEAN" = "$NEW_CLEAN" ]; then
+  echo "appVersion unchanged ($OLD_APP_VERSION); nothing to do"
+  exit 0
+fi
+
+if [ "$NEW_MAJOR" -lt "$OLD_MAJOR" ] \
+  || { [ "$NEW_MAJOR" -eq "$OLD_MAJOR" ] && [ "$NEW_MINOR" -lt "$OLD_MINOR" ]; } \
+  || { [ "$NEW_MAJOR" -eq "$OLD_MAJOR" ] && [ "$NEW_MINOR" -eq "$OLD_MINOR" ] && [ "$NEW_PATCH" -lt "$OLD_PATCH" ]; }; then
+  echo "::error::appVersion downgrade refused: $OLD_APP_VERSION -> $NEW_APP_VERSION" >&2
+  exit 1
+fi
+
+if   [ "$NEW_MAJOR" -gt "$OLD_MAJOR" ]; then BUMP=major
+elif [ "$NEW_MINOR" -gt "$OLD_MINOR" ]; then BUMP=minor
+else                                         BUMP=patch
+fi
+
+CHART_VERSION=$(yq '.version' "$CHART_FILE")
+if ! [[ "$CHART_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "::error::Existing chart version ($CHART_VERSION) is not a clean semver triplet" >&2
+  exit 1
+fi
+IFS='.' read -r CM Cm Cp <<<"$CHART_VERSION"
+case "$BUMP" in
+  major) NEW_CHART_VERSION="$((CM + 1)).0.0" ;;
+  minor) NEW_CHART_VERSION="$CM.$((Cm + 1)).0" ;;
+  patch) NEW_CHART_VERSION="$CM.$Cm.$((Cp + 1))" ;;
+esac
+
+yq e -i ".appVersion = \"${NEW_APP_VERSION}\"" "$CHART_FILE"
+yq e -i ".version    = \"${NEW_CHART_VERSION}\"" "$CHART_FILE"
+
+echo "Detected appVersion bump: $OLD_APP_VERSION -> $NEW_APP_VERSION ($BUMP)"
+echo "Updated $CHART_FILE: version $CHART_VERSION -> $NEW_CHART_VERSION, appVersion $OLD_APP_VERSION -> $NEW_APP_VERSION"

--- a/hack/bump-chart-version.test.sh
+++ b/hack/bump-chart-version.test.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+#
+# Tests for hack/bump-chart-version.sh
+#
+# Run with: bash hack/bump-chart-version.test.sh
+# Requires `yq` (mikefarah) on PATH.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$SCRIPT_DIR/bump-chart-version.sh"
+
+if ! command -v yq >/dev/null 2>&1; then
+  echo "yq not found on PATH" >&2
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+FAIL_NAMES=()
+
+make_chart() {
+  # make_chart <dir> <version> <appVersion>
+  cat >"$1/Chart.yaml" <<YAML
+apiVersion: v2
+name: test
+version: $2
+appVersion: "$3"
+YAML
+}
+
+assert() {
+  # assert <name> <expected_exit> <expected_chart_version_or_-> <expected_app_version_or_-> <output...>
+  local name="$1" exp_exit="$2" exp_ver="$3" exp_app="$4"
+  shift 4
+  local actual_exit="$1" actual_ver="$2" actual_app="$3"
+  if [ "$actual_exit" = "$exp_exit" ] \
+     && { [ "$exp_ver" = "-" ] || [ "$actual_ver" = "$exp_ver" ]; } \
+     && { [ "$exp_app" = "-" ] || [ "$actual_app" = "$exp_app" ]; }; then
+    echo "  PASS  $name"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL  $name"
+    echo "        expected: exit=$exp_exit version=$exp_ver appVersion=$exp_app"
+    echo "        actual:   exit=$actual_exit version=$actual_ver appVersion=$actual_app"
+    FAIL=$((FAIL + 1))
+    FAIL_NAMES+=("$name")
+  fi
+}
+
+run_case() {
+  # run_case <name> <chart_version> <old_app> <new_app> <expected_exit> <expected_chart_after> <expected_app_after>
+  local name="$1" chart_ver="$2" old_app="$3" new_app="$4" exp_exit="$5" exp_ver="$6" exp_app="$7"
+  local tmp; tmp=$(mktemp -d)
+  make_chart "$tmp" "$chart_ver" "$old_app"
+  bash "$SCRIPT" "$tmp/Chart.yaml" "$new_app" >/dev/null 2>&1
+  local rc=$?
+  local actual_ver actual_app
+  actual_ver=$(yq '.version' "$tmp/Chart.yaml")
+  actual_app=$(yq '.appVersion' "$tmp/Chart.yaml" | tr -d '"')
+  assert "$name" "$exp_exit" "$exp_ver" "$exp_app" "$rc" "$actual_ver" "$actual_app"
+  rm -rf "$tmp"
+}
+
+echo "Running bump-chart-version.sh tests..."
+
+# Happy paths: each segment moves
+run_case "patch bump"                      "0.39.3" "v1.11.3" "v1.11.4"      0 "0.39.4" "v1.11.4"
+run_case "minor bump resets patch"         "0.39.3" "v1.11.3" "v1.12.0"      0 "0.40.0" "v1.12.0"
+run_case "major bump resets minor+patch"   "0.39.3" "v1.11.3" "v2.0.0"       0 "1.0.0"  "v2.0.0"
+
+# Pre-release suffix is stripped for comparison but written through unchanged.
+run_case "pre-release counts toward minor" "0.39.3" "v1.11.3" "v1.12.0-rc.1" 0 "0.40.0" "v1.12.0-rc.1"
+
+# No-op: file untouched.
+run_case "unchanged is no-op"              "0.39.3" "v1.11.3" "v1.11.3"      0 "0.39.3" "v1.11.3"
+
+# Downgrade: error, file untouched.
+run_case "minor downgrade refused"         "0.39.3" "v1.11.3" "v1.10.9"      1 "0.39.3" "v1.11.3"
+run_case "patch downgrade refused"         "0.39.3" "v1.11.3" "v1.11.2"      1 "0.39.3" "v1.11.3"
+run_case "major downgrade refused"         "0.39.3" "v2.0.0"  "v1.99.99"     1 "0.39.3" "v2.0.0"
+
+# Skipping segments still classifies as the highest moved segment.
+run_case "minor skip (1.11 -> 1.13)"       "0.39.3" "v1.11.3" "v1.13.0"      0 "0.40.0" "v1.13.0"
+run_case "major skip (1.x -> 3.0.0)"       "0.39.3" "v1.11.3" "v3.0.0"       0 "1.0.0"  "v3.0.0"
+
+# appVersion without the leading "v" still works (some charts store it that way).
+run_case "no-v prefix old, v-prefix new"   "0.39.3" "1.11.3"  "v1.12.0"      0 "0.40.0" "v1.12.0"
+
+# Invalid new appVersion format -> error before mutation.
+tmp=$(mktemp -d); make_chart "$tmp" "0.39.3" "v1.11.3"
+bash "$SCRIPT" "$tmp/Chart.yaml" "not-a-version" >/dev/null 2>&1; rc=$?
+actual_ver=$(yq '.version' "$tmp/Chart.yaml"); actual_app=$(yq '.appVersion' "$tmp/Chart.yaml" | tr -d '"')
+assert "invalid new appVersion refused" 1 "0.39.3" "v1.11.3" "$rc" "$actual_ver" "$actual_app"
+rm -rf "$tmp"
+
+# Missing chart file -> error.
+bash "$SCRIPT" "/nonexistent/Chart.yaml" "v1.0.0" >/dev/null 2>&1; rc=$?
+assert "missing chart file errors" 1 "-" "-" "$rc" "-" "-"
+
+# Wrong arg count -> error.
+bash "$SCRIPT" "only-one-arg" >/dev/null 2>&1; rc=$?
+assert "wrong arg count errors" 1 "-" "-" "$rc" "-" "-"
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  printf '  - %s\n' "${FAIL_NAMES[@]}"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

The `update-chart-parameters` workflow set a chart's `appVersion` from the manual `workflow_dispatch` input but **always** bumped the chart `version` by a single PATCH. When the underlying app received a minor or major release, chart consumers still saw a patch-shaped Helm version.

Recent history shows the gap — e.g., `kubernetes-graphql-gateway` went `v1.10.5 → v1.11.0` (app minor) but the chart only went `0.38.21 → 0.38.22`.

This change detects the semver delta between the previous `appVersion` (still in `Chart.yaml` before overwrite) and the new input, and bumps the chart's MAJOR / MINOR / PATCH segment accordingly.

- App **major** bump → chart **major** bump (true mirror).
- App **minor** bump → chart **minor** bump.
- App **patch** bump → chart **patch** bump (current behavior).
- App version **unchanged** → no-op, exit 0 without touching the file.
- App **downgrade** → `::error::` and fail the workflow.

Pre-release / build-metadata suffixes on the input (e.g. `v1.12.0-rc.1`) are stripped before comparison, so a `-rc` release counts toward whichever segment moved.

## Structure

- `hack/bump-chart-version.sh` — the bump logic, takes `<chart_file> <new_app_version>`.
- `hack/bump-chart-version.test.sh` — 14 cases exercising the bump matrix, pre-release suffixes, no-op, downgrade refusal, and malformed input. Runs locally with just `yq` on PATH.
- `.github/workflows/hack-tests.yml` — runs the test suite on PRs that touch the script.
- `.github/workflows/update-chart-parameters.yaml` — slimmed down to call the script and commit the result.

## Verification

`bash hack/bump-chart-version.test.sh` — 14/14 pass locally. The new `hack-tests.yml` workflow runs the same suite in CI on this PR.