### PR TITLE
fix: declaration of secrets in platform-mesh-operator deployment

### DIFF
--- a/charts/platform-mesh-operator/Chart.yaml
+++ b/charts/platform-mesh-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: platform-mesh-operator
 description: A Helm chart to automate bootstrapping of new environment
 type: application
-version: 0.23.4
+version: 0.23.5
 appVersion: "v0.75.3"
 dependencies:
   - name: common

--- a/charts/platform-mesh-operator/templates/deployment.yaml
+++ b/charts/platform-mesh-operator/templates/deployment.yaml
@@ -68,14 +68,18 @@ spec:
       - name: external-infra-deployment
         secret:
           secretName: {{ .Values.remoteInfra.secretName }}
-          secretKey: {{ .Values.remoteInfra.secretKey }}
+          items:
+          - key: {{ .Values.remoteInfra.secretKey }}
+            path: kubeconfig
           defaultMode: 420
       {{- end }}
       {{- if .Values.remoteRuntime.enabled }}
       - name: external-platformmesh-deployment
         secret:
           secretName: {{ .Values.remoteRuntime.secretName }}
-          secretKey: {{ .Values.remoteRuntime.secretKey }}
+          items:
+          - key: {{ .Values.remoteRuntime.secretKey }}
+            path: kubeconfig
           defaultMode: 420
       {{- end }}
       {{- end }}

--- a/charts/platform-mesh-operator/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform-mesh-operator/tests/__snapshot__/deployment_test.yaml.snap
@@ -471,12 +471,16 @@ enable remote PlatformMesh and Infra:
             - name: external-infra-deployment
               secret:
                 defaultMode: 420
-                secretKey: kubeconfig
+                items:
+                  - key: kubeconfig
+                    path: kubeconfig
                 secretName: kubeconfig-platformmesh
             - name: external-platformmesh-deployment
               secret:
                 defaultMode: 420
-                secretKey: kubeconfig
+                items:
+                  - key: kubeconfig
+                    path: kubeconfig
                 secretName: kubeconfig-deployment
 enables istio sidecar injection:
   1: |

--- a/charts/virtual-workspaces/Chart.yaml
+++ b/charts/virtual-workspaces/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: virtual-workspaces
 description: A Helm chart to deploy platform-mesh virtual-workspaces
 type: application
-version: 0.5.2
-appVersion: "v0.13.2"
+version: 0.5.3
+appVersion: "v0.13.3"
 dependencies:
   - name: common
     version: 0.12.2


### PR DESCRIPTION
The way the secret for the remote setup was referenced in the K8s Deployment was wrong as to the spec of K8s Deployment resources. This has been fixed