### PR TITLE
chore: bump chart versions across multiple Helm charts

### DIFF
--- a/charts/account-operator-crds/Chart.yaml
+++ b/charts/account-operator-crds/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: account-operator-crds
 description: A Helm chart for Kubernetes
 type: application
-version: 0.2.6
+version: 0.2.7
 appVersion: "0.0.0"

--- a/charts/account-operator/Chart.yaml
+++ b/charts/account-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: account-operator
 description: A Helm chart to deploy platform-mesh Account-Operator
 type: application
-version: 0.15.106
+version: 0.15.107
 appVersion: "v0.14.41"
 dependencies:
   - name: account-operator-crds

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart containing reuse templates
 
 type: library
 
-version: 0.12.2
+version: 0.12.3

--- a/charts/example-httpbin-operator/Chart.yaml
+++ b/charts/example-httpbin-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: example-httpbin-operator
 description: A Helm chart for deploying the httpbin operator and its CRDs
 type: application
-version: 0.5.16
+version: 0.5.17
 appVersion: "v0.6.2"
 annotations:
   # Automatically install and upgrade CRDs

--- a/charts/extension-manager-operator-crds/Chart.yaml
+++ b/charts/extension-manager-operator-crds/Chart.yaml
@@ -3,5 +3,5 @@ name: extension-manager-operator-crds
 description: A Helm chart for Kubernetes
 
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: "0.0.0"

--- a/charts/extension-manager-operator/Chart.yaml
+++ b/charts/extension-manager-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: extension-manager-operator
 description: A Helm chart for extension-manager-operator which manages resources like ContentConfigurations and exposes REST `/validate` endpoint
 type: application
-version: 0.37.6
+version: 0.37.7
 appVersion: "v0.9.6"
 dependencies:
   - name: extension-manager-operator-crds

--- a/charts/iam-service/Chart.yaml
+++ b/charts/iam-service/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: iam-service
 description: A Helm chart for Kubernetes
-version: 0.16.6
+version: 0.16.7
 appVersion: v0.17.6
 dependencies:
   - name: common

--- a/charts/iam-ui/Chart.yaml
+++ b/charts/iam-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v0.12.1"
 description: Helm Chart for the iam-ui
 name: iam-ui
-version: 0.7.1
+version: 0.7.2
 dependencies:
   - name: common
     version: 0.12.2

--- a/charts/infra/Chart.yaml
+++ b/charts/infra/Chart.yaml
@@ -2,7 +2,7 @@ type: application
 apiVersion: v2
 name: infra
 description: A Helm chart for Kubernetes
-version: 0.30.1
+version: 0.30.2
 appVersion: "0.0.0"
 
 dependencies:

--- a/charts/kubernetes-graphql-gateway-crds/Chart.yaml
+++ b/charts/kubernetes-graphql-gateway-crds/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: kubernetes-graphql-gateway-crds
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "0.0.0"

--- a/charts/kubernetes-graphql-gateway/Chart.yaml
+++ b/charts/kubernetes-graphql-gateway/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.42.0
+version: 0.42.1
 appVersion: v1.16.0
 name: kubernetes-graphql-gateway
 description: Basic helm chart that contains listener and gateway

--- a/charts/marketplace-ui/Chart.yaml
+++ b/charts/marketplace-ui/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "v0.12.7"
 description: Helm Chart for the marketplace-ui
 name: marketplace-ui
-version: 0.7.7
+version: 0.7.8
 dependencies:
   - name: common
     version: 0.12.2

--- a/charts/observability/Chart.yaml
+++ b/charts/observability/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability
 description: OpenTelemetry-based observability stack for platform-mesh
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: "0.0.0"
 dependencies:
   - name: prometheus-operator-crds

--- a/charts/observability/README.md
+++ b/charts/observability/README.md
@@ -90,7 +90,7 @@ Example
 ```
 # observability
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
 
 OpenTelemetry-based observability stack for platform-mesh
 

--- a/charts/platform-mesh-operator-crds/Chart.yaml
+++ b/charts/platform-mesh-operator-crds/Chart.yaml
@@ -4,6 +4,6 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.6.0
+version: 0.6.1
 
 appVersion: "0.0.0"

--- a/charts/platform-mesh-operator/Chart.yaml
+++ b/charts/platform-mesh-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: platform-mesh-operator
 description: A Helm chart to automate bootstrapping of new environment
 type: application
-version: 0.23.6
+version: 0.23.7
 appVersion: "v0.75.4"
 dependencies:
   - name: common

--- a/charts/rebac-authz-webhook/Chart.yaml
+++ b/charts/rebac-authz-webhook/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: rebac-authz-webhook
 description: A Helm chart for Kubernetes
 type: application
-version: 0.17.3
+version: 0.17.4
 appVersion: "v0.9.3"
 dependencies:
   - name: common

--- a/charts/security-operator-crds/Chart.yaml
+++ b/charts/security-operator-crds/Chart.yaml
@@ -4,5 +4,5 @@ description: A Helm chart for Kubernetes
 
 type: application
 
-version: 0.4.0
+version: 0.4.1
 appVersion: "0.0.0"

--- a/charts/security-operator/Chart.yaml
+++ b/charts/security-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: security-operator
 description: A Helm chart for security-operator
 type: application
-version: 0.31.7
+version: 0.31.8
 appVersion: "v0.33.8"
 dependencies:
   - name: security-operator-crds

--- a/charts/security-operator/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/security-operator/tests/__snapshot__/deployment_test.yaml.snap
@@ -65,7 +65,7 @@ operator match the snapshot:
   3: |
     apiVersion: v1
     data:
-      coreModule.fga: |2-
+      coreModule.fga: |-
         module core
 
         type user
@@ -810,7 +810,7 @@ operator match the snapshot w. sentry:
   3: |
     apiVersion: v1
     data:
-      coreModule.fga: |2-
+      coreModule.fga: |-
         module core
 
         type user

--- a/charts/security-operator/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/security-operator/tests/__snapshot__/deployment_test.yaml.snap
@@ -65,7 +65,7 @@ operator match the snapshot:
   3: |
     apiVersion: v1
     data:
-      coreModule.fga: |-
+      coreModule.fga: |2-
         module core
 
         type user
@@ -810,7 +810,7 @@ operator match the snapshot w. sentry:
   3: |
     apiVersion: v1
     data:
-      coreModule.fga: |-
+      coreModule.fga: |2-
         module core
 
         type user

--- a/charts/terminal-controller-manager/Chart.yaml
+++ b/charts/terminal-controller-manager/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: terminal-controller-manager
 description: A Helm chart to deploy platform-mesh Terminal Controller Manager
 type: application
-version: 0.4.0
+version: 0.4.1
 appVersion: "v0.6.0"
 dependencies:
   - name: common

--- a/charts/virtual-workspaces/Chart.yaml
+++ b/charts/virtual-workspaces/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: virtual-workspaces
 description: A Helm chart to deploy platform-mesh virtual-workspaces
 type: application
-version: 0.5.3
+version: 0.5.4
 appVersion: "v0.13.3"
 dependencies:
   - name: common


### PR DESCRIPTION
refers to https://github.com/platform-mesh/helm-charts/issues/1865

Since the service and aggregator OCM workflows in `ocm` repo were failing for almost 24h, this is needed to trigger version updates for all changes during this period.