### PR TITLE
fix(local-setup): append root CA to kcp admin kubeconfig

### DIFF
--- a/local-setup/scripts/createKcpAdminKubeconfig.sh
+++ b/local-setup/scripts/createKcpAdminKubeconfig.sh
@@ -7,5 +7,15 @@ KCP_URL=https://localhost:8443
 
 mkdir -p $PWD/.secret/kcp
 kubectl --context kind-platform-mesh get secret kubeconfig-kcp-admin -n platform-mesh-system -o=jsonpath='{.data.kubeconfig}'|base64 -d > $PWD/.secret/kcp/admin.kubeconfig
+
+# kcp-operator embeds only the intermediate CA (root-server-ca) in
+# certificate-authority-data. Node's TLS stack rejects this with
+# UNABLE_TO_GET_ISSUER_CERT because the chain doesn't terminate at a
+# self-signed anchor. Append the kcp root CA so Node-based clients (e.g.
+# the portal backend via @kubernetes/client-node) can validate.
+ROOT_CA_PEM=$(kubectl --context kind-platform-mesh -n platform-mesh-system get secret root-ca -o=jsonpath='{.data.ca\.crt}' | base64 -d)
+INT_CA_PEM=$(yq -r '.clusters[0].cluster["certificate-authority-data"]' $PWD/.secret/kcp/admin.kubeconfig | base64 -d)
+COMBINED_CA=$(printf '%s\n%s\n' "$INT_CA_PEM" "$ROOT_CA_PEM" | base64 -w0)
+yq -i "(.clusters[].cluster.\"certificate-authority-data\") = \"$COMBINED_CA\"" $PWD/.secret/kcp/admin.kubeconfig
 # kubectl --kubeconfig=$PWD/.secret/kcp/admin.kubeconfig config set-context workspace.kcp.io/current --cluster=workspace.kcp.io/current --user=kcp-admin
 # kubectl --kubeconfig=$PWD/.secret/kcp/admin.kubeconfig config use-context workspace.kcp.io/current


### PR DESCRIPTION
## PR description

### What

Append the kcp root CA (`root-ca`) to `certificate-authority-data` in the generated `.secret/kcp/admin.kubeconfig`. The bundle now contains both the intermediate (`root-server-ca`) and the self-signed root.

### Why

`kcp-operator` emits a kubeconfig where `certificate-authority-data` contains only the intermediate CA `root-server-ca` (signed by `root-ca`). Go-based clients (`kubectl`, controllers) accept this, but Node-based clients fail TLS validation with `UNABLE_TO_GET_ISSUER_CERT` because OpenSSL requires the chain to terminate at a self-signed anchor.

This surfaced via the portal backend (`@kubernetes/client-node`) when talking to `https://root.kcp.localhost:8443`:

```
FetchError: request to https://root.kcp.localhost:8443/clusters/root:platform-mesh-system/... failed,
reason: unable to get issuer certificate
code: 'UNABLE_TO_GET_ISSUER_CERT'
```

`NODE_EXTRA_CA_CERTS` does not help here — `@kubernetes/client-node` builds its own `https.Agent` from the kubeconfig's `ca` and bypasses Node's default trust store.

Closes #1846.

### Scope

Local setup only. The in-cluster `kubeconfig-kcp-admin` and `portal-kubeconfig` secrets are still emitted by `kcp-operator` with the partial chain — the proper fix belongs upstream in `kcp-operator`'s `Kubeconfig` reconciler (embed the full chain). A follow-up will track that.

### Test plan

- [x] Run `bash local-setup/scripts/createKcpAdminKubeconfig.sh`
- [x] Confirm the bundle contains two certs:
  ```sh
  yq -r '.clusters[0].cluster["certificate-authority-data"]' .secret/kcp/admin.kubeconfig \
    | base64 -d | grep -c "BEGIN CERTIFICATE"   # expect: 2
  ```
- [x] Run the portal backend locally against the kubeconfig and hit a kcp endpoint — no `UNABLE_TO_GET_ISSUER_CERT`.
