### PR TITLE
chore(local-setup): reduce OCM GHCR reconciliation pressure

### DIFF
--- a/local-setup/kustomize/base/ocm-k8s-toolkit/ocm-k8s-toolkit.yaml
+++ b/local-setup/kustomize/base/ocm-k8s-toolkit/ocm-k8s-toolkit.yaml
@@ -26,4 +26,4 @@ spec:
   values:
     manager:
       concurrency:
-        resource: 6
+        resource: 3

--- a/local-setup/kustomize/base/ocm-k8s-toolkit/ocm-k8s-toolkit.yaml
+++ b/local-setup/kustomize/base/ocm-k8s-toolkit/ocm-k8s-toolkit.yaml
@@ -17,7 +17,7 @@ metadata:
   namespace: default
 spec:
   releaseName: ocm-k8s-toolkit
-  interval: 1m
+  interval: 5m
   timeout: 15m
   targetNamespace: ocm-system
   chartRef:
@@ -26,4 +26,4 @@ spec:
   values:
     manager:
       concurrency:
-        resource: 21
+        resource: 6


### PR DESCRIPTION
 ## Summary

  Reduce GHCR request pressure from local setup by smoothing OCM reconciliation bursts and lowering steady polling frequency.

  ## Changes

  - Lower OCM Toolkit resource reconciliation concurrency from `21` to `3`.
  - Increase the local setup root OCM `Component` interval from `1m` to `5m`.
  - Increase the local setup OCM `Repository` interval from `1m` to `5m`.

  ## Impact

  This preserves the existing local setup validation path, including Renovate OCM component bump PRs, while reducing how aggressively CI and local setup hit `ghcr.io/platform-mesh`.

  The concurrency change reduces peak burst traffic when many OCM `Resource` objects are created at once. The interval changes reduce repeated polling after the initial reconcile.

  This does not remove OCM/GHCR usage or change GHCR rate limits. It should make `429 toomanyrequests` less likely by spreading requests over time. Local setup may take longer to retry or refresh OCM state after transient failures.