### PR TITLE
fix: update sharding overlays

### DIFF
--- a/local-setup/kustomize/components/platform-mesh-operator-resource/default-profile.yaml
+++ b/local-setup/kustomize/components/platform-mesh-operator-resource/default-profile.yaml
@@ -192,7 +192,7 @@ data:
                 clusterIP: 10.96.0.100
                 port: 8443
               image:
-                tag: "0.31.0"
+                tag: v0.31.0
               rootShard:
                 extraArgs:
                 - --feature-gates=WorkspaceAuthentication=true

--- a/local-setup/kustomize/components/platform-mesh-operator-resource/default-profile.yaml
+++ b/local-setup/kustomize/components/platform-mesh-operator-resource/default-profile.yaml
@@ -192,7 +192,7 @@ data:
                 clusterIP: 10.96.0.100
                 port: 8443
               image:
-                tag: v0.31.0
+                tag: ""
               rootShard:
                 extraArgs:
                 - --feature-gates=WorkspaceAuthentication=true

--- a/local-setup/kustomize/components/platform-mesh-operator-resource/default-profile.yaml
+++ b/local-setup/kustomize/components/platform-mesh-operator-resource/default-profile.yaml
@@ -192,7 +192,7 @@ data:
                 clusterIP: 10.96.0.100
                 port: 8443
               image:
-                tag: ""
+                tag: "0.31.0"
               rootShard:
                 extraArgs:
                 - --feature-gates=WorkspaceAuthentication=true

--- a/local-setup/kustomize/overlays/platform-mesh-resource-prerelease-sharded/kustomization.yaml
+++ b/local-setup/kustomize/overlays/platform-mesh-resource-prerelease-sharded/kustomization.yaml
@@ -6,6 +6,29 @@ patches:
   - target:
       kind: PlatformMesh
       name: platform-mesh
-    patch: |
-      - op: remove
-        path: /spec/values/infra/values/kcp/shards
+      namespace: platform-mesh-system
+    patch: |-
+      - op: add
+        path: /spec/values
+        value:
+          services:
+            infra:
+              values:
+                kcp:
+                  image:
+                    tag: "15923aca7"
+                  shards:
+                    - name: nereus
+                    - name: triton
+            portal:
+              values:
+                hostAliases:
+                  entries:
+                    - ip: "10.96.188.4"
+                      hostnames:
+                        - "localhost"
+                        - "portal.localhost"
+                        - "kcp.localhost"
+                        - "root.kcp.localhost"
+                        - "nereus.kcp.localhost"
+                        - "triton.kcp.localhost"

--- a/local-setup/kustomize/overlays/platform-mesh-resource-prerelease-sharded/kustomization.yaml
+++ b/local-setup/kustomize/overlays/platform-mesh-resource-prerelease-sharded/kustomization.yaml
@@ -20,15 +20,3 @@ patches:
                   shards:
                     - name: nereus
                     - name: triton
-            portal:
-              values:
-                hostAliases:
-                  entries:
-                    - ip: "10.96.188.4"
-                      hostnames:
-                        - "localhost"
-                        - "portal.localhost"
-                        - "kcp.localhost"
-                        - "root.kcp.localhost"
-                        - "nereus.kcp.localhost"
-                        - "triton.kcp.localhost"

--- a/local-setup/kustomize/overlays/platform-mesh-resource-sharded/kustomization.yaml
+++ b/local-setup/kustomize/overlays/platform-mesh-resource-sharded/kustomization.yaml
@@ -6,6 +6,30 @@ patches:
   - target:
       kind: PlatformMesh
       name: platform-mesh
-    patch: |
-      - op: remove
-        path: /spec/values/infra/values/kcp/shards
+      namespace: platform-mesh-system
+    patch: |-
+      - op: add
+        path: /spec/values
+        value:
+          services:
+            infra:
+              values:
+                kcp:
+                # TODO remove commit image tag when released version is compatible
+                  image:
+                    tag: "15923aca7"
+                  shards:
+                    - name: nereus
+                    - name: triton
+            portal:
+              values:
+                hostAliases:
+                  entries:
+                    - ip: "10.96.188.4"
+                      hostnames:
+                        - "localhost"
+                        - "portal.localhost"
+                        - "kcp.localhost"
+                        - "root.kcp.localhost"
+                        - "nereus.kcp.localhost"
+                        - "triton.kcp.localhost"

--- a/local-setup/kustomize/overlays/platform-mesh-resource-sharded/kustomization.yaml
+++ b/local-setup/kustomize/overlays/platform-mesh-resource-sharded/kustomization.yaml
@@ -21,15 +21,3 @@ patches:
                   shards:
                     - name: nereus
                     - name: triton
-            portal:
-              values:
-                hostAliases:
-                  entries:
-                    - ip: "10.96.188.4"
-                      hostnames:
-                        - "localhost"
-                        - "portal.localhost"
-                        - "kcp.localhost"
-                        - "root.kcp.localhost"
-                        - "nereus.kcp.localhost"
-                        - "triton.kcp.localhost"


### PR DESCRIPTION
On-behalf-of: SAP aleh.yarshou@sap.com

This pr makes sharding task commands work again after introduction of profile map. It's related to this sharding issue https://github.com/platform-mesh/helm-charts/issues/1848

Also it uses commit tag of kcp for sharding commands. It will be removed when this commit is released or added to already existing releases of kcp https://github.com/kcp-dev/kcp/commit/3ec15ed3773006033aeae3b472c4a6d5bd47231c