### PR TITLE
fix: update admin kubeconfig creation script

### DIFF
--- a/local-setup/scripts/createKcpAdminKubeconfig.sh
+++ b/local-setup/scripts/createKcpAdminKubeconfig.sh
@@ -4,9 +4,16 @@ KCP_CA_SECRET=root-frontproxy-server
 KCP_ADMIN_SECRET=kcp-cluster-admin-client-cert
 KCP_URL=https://localhost:8443
 #KCP_URL=https://kcp.api.portal.cc-one.showroom.apeirora.eu
+SHARDED=${1:-false}
 
 mkdir -p $PWD/.secret/kcp
 kubectl --context kind-platform-mesh get secret kubeconfig-kcp-admin -n platform-mesh-system -o=jsonpath='{.data.kubeconfig}'|base64 -d > $PWD/.secret/kcp/admin.kubeconfig
+
+# TODO remove when kcp-operator uses front-proxy address for kcp-admin kubeconfig instead of root shard
+# Override server URLs to use localhost (front-proxy host) instead of root.kcp.localhost only in sharded mode
+if [ "$SHARDED" = true ]; then
+sed -i 's|https://root\.kcp\.localhost:8443/|https://localhost:8443/|g' $PWD/.secret/kcp/admin.kubeconfig
+fi
 
 # kcp-operator embeds only the intermediate CA (root-server-ca) in
 # certificate-authority-data. Node's TLS stack rejects this with

--- a/local-setup/scripts/start.sh
+++ b/local-setup/scripts/start.sh
@@ -232,7 +232,7 @@ if [ "$EXAMPLE_DATA" = true ]; then
 fi
 
 echo -e "${COL}[$(date '+%H:%M:%S')] Preparing kcp Secrets for admin access ${COL_RES}"
-$SCRIPT_DIR/createKcpAdminKubeconfig.sh
+$SCRIPT_DIR/createKcpAdminKubeconfig.sh $SHARDED
 
 # Run post-platform-mesh hook if it exists (PlatformMesh is ready, kcp is accessible)
 if [ -f "$SCRIPT_DIR/post-platform-mesh-hook.sh" ]; then


### PR DESCRIPTION
On-behalf-of: SAP aleh.yarshou@sap.com
Motivation: kcp-operator generates admin kubeconfig which references root shard instead of the front-proxy. In 1 shard mode everything is fine, but in multi sharded setup using admin kubeconfig it's possible to access logical clusters only from root shard.

This pr replaces root address with front-proxy address and is related to this issue https://github.com/platform-mesh/helm-charts/issues/1848