### PR TITLE
chore: remove deprecated --cached flag and local-setup:cached:* tasks

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -357,16 +357,6 @@ tasks:
       - ./local-setup/scripts/start.sh {{.FLAGS}}
 
   # Convenience aliases with common flag combinations
-  local-setup:cached:
-    cmds:
-      - task: local-setup
-        vars: {FLAGS: "--cached"}
-
-  local-setup:cached:iterate:
-    cmds:
-      - task: local-setup:iterate
-        vars: {FLAGS: "--cached"}
-
   local-setup:example-data:
     cmds:
       - task: local-setup
@@ -376,16 +366,6 @@ tasks:
     cmds:
       - task: local-setup:iterate
         vars: {FLAGS: "--example-data"}
-
-  local-setup:cached:example-data:
-    cmds:
-      - task: local-setup
-        vars: {FLAGS: "--cached --example-data"}
-
-  local-setup:cached:example-data:iterate:
-    cmds:
-      - task: local-setup:iterate
-        vars: {FLAGS: "--cached --example-data"}
 
   local-setup:prerelease:
     cmds:
@@ -397,6 +377,16 @@ tasks:
       - task: local-setup:iterate
         vars: {FLAGS: "--prerelease --iterate"}
 
+  local-setup:prerelease:concurrent:
+    cmds:
+      - task: local-setup
+        vars: {FLAGS: "--prerelease --concurrent"}
+
+  local-setup:prerelease:concurrent:iterate:
+    cmds:
+      - task: local-setup:iterate
+        vars: {FLAGS: "--prerelease --concurrent --iterate"}
+
   local-setup:prerelease:example-data:
     cmds:
       - task: local-setup
@@ -406,36 +396,6 @@ tasks:
     cmds:
       - task: local-setup:iterate
         vars: {FLAGS: "--prerelease --example-data --iterate"}
-
-  local-setup:cached:prerelease:
-    cmds:
-      - task: local-setup
-        vars: {FLAGS: "--cached --prerelease"}
-
-  local-setup:cached:prerelease:iterate:
-    cmds:
-      - task: local-setup:iterate
-        vars: {FLAGS: "--cached --prerelease --iterate"}
-
-  local-setup:cached:prerelease:example-data:
-    cmds:
-      - task: local-setup
-        vars: {FLAGS: "--cached --prerelease --example-data"}
-
-  local-setup:cached:prerelease:example-data:iterate:
-    cmds:
-      - task: local-setup:iterate
-        vars: {FLAGS: "--cached --prerelease --example-data --iterate"}
-
-  local-setup:cached:prerelease:concurrent:
-    cmds:
-      - task: local-setup
-        vars: {FLAGS: "--cached --prerelease --concurrent"}
-
-  local-setup:cached:prerelease:concurrent:iterate:
-    cmds:
-      - task: local-setup:iterate
-        vars: {FLAGS: "--cached --prerelease --concurrent --iterate"}
 
   local-setup:remote:fluxcd:
     cmds:
@@ -487,16 +447,6 @@ tasks:
       - task: local-setup:iterate
         vars: {FLAGS: "--sharded"}
 
-  local-setup:cached:sharded:
-    cmds:
-      - task: local-setup
-        vars: {FLAGS: "--cached --sharded"}
-
-  local-setup:cached:sharded:iterate:
-    cmds:
-      - task: local-setup:iterate
-        vars: {FLAGS: "--cached --sharded"}
-
   local-setup:prerelease:sharded:
     cmds:
       - task: local-setup
@@ -507,21 +457,6 @@ tasks:
       - task: local-setup:iterate
         vars: {FLAGS: "--prerelease --sharded --iterate"}
 
-  local-setup:cached:prerelease:sharded:
-    cmds:
-      - task: local-setup
-        vars: {FLAGS: "--cached --prerelease --sharded"}
-
-  local-setup:cached:prerelease:sharded:iterate:
-    cmds:
-      - task: local-setup:iterate
-        vars: {FLAGS: "--cached --prerelease --sharded"}
-
-  local-setup:cached:sharded:example-data:
-    cmds:
-      - task: local-setup
-        vars: {FLAGS: "--cached --sharded --example-data"}
-
   local-setup:sharded:example-data:
     cmds:
       - task: local-setup
@@ -531,8 +466,3 @@ tasks:
     cmds:
       - task: local-setup:iterate
         vars: {FLAGS: "--sharded --example-data"}
-        
-  local-setup:cached:sharded:example-data:iterate:
-    cmds:
-      - task: local-setup:iterate
-        vars: {FLAGS: "--cached --sharded --example-data"}

--- a/local-setup/DEVELOPERS.md
+++ b/local-setup/DEVELOPERS.md
@@ -10,11 +10,8 @@ The simplest way to test local chart changes is using the `--prerelease` flag:
 # Full setup with locally built components (deletes existing cluster)
 task local-setup:prerelease
 
-# With caching for faster image pulls
-task local-setup:cached:prerelease
-
 # With concurrent chart builds (faster on multi-core systems)
-task local-setup:cached:prerelease:concurrent
+task local-setup:prerelease:concurrent
 ```
 
 This automatically:
@@ -31,11 +28,8 @@ If you already have a running cluster and want to test prerelease changes withou
 # Reuse existing cluster (faster, no cluster recreation)
 task local-setup:prerelease:iterate
 
-# With caching
-task local-setup:cached:prerelease:iterate
-
 # With concurrent chart builds
-task local-setup:cached:prerelease:concurrent:iterate
+task local-setup:prerelease:concurrent:iterate
 ```
 
 This is the recommended approach for iterative development as it:

--- a/local-setup/README.md
+++ b/local-setup/README.md
@@ -158,38 +158,6 @@ kind delete cluster --name platform-mesh
 - Example provider workspace: `root:providers:httpbin-provider`
 - HTTPBin provider configuration demonstrating provider integration patterns
 
-### 3. Alternative: Bootstrap with Image Caching
-
-Image caching speeds up cluster recreation by using local Docker registry mirrors. The registry setup is automatically handled by the script.
-
-**Using Task:**
-
-```sh
-# Full setup with caching
-task local-setup:cached
-
-# Iterate on existing cluster
-task local-setup:cached:iterate
-
-# With example data + caching
-task local-setup:cached:example-data
-task local-setup:cached:example-data:iterate
-```
-
-**Without Task:**
-
-```sh
-# Full setup with caching
-kind delete cluster --name platform-mesh
-./local-setup/scripts/start.sh --cached
-
-# Iterate on existing cluster
-./local-setup/scripts/start.sh --cached
-
-# With example data + caching
-./local-setup/scripts/start.sh --cached --example-data
-```
-
 ### Understanding Version Options
 
 **Default:** By default, the setup uses the current tested OCM component version from the OCM registry. This reflects the version pinned in the repository configuration and is ideal for:
@@ -239,7 +207,7 @@ task local-setup:remote:argocd:example-data:iterate
 
 - Base tasks: `task local-setup`, `task local-setup:iterate`
 - With flags: `task local-setup:<flag1>:<flag2>:...`
-- Available flags: `cached`, `prerelease`, `example-data`, `concurrent`, `sharded`, `remote`
+- Available flags: `prerelease`, `example-data`, `concurrent`, `sharded`, `remote`
 - All tasks support both full setup and `:iterate` variants
 
 #### Developer information
@@ -514,7 +482,6 @@ npx playwright test test-register-and-navigate.test.ts
 ### Configuration
 
 - `kind/kind-config.yaml`: Kind cluster configuration
-- `kind/kind-config-cached.yaml`: Kind cluster configuration with cached images
 - `kustomize/`: Kubernetes manifests and overlays
 - `webhook-config/`: Authorization webhook certificates and configuration
 

--- a/local-setup/scripts/createKcpAdminKubeconfig.sh
+++ b/local-setup/scripts/createKcpAdminKubeconfig.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 KCP_CA_SECRET=root-frontproxy-server
 KCP_ADMIN_SECRET=kcp-cluster-admin-client-cert
 BASE_DOMAIN="${BASE_DOMAIN:-portal.localhost}"

--- a/local-setup/scripts/setup-registry-proxies.sh
+++ b/local-setup/scripts/setup-registry-proxies.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 # Registry Proxies Setup Script
-# This script sets up Docker/Podman registry proxies for cached mode
+# This script sets up Docker/Podman registry mirrors
 
 COL='\033[92m'
 RED='\033[91m'
 COL_RES='\033[0m'
 
 setup_registry_proxies() {
-    echo -e "${COL}[$(date '+%H:%M:%S')] Setting up registry proxies for cached mode ${COL_RES}"
+    echo -e "${COL}[$(date '+%H:%M:%S')] Setting up registry proxies ${COL_RES}"
 
     CONTAINER_RUNTIME=$(detect_container_runtime)
     if [ -z "$CONTAINER_RUNTIME" ]; then

--- a/local-setup/scripts/start.sh
+++ b/local-setup/scripts/start.sh
@@ -75,6 +75,11 @@ done
 export CONCURRENT
 export ITERATE
 
+# A stale KUBECONFIG from a previous run (e.g. pointing at .secret/kcp/admin.kubeconfig)
+# would misdirect every kubectl/helm call in this script. kind merges cluster
+# credentials into ~/.kube/config, so the default kubeconfig is always correct here.
+unset KUBECONFIG
+
 if [ "$ITERATE" = true ] && [ "$PRERELEASE" = false ]; then
   echo -e "${RED}--iterate requires --prerelease${COL_RES}" >&2
   exit 1

--- a/local-setup/scripts/start.sh
+++ b/local-setup/scripts/start.sh
@@ -34,10 +34,12 @@ ITERATE=false
 
 usage() {
   echo "Usage: $0 [--prerelease] [--example-data] [--concurrent] [--sharded] [--remote] [--deployment-tech=fluxcd|argocd] [--iterate] [--help]"
+
   echo ""
   echo "Options:"
   echo "  --prerelease       Deploy with locally built OCM components instead of released versions"
   echo "  --example-data     Install with example provider data (requires kubectl-kcp plugin)"
+
   echo "  --concurrent       Run prerelease chart builds in parallel instead of sequentially"
   echo "  --sharded          Deploy additional kcp shards"
   echo "  --remote           Use remote deployment mode with 2 kind clusters (infra + runtime)"
@@ -50,11 +52,6 @@ usage() {
 while [ $# -gt 0 ]; do
   case "$1" in
     --prerelease) PRERELEASE=true ;;
-    --cached)
-      # Deprecated: registry mirrors are always-on now; the flag is accepted
-      # for backwards compatibility with the local-setup:cached* Taskfile entries.
-      echo -e "${YELLOW}Note: --cached is deprecated; registry mirrors are now always enabled.${COL_RES}" >&2
-      ;;
     --example-data) EXAMPLE_DATA=true ;;
     --concurrent) CONCURRENT=true ;;
     --sharded) SHARDED=true ;;


### PR DESCRIPTION
  Registry mirrors are now always enabled, making --cached a no-op.
  Remove the flag, all 13 cached:* Taskfile aliases, the docs section
  describing caching as an optional setup step, and stale comments
  referencing "cached mode".

Running 

```
task local-setup:cached:example-data:iterate
```

shows 

```
task: [setup:mkcert] test -s bin/mkcert || GOBIN=$(pwd)/bin go install filippo.io/mkcert@latest
task: [setup:mkcert] export PATH=$(pwd)/bin:$PATH
task: [local-setup:iterate] ./local-setup/scripts/start.sh --cached --example-data
Note: --cached is deprecated; registry mirrors are now always enabled.
```