### PR TITLE
fix: argo has needs access to patch applications

### DIFF
--- a/charts/platform-mesh-operator/Chart.yaml
+++ b/charts/platform-mesh-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: platform-mesh-operator
 description: A Helm chart to automate bootstrapping of new environment
 type: application
-version: 0.27.0
+version: 0.27.1
 appVersion: "v0.75.30"
 dependencies:
   - name: common

--- a/charts/platform-mesh-operator/templates/cluster-role.yaml
+++ b/charts/platform-mesh-operator/templates/cluster-role.yaml
@@ -125,6 +125,7 @@ rules:
   - argoproj.io
   resources:
   - appprojects
+  - applications
   verbs:
   - create
   - delete

--- a/charts/platform-mesh-operator/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform-mesh-operator/tests/__snapshot__/deployment_test.yaml.snap
@@ -721,6 +721,7 @@ operator match the snapshot:
           - argoproj.io
         resources:
           - appprojects
+          - applications
         verbs:
           - create
           - delete


### PR DESCRIPTION
When running with Argo we encountered another missing permission `applications`:

```sh
User \"system:serviceaccount:platform-mesh-system:platform-mesh-infra-platform-mesh-operator\"
cannot patch resource \"applications\" in API group \"argoproj.io\" in the namespace \"platform-mesh-system\""
```

On-behalf-of: @SAP florian.wuermseer@sap.com