### PR TITLE
fix: add crd permissions to platform-mesh operator

### DIFF
--- a/charts/platform-mesh-operator/Chart.yaml
+++ b/charts/platform-mesh-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: platform-mesh-operator
 description: A Helm chart to automate bootstrapping of new environment
 type: application
-version: 0.27.7
+version: 0.27.8
 appVersion: "v0.75.37"
 dependencies:
   - name: common

--- a/charts/platform-mesh-operator/templates/cluster-role.yaml
+++ b/charts/platform-mesh-operator/templates/cluster-role.yaml
@@ -81,6 +81,13 @@ rules:
     - get
     - list
     - watch
+- apiGroups: ["apiextensions.k8s.io"]
+  resources:
+    - customresourcedefinitions
+  verbs:
+    - get
+    - list
+    - watch
 - apiGroups: ["cert-manager.io"]
   resources:
     - certificates

--- a/charts/platform-mesh-operator/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/platform-mesh-operator/tests/__snapshot__/deployment_test.yaml.snap
@@ -663,6 +663,14 @@ operator match the snapshot:
           - list
           - watch
       - apiGroups:
+          - apiextensions.k8s.io
+        resources:
+          - customresourcedefinitions
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
           - cert-manager.io
         resources:
           - certificates


### PR DESCRIPTION
On-behalf-of: SAP aleh.yarshou@sap.com

## Description
since 0.75.36 version of Platform-mesh operator, it has this error 

```
2026-06-15T12:43:28Z ERR workspace/pkg/subroutines/deployment.go:242 > Failed to check cert-manager CRD error="customresourcedefinitions.apiextensions.k8s.io \"issuers.cert-manager.io\" is forbidden: User \"system:serviceaccount:platform-mesh-system:platform-mesh-operator\" cannot get resource \"customresourcedefinitions\" in API group \"apiextensions.k8s.io\" at the cluster scope" crd=issuers.cert-manager.io service=/go/pkg/mod/github.com/platform-mesh/golang-commons@v0.17.8/logger/logger.go subroutine=DeploymentSubroutine                                                                                        

```
This PR adds permissions to get,list,watch crds for platform-mesh operator