### PR TITLE
fix: prerelease after image.name field removal

### DIFF
--- a/local-setup/scripts/ocm-build-local-charts.sh
+++ b/local-setup/scripts/ocm-build-local-charts.sh
@@ -161,7 +161,8 @@ prepare_and_push_chart() {
 
     # Get image name and prepare variables
     local image_name commit chart_oci_path local_chart_path
-    image_name=$(yq '.image["name"] // ""' "$PROJECT_ROOT/$chart_dir/values.yaml")
+    # Construct full image name from registry/repository
+    image_name=$(yq '.image.registry + "/" + .image.repository' "$PROJECT_ROOT/$chart_dir/values.yaml" 2>/dev/null || echo "")
     commit=$(git -C "$PROJECT_ROOT" rev-parse HEAD)
     chart_oci_path="oci://oci-registry-docker-registry.registry.svc.cluster.local/platform-mesh/$comp"
     local_chart_path="../$chart_dir"


### PR DESCRIPTION
On-behalf-of: SAP aleh.yarshou@sap.com

## Description
image.Name field was removed from values here https://github.com/platform-mesh/helm-charts/commit/8dbe8ceb81d95b20f72368045fd429c539e2baed

This pr adds support for this in prerelease script to build image reference based on the registry and repository instead of the name which was removed