### PR TITLE
feat: update secret name for root/front-proxy ca

### DIFF
--- a/charts/virtual-workspaces/Chart.yaml
+++ b/charts/virtual-workspaces/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: virtual-workspaces
 description: A Helm chart to deploy platform-mesh virtual-workspaces
 type: application
-version: 0.8.0
+version: 0.8.1
 appVersion: "v0.14.8"
 dependencies:
   - name: common

--- a/charts/virtual-workspaces/README.md
+++ b/charts/virtual-workspaces/README.md
@@ -22,7 +22,7 @@ A Helm chart to deploy platform-mesh virtual-workspaces
 | cert.key.size | int | `4096` | Key size (e.g. 2048, 3072, 4096 for RSA or 256, 384, 521 for ECDSA) |
 | cert.renewBefore | string | `"168h0m0s"` | Certificate renew before |
 | cert.secretName | string | `"virtual-workspaces-cert"` | Secret name to store the certificate |
-| clientCASecretName | string | `"root-front-proxy-client-ca"` |  |
+| clientCASecretName | string | `"frontproxy-merged-client-ca"` |  |
 | clusterAccess.marketplace.auth | object | `{"kubeconfigSecretRef":{"key":"kubeconfig","name":"virtual-workspace-clusteraccess-kubeconfig"}}` | Path for gateway url path: "" |
 | clusterAccess.marketplace.enabled | bool | `true` |  |
 | deployment.accountEntityName | string | `"core_platform-mesh_io_account"` |  |

--- a/charts/virtual-workspaces/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/virtual-workspaces/tests/__snapshot__/deployment_test.yaml.snap
@@ -125,7 +125,7 @@ virtual-workspaces match the snapshot:
                 secretName: portal-kubeconfig
             - name: client-ca-secret
               secret:
-                secretName: root-front-proxy-client-ca
+                secretName: frontproxy-merged-client-ca
             - name: vws-cert
               secret:
                 secretName: virtual-workspaces-cert

--- a/charts/virtual-workspaces/values.yaml
+++ b/charts/virtual-workspaces/values.yaml
@@ -1,6 +1,6 @@
 kubeconfigSecretName: account-operator-kubeconfig
 authenticationKubeconfigSecretName: portal-kubeconfig
-clientCASecretName: root-front-proxy-client-ca
+clientCASecretName: frontproxy-merged-client-ca
 virtualWorkspaceSecretName: virtual-workspaces-cert
 requestHeaderClientCASecretName: root-requestheader-client-ca
 


### PR DESCRIPTION
On-behalf-of: SAP aleh.yarshou@sap.com

The latest version of kcp-operator which is 0.8.0 generates this secret `frontproxy-merged-client-ca `instead of the this one` front-proxy-client-ca`. This pr changes secret name for virtual-workspace chart to support the latest version of kcp-operator
