### PR TITLE
Pass correct signature to ocm signing

### DIFF
--- a/.github/workflows/ocm-aggregator.yaml
+++ b/.github/workflows/ocm-aggregator.yaml
@@ -557,7 +557,7 @@ jobs:
         run: |
           printf '%s' "$OCM_SIGNING_PRIVATE_KEY" > /tmp/ocm-signing.priv
           printf '%s' "$OCM_SIGNING_CERT" > /tmp/ocm-signing.cert
-          ./ocm sign componentversions --signature ocm.platform-mesh --private-key /tmp/ocm-signing.priv \
+          ./ocm sign componentversions --signature helm-charts.platform-mesh --private-key /tmp/ocm-signing.priv \
           --public-key /tmp/ocm-signing.cert \
           --ca-cert .ocm/signature/ca.cert \
             "oci://ghcr.io/platform-mesh//github.com/platform-mesh/platform-mesh:${{ env.VERSION }}"

--- a/.github/workflows/ocm-service-component.yaml
+++ b/.github/workflows/ocm-service-component.yaml
@@ -101,7 +101,7 @@ jobs:
         run: |
           printf '%s' "$OCM_SIGNING_PRIVATE_KEY" > /tmp/ocm-signing.priv
           printf '%s' "$OCM_SIGNING_CERT" > /tmp/ocm-signing.cert
-          ./ocm sign componentversion --signature ocm.platform-mesh --private-key /tmp/ocm-signing.priv \
+          ./ocm sign componentversion --signature helm-charts.platform-mesh --private-key /tmp/ocm-signing.priv \
           --public-key /tmp/ocm-signing.cert \
           --ca-cert .ocm/signature/ca.cert \
             "oci://ghcr.io/platform-mesh//${{ inputs.componentName }}:${{ inputs.chartVersion }}"


### PR DESCRIPTION
The signer needs to mach the certificate used to sign: 

```text
Run printf '%s' "$OCM_SIGNING_PRIVATE_KEY" > /tmp/ocm-signing.priv
Error: public key not valid: issuer [CN=ocm.platform-mesh]: common name "helm-charts.platform-mesh" is invalid
Error: Process completed with exit code 1.
```