### PR TITLE
chore: remove unused platform-mesh-operator components from workflows and scripts

### DIFF
--- a/.github/workflows/ocm-aggregator.yaml
+++ b/.github/workflows/ocm-aggregator.yaml
@@ -287,8 +287,6 @@ jobs:
             CURRENT_KEYCLOAK=$(yq eval '.component.componentReferences[] | select(.name == "keycloak") | .version' current_pm_component.yaml 2>/dev/null || echo "")
             CURRENT_KUBERNETES_GRAPHQL_GATEWAY=$(yq eval '.component.componentReferences[] | select(.name == "kubernetes-graphql-gateway") | .version' current_pm_component.yaml 2>/dev/null || echo "")
             CURRENT_VIRTUAL_WORKSPACES=$(yq eval '.component.componentReferences[] | select(.name == "virtual-workspaces") | .version' current_pm_component.yaml 2>/dev/null || echo "")
-            CURRENT_PLATFORM_MESH_OPERATOR_COMPONENTS=$(yq eval '.component.componentReferences[] | select(.name == "platform-mesh-operator-components") | .version' current_pm_component.yaml 2>/dev/null || echo "")
-            CURRENT_PLATFORM_MESH_OPERATOR_INFRA_COMPONENTS=$(yq eval '.component.componentReferences[] | select(.name == "platform-mesh-operator-infra-components") | .version' current_pm_component.yaml 2>/dev/null || echo "")
             CURRENT_EXAMPLE_HTTPBIN_OPERATOR=$(yq eval '.component.componentReferences[] | select(.name == "example-httpbin-operator") | .version' current_pm_component.yaml 2>/dev/null || echo "")
             CURRENT_IAM_SERVICE=$(yq eval '.component.componentReferences[] | select(.name == "iam-service") | .version' current_pm_component.yaml 2>/dev/null || echo "")
             CURRENT_IAM_UI=$(yq eval '.component.componentReferences[] | select(.name == "iam-ui") | .version' current_pm_component.yaml 2>/dev/null || echo "")

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -23,8 +23,6 @@ vars:
     - infra: charts/infra
     - kubernetes-graphql-gateway: charts/kubernetes-graphql-gateway
     - platform-mesh-operator: charts/platform-mesh-operator
-    - platform-mesh-operator-components: charts/platform-mesh-operator-components
-    - platform-mesh-operator-infra-components: charts/platform-mesh-operator-infra-components
     - portal: charts/portal
     - rebac-authz-webhook: charts/rebac-authz-webhook
     - security-operator: charts/security-operator

--- a/local-setup/scripts/ocm-build-component.sh
+++ b/local-setup/scripts/ocm-build-component.sh
@@ -148,8 +148,6 @@ resolve_component_versions() {
     get_component_version virtual-workspaces github.com/platform-mesh/virtual-workspaces charts/virtual-workspaces VIRTUAL_WORKSPACES_VERSION
     get_component_version keycloak github.com/platform-mesh/keycloak "../helm-charts/keycloak/" KEYCLOAK_VERSION
     get_component_version keycloak-operator github.com/platform-mesh/keycloak-operator charts/keycloak-operator KEYCLOAK_OPERATOR_VERSION
-    get_component_version platform-mesh-operator-components github.com/platform-mesh/platform-mesh-operator-components charts/platform-mesh-operator-components PLATFORM_MESH_OPERATOR_COMPONENTS_VERSION
-    get_component_version platform-mesh-operator-infra-components github.com/platform-mesh/platform-mesh-operator-infra-components charts/platform-mesh-operator-infra-components PLATFORM_MESH_OPERATOR_INFRA_COMPONENTS_VERSION
     get_component_version iam-service github.com/platform-mesh/iam-service charts/iam-service IAM_SERVICE_VERSION
     get_component_version iam-ui github.com/platform-mesh/iam-ui charts/iam-ui IAM_UI_VERSION
     get_component_version marketplace-ui github.com/platform-mesh/marketplace-ui charts/marketplace-ui MARKETPLACE_UI_VERSION
@@ -229,7 +227,6 @@ build_final_component() {
         PM_KEYCLOAK_VERSION="$KEYCLOAK_VERSION" \
         KEYCLOAK_OPERATOR_VERSION="$KEYCLOAK_OPERATOR_VERSION" \
         VIRTUAL_WORKSPACES_VERSION="$VIRTUAL_WORKSPACES_VERSION" \
-        PLATFORM_MESH_OPERATOR_COMPONENTS_VERSION="$PLATFORM_MESH_OPERATOR_COMPONENTS_VERSION" \
         EXAMPLE_HTTPBIN_OPERATOR_VERSION="$EXAMPLE_HTTPBIN_OPERATOR_VERSION" \
         IAM_SERVICE_VERSION="$IAM_SERVICE_VERSION" \
         IAM_UI_VERSION="$IAM_UI_VERSION" \
@@ -240,7 +237,6 @@ build_final_component() {
         TRAEFIK_CRD_VERSION="$TRAEFIK_CRD_VERSION" \
         TRAEFIK_CHART_VERSION="$TRAEFIK_CHART_VERSION" \
         CERT_MANAGER_VERSION="$CERT_MANAGER_VERSION" \
-        PLATFORM_MESH_OPERATOR_INFRA_COMPONENTS_VERSION="$PLATFORM_MESH_OPERATOR_INFRA_COMPONENTS_VERSION" \
         KCP_OPERATOR_CHART_VERSION="$KCP_OPERATOR_CHART_VERSION" \
         KCP_OPERATOR_IMAGE_VERSION="$KCP_OPERATOR_IMAGE_VERSION" \
         KCP_VERSION="$KCP_VERSION" \

--- a/local-setup/scripts/ocm-build-local-charts.sh
+++ b/local-setup/scripts/ocm-build-local-charts.sh
@@ -29,8 +29,6 @@ CUSTOM_LOCAL_COMPONENTS_CHART_PATHS=(
     "kubernetes-graphql-gateway:charts/kubernetes-graphql-gateway"
     "observability:charts/observability"
     "platform-mesh-operator:charts/platform-mesh-operator"
-    "platform-mesh-operator-components:charts/platform-mesh-operator-components"
-    "platform-mesh-operator-infra-components:charts/platform-mesh-operator-infra-components"
     "portal:charts/portal"
     "rebac-authz-webhook:charts/rebac-authz-webhook"
     "security-operator:charts/security-operator"


### PR DESCRIPTION
replaces https://github.com/platform-mesh/ocm/pull/116

Removes obsolete components