### PR TITLE
feat: update component versions to PM-stamped values and add demo script for OCI migration

### DIFF
--- a/.github/workflows/ocm-aggregator.yaml
+++ b/.github/workflows/ocm-aggregator.yaml
@@ -65,7 +65,6 @@ jobs:
       KCP_VERSION: "v0.32.0"
       INIT_AGENT_CHART_VERSION: "0.2.0"
       INIT_AGENT_IMAGE_VERSION: "v0.2.0"
-      PM_OPENFGA_VERSION: "0.2.62"
       PM_KEYCLOAK_VERSION: "26.6.0"
       OPENFGA_VERSION: "0.2.62"
       OPENFGA_IMAGE_VERSION: "v1.14.0"
@@ -81,6 +80,20 @@ jobs:
       CNPG_OPERATOR_IMAGE_VERSION: "1.29.0"
       PROMETHEUS_OPERATOR_CRDS_VERSION: "29.0.0"
       KUBE_PROMETHEUS_STACK_VERSION: "27.0.0"
+      # PM-stamped component descriptor versions for third-party components.
+      # Bump these to publish a new descriptor without touching resource versions. If resource
+      # versions change, make sure to bump those as well.
+      PM_GATEWAY_API_VERSION: "0.0.1"
+      PM_TRAEFIK_VERSION: "0.0.1"
+      PM_CERT_MANAGER_VERSION: "0.0.1"
+      PM_OPENFGA_VERSION: "0.0.1"
+      PM_KCP_OPERATOR_VERSION: "0.0.1"
+      PM_KCP_VERSION: "0.0.1"
+      PM_INIT_AGENT_VERSION: "0.0.1"
+      PM_CNPG_OPERATOR_VERSION: "0.0.1"
+      PM_PROMETHEUS_OPERATOR_CRDS_VERSION: "0.0.1"
+      PM_KUBE_PROMETHEUS_STACK_VERSION: "0.0.1"
+      PM_OPENTELEMETRY_OPERATOR_VERSION: "0.0.1"
       OPENTELEMETRY_OPERATOR_VERSION: "0.114.1"
     steps:
       - name: Setup yq@latest
@@ -417,19 +430,21 @@ jobs:
             NEEDS_UPDATE=true
           fi
 
-          # Check third-party dependency versions
-          if [ "$CURRENT_KCP_OPERATOR" != "${{ env.KCP_OPERATOR_CHART_VERSION }}" ]; then
-            echo "KCP Operator: $CURRENT_KCP_OPERATOR -> ${{ env.KCP_OPERATOR_CHART_VERSION }}"
+          # Check third-party dependency versions. Third-party component descriptors are
+          # published with PM-stamped versions (PM_* env vars above), independent of the
+          # upstream resource versions, so compare against the PM-stamped value.
+          if [ "$CURRENT_KCP_OPERATOR" != "${{ env.PM_KCP_OPERATOR_VERSION }}" ]; then
+            echo "KCP Operator: $CURRENT_KCP_OPERATOR -> ${{ env.PM_KCP_OPERATOR_VERSION }}"
             NEEDS_UPDATE=true
           fi
 
-          if [ "$CURRENT_KCP" != "${{ env.KCP_VERSION }}" ]; then
-            echo "KCP: $CURRENT_KCP -> ${{ env.KCP_VERSION }}"
+          if [ "$CURRENT_KCP" != "${{ env.PM_KCP_VERSION }}" ]; then
+            echo "KCP: $CURRENT_KCP -> ${{ env.PM_KCP_VERSION }}"
             NEEDS_UPDATE=true
           fi
 
-          if [ "$CURRENT_INIT_AGENT" != "${{ env.INIT_AGENT_CHART_VERSION }}" ]; then
-            echo "Init Agent: $CURRENT_INIT_AGENT -> ${{ env.INIT_AGENT_CHART_VERSION }}"
+          if [ "$CURRENT_INIT_AGENT" != "${{ env.PM_INIT_AGENT_VERSION }}" ]; then
+            echo "Init Agent: $CURRENT_INIT_AGENT -> ${{ env.PM_INIT_AGENT_VERSION }}"
             NEEDS_UPDATE=true
           fi
 
@@ -443,38 +458,38 @@ jobs:
             NEEDS_UPDATE=true
           fi
 
-          if [ "$CURRENT_GATEWAY_API" != "${{ env.GATEWAY_API_VERSION }}" ]; then
-            echo "Gateway API: $CURRENT_GATEWAY_API -> ${{ env.GATEWAY_API_VERSION }}"
+          if [ "$CURRENT_GATEWAY_API" != "${{ env.PM_GATEWAY_API_VERSION }}" ]; then
+            echo "Gateway API: $CURRENT_GATEWAY_API -> ${{ env.PM_GATEWAY_API_VERSION }}"
             NEEDS_UPDATE=true
           fi
 
-          if [ "$CURRENT_TRAEFIK" != "${{ env.TRAEFIK_VERSION }}" ]; then
-            echo "Traefik: $CURRENT_TRAEFIK -> ${{ env.TRAEFIK_VERSION }}"
+          if [ "$CURRENT_TRAEFIK" != "${{ env.PM_TRAEFIK_VERSION }}" ]; then
+            echo "Traefik: $CURRENT_TRAEFIK -> ${{ env.PM_TRAEFIK_VERSION }}"
             NEEDS_UPDATE=true
           fi
 
-          if [ "$CURRENT_CERT_MANAGER" != "${{ env.CERT_MANAGER_VERSION }}" ]; then
-            echo "Cert Manager: $CURRENT_CERT_MANAGER -> ${{ env.CERT_MANAGER_VERSION }}"
+          if [ "$CURRENT_CERT_MANAGER" != "${{ env.PM_CERT_MANAGER_VERSION }}" ]; then
+            echo "Cert Manager: $CURRENT_CERT_MANAGER -> ${{ env.PM_CERT_MANAGER_VERSION }}"
             NEEDS_UPDATE=true
           fi
 
-          if [ "$CURRENT_CNPG_OPERATOR" != "${{ env.CNPG_OPERATOR_CHART_VERSION }}" ]; then
-            echo "CNPG Operator: $CURRENT_CNPG_OPERATOR -> ${{ env.CNPG_OPERATOR_CHART_VERSION }}"
+          if [ "$CURRENT_CNPG_OPERATOR" != "${{ env.PM_CNPG_OPERATOR_VERSION }}" ]; then
+            echo "CNPG Operator: $CURRENT_CNPG_OPERATOR -> ${{ env.PM_CNPG_OPERATOR_VERSION }}"
             NEEDS_UPDATE=true
           fi
 
-          if [ "$CURRENT_PROMETHEUS_OPERATOR_CRDS" != "${{ env.PROMETHEUS_OPERATOR_CRDS_VERSION }}" ]; then
-            echo "Prometheus Operator CRDs: $CURRENT_PROMETHEUS_OPERATOR_CRDS -> ${{ env.PROMETHEUS_OPERATOR_CRDS_VERSION }}"
+          if [ "$CURRENT_PROMETHEUS_OPERATOR_CRDS" != "${{ env.PM_PROMETHEUS_OPERATOR_CRDS_VERSION }}" ]; then
+            echo "Prometheus Operator CRDs: $CURRENT_PROMETHEUS_OPERATOR_CRDS -> ${{ env.PM_PROMETHEUS_OPERATOR_CRDS_VERSION }}"
             NEEDS_UPDATE=true
           fi
 
-          if [ "$CURRENT_KUBE_PROMETHEUS_STACK" != "${{ env.KUBE_PROMETHEUS_STACK_VERSION }}" ]; then
-            echo "Kube Prometheus Stack: $CURRENT_KUBE_PROMETHEUS_STACK -> ${{ env.KUBE_PROMETHEUS_STACK_VERSION }}"
+          if [ "$CURRENT_KUBE_PROMETHEUS_STACK" != "${{ env.PM_KUBE_PROMETHEUS_STACK_VERSION }}" ]; then
+            echo "Kube Prometheus Stack: $CURRENT_KUBE_PROMETHEUS_STACK -> ${{ env.PM_KUBE_PROMETHEUS_STACK_VERSION }}"
             NEEDS_UPDATE=true
           fi
 
-          if [ "$CURRENT_OPENTELEMETRY_OPERATOR" != "${{ env.OPENTELEMETRY_OPERATOR_VERSION }}" ]; then
-            echo "OpenTelemetry Operator: $CURRENT_OPENTELEMETRY_OPERATOR -> ${{ env.OPENTELEMETRY_OPERATOR_VERSION }}"
+          if [ "$CURRENT_OPENTELEMETRY_OPERATOR" != "${{ env.PM_OPENTELEMETRY_OPERATOR_VERSION }}" ]; then
+            echo "OpenTelemetry Operator: $CURRENT_OPENTELEMETRY_OPERATOR -> ${{ env.PM_OPENTELEMETRY_OPERATOR_VERSION }}"
             NEEDS_UPDATE=true
           fi
 
@@ -544,7 +559,17 @@ jobs:
             CNPG_OPERATOR_IMAGE_VERSION=${{ env.CNPG_OPERATOR_IMAGE_VERSION }} \
             PROMETHEUS_OPERATOR_CRDS_VERSION=${{ env.PROMETHEUS_OPERATOR_CRDS_VERSION }} \
             KUBE_PROMETHEUS_STACK_VERSION=${{ env.KUBE_PROMETHEUS_STACK_VERSION }} \
-            OPENTELEMETRY_OPERATOR_VERSION=${{ env.OPENTELEMETRY_OPERATOR_VERSION }}
+            OPENTELEMETRY_OPERATOR_VERSION=${{ env.OPENTELEMETRY_OPERATOR_VERSION }} \
+            PM_GATEWAY_API_VERSION=${{ env.PM_GATEWAY_API_VERSION }} \
+            PM_TRAEFIK_VERSION=${{ env.PM_TRAEFIK_VERSION }} \
+            PM_CERT_MANAGER_VERSION=${{ env.PM_CERT_MANAGER_VERSION }} \
+            PM_KCP_OPERATOR_VERSION=${{ env.PM_KCP_OPERATOR_VERSION }} \
+            PM_KCP_VERSION=${{ env.PM_KCP_VERSION }} \
+            PM_INIT_AGENT_VERSION=${{ env.PM_INIT_AGENT_VERSION }} \
+            PM_CNPG_OPERATOR_VERSION=${{ env.PM_CNPG_OPERATOR_VERSION }} \
+            PM_PROMETHEUS_OPERATOR_CRDS_VERSION=${{ env.PM_PROMETHEUS_OPERATOR_CRDS_VERSION }} \
+            PM_KUBE_PROMETHEUS_STACK_VERSION=${{ env.PM_KUBE_PROMETHEUS_STACK_VERSION }} \
+            PM_OPENTELEMETRY_OPERATOR_VERSION=${{ env.PM_OPENTELEMETRY_OPERATOR_VERSION }}
 
       - name: Transfer to OCM REPO
         if: steps.version_check.outputs.needs_update == 'true'

--- a/.ocm/component-constructor-aggregate.yaml
+++ b/.ocm/component-constructor-aggregate.yaml
@@ -1,11 +1,12 @@
 components:
   - name: github.com/kubernetes-sigs/gateway-api
-    version: {{ .GATEWAY_API_VERSION }}
+    version: {{ .PM_GATEWAY_API_VERSION }}
     provider:
       name: gateway-api
     resources:
       - name: crds
         type: gitOpsTemplate
+        relation: external
         version: {{ .GATEWAY_API_VERSION }}
         access:
           type: github
@@ -13,59 +14,60 @@ components:
           ref: {{ .GATEWAY_API_VERSION }}
           commit: {{ .GATEWAY_API_COMMIT }}
   - name: github.com/traefik/traefik
-    version: {{ .TRAEFIK_VERSION }}
+    version: {{ .PM_TRAEFIK_VERSION }}
     provider:
       name: traefik
     resources:
       - name: chart
         type: helmChart
+        relation: local
         version: {{ .TRAEFIK_CHART_VERSION }}
         access:
-          type: helm
-          helmChart: traefik:{{ .TRAEFIK_CHART_VERSION }}
-          helmRepository: https://traefik.github.io/charts
+          type: ociArtifact
+          imageReference: ghcr.io/platform-mesh/ocm/charts/traefik:{{ .TRAEFIK_CHART_VERSION }}
       - name: crds
         type: helmChart
+        relation: local
         version: {{ .TRAEFIK_CRD_VERSION }}
         access:
-          type: helm
-          helmChart: traefik-crds:{{ .TRAEFIK_CRD_VERSION }}
-          helmRepository: https://traefik.github.io/charts
+          type: ociArtifact
+          imageReference: ghcr.io/platform-mesh/ocm/charts/traefik-crds:{{ .TRAEFIK_CRD_VERSION }}
       - name: image
         type: ociImage
-        relation: external
+        relation: local
         version: {{ .TRAEFIK_IMAGE_VERSION }}
         access:
           type: ociArtifact
           imageReference: "docker.io/library/traefik:{{ .TRAEFIK_IMAGE_VERSION }}"
   - name: github.com/cert-manager/cert-manager
-    version: {{ .CERT_MANAGER_VERSION }}
+    version: {{ .PM_CERT_MANAGER_VERSION }}
     provider:
       name: cert-manager
     resources:
       - name: chart
         type: helmChart
+        relation: local
         version: {{ .CERT_MANAGER_VERSION }}
         access:
           type: ociArtifact
           imageReference: quay.io/jetstack/charts/cert-manager:{{ .CERT_MANAGER_VERSION }}
       - name: webhook-image
         type: ociImage
-        relation: external
+        relation: local
         version: {{ .CERT_MANAGER_VERSION }}
         access:
           type: ociArtifact
           imageReference: "quay.io/jetstack/cert-manager-webhook:{{ .CERT_MANAGER_VERSION }}"
       - name: controller-image
         type: ociImage
-        relation: external
+        relation: local
         version: {{ .CERT_MANAGER_VERSION }}
         access:
           type: ociArtifact
           imageReference: "quay.io/jetstack/cert-manager-controller:{{ .CERT_MANAGER_VERSION }}"
       - name: cainjector-image
         type: ociImage
-        relation: external
+        relation: local
         version: {{ .CERT_MANAGER_VERSION }}
         access:
           type: ociArtifact
@@ -77,124 +79,126 @@ components:
     resources:
       - name: chart
         type: helmChart
+        relation: local
         version: {{ .OPENFGA_VERSION }}
         access:
-          type: helm
-          helmChart: openfga:{{ .OPENFGA_VERSION }}
-          helmRepository: https://openfga.github.io/helm-charts
+          type: ociArtifact
+          imageReference: ghcr.io/platform-mesh/ocm/charts/openfga:{{ .OPENFGA_VERSION }}
       - name: image
         type: ociImage
-        relation: external
+        relation: local
         version: {{ .OPENFGA_IMAGE_VERSION }}
         access:
           type: ociArtifact
           imageReference: "docker.io/openfga/openfga:{{ .OPENFGA_IMAGE_VERSION }}"
       - name: postgresql-image
         type: ociImage
-        relation: external
+        relation: local
         version: {{ .OPENFGA_POSTGRESQL_IMAGE_VERSION }}
         access:
           type: ociArtifact
           imageReference: "ghcr.io/platform-mesh/upstream-images/postgresql:{{ .OPENFGA_POSTGRESQL_IMAGE_VERSION }}"
   - name: github.com/kcp-dev/kcp-operator
-    version: {{ .KCP_OPERATOR_CHART_VERSION }}
+    version: {{ .PM_KCP_OPERATOR_VERSION }}
     provider:
       name: kcp
     resources:
       - name: chart
         type: helmChart
+        relation: local
         version: {{ .KCP_OPERATOR_CHART_VERSION }}
         access:
-          type: helm
-          helmChart: kcp-operator:{{ .KCP_OPERATOR_CHART_VERSION }}
-          helmRepository: https://kcp-dev.github.io/helm-charts
+          type: ociArtifact
+          imageReference: ghcr.io/platform-mesh/ocm/charts/kcp-operator:{{ .KCP_OPERATOR_CHART_VERSION }}
       - name: image
         type: ociImage
-        relation: external
+        relation: local
         version: {{ .KCP_OPERATOR_IMAGE_VERSION }}
         access:
           type: ociArtifact
           imageReference: "ghcr.io/kcp-dev/kcp-operator:{{ .KCP_OPERATOR_IMAGE_VERSION }}"
   - name: github.com/kcp-dev/kcp
-    version: {{ .KCP_VERSION }}
+    version: {{ .PM_KCP_VERSION }}
     provider:
       name: kcp
     resources:
       - name: image
         type: ociImage
-        relation: external
+        relation: local
         version: {{ .KCP_VERSION }}
         access:
           type: ociArtifact
           imageReference: "ghcr.io/kcp-dev/kcp:{{ .KCP_VERSION }}"
   - name: github.com/kcp-dev/init-agent
-    version: {{ .INIT_AGENT_CHART_VERSION }}
+    version: {{ .PM_INIT_AGENT_VERSION }}
     provider:
       name: kcp
     resources:
       - name: chart
         type: helmChart
+        relation: local
         version: {{ .INIT_AGENT_CHART_VERSION }}
         access:
-          type: helm
-          helmChart: init-agent:{{ .INIT_AGENT_CHART_VERSION }}
-          helmRepository: https://kcp-dev.github.io/helm-charts
+          type: ociArtifact
+          imageReference: ghcr.io/platform-mesh/ocm/charts/init-agent:{{ .INIT_AGENT_CHART_VERSION }}
       - name: image
         type: ociImage
-        relation: external
+        relation: local
         version: {{ .INIT_AGENT_IMAGE_VERSION }}
         access:
           type: ociArtifact
           imageReference: "ghcr.io/kcp-dev/init-agent:{{ .INIT_AGENT_IMAGE_VERSION }}"
   - name: github.com/cloudnative-pg/cloudnative-pg
-    version: {{ .CNPG_OPERATOR_CHART_VERSION }}
+    version: {{ .PM_CNPG_OPERATOR_VERSION }}
     provider:
       name: cloudnative-pg
     resources:
       - name: chart
         type: helmChart
+        relation: local
         version: {{ .CNPG_OPERATOR_CHART_VERSION }}
         access:
           type: ociArtifact
           imageReference: ghcr.io/cloudnative-pg/charts/cloudnative-pg:{{ .CNPG_OPERATOR_CHART_VERSION }}
       - name: image
         type: ociImage
-        relation: external
+        relation: local
         version: {{ .CNPG_OPERATOR_IMAGE_VERSION }}
         access:
           type: ociArtifact
           imageReference: "ghcr.io/cloudnative-pg/cloudnative-pg:{{ .CNPG_OPERATOR_IMAGE_VERSION }}"
   - name: github.com/prometheus-community/prometheus-operator-crds
-    version: {{ .PROMETHEUS_OPERATOR_CRDS_VERSION }}
+    version: {{ .PM_PROMETHEUS_OPERATOR_CRDS_VERSION }}
     provider:
       name: prometheus-community
     resources:
       - name: chart
         type: helmChart
+        relation: local
         version: {{ .PROMETHEUS_OPERATOR_CRDS_VERSION }}
         access:
-          type: helm
-          helmChart: prometheus-operator-crds:{{ .PROMETHEUS_OPERATOR_CRDS_VERSION }}
-          helmRepository: https://prometheus-community.github.io/helm-charts
+          type: ociArtifact
+          imageReference: ghcr.io/platform-mesh/ocm/charts/prometheus-operator-crds:{{ .PROMETHEUS_OPERATOR_CRDS_VERSION }}
   - name: github.com/prometheus-community/kube-prometheus-stack
-    version: {{ .KUBE_PROMETHEUS_STACK_VERSION }}
+    version: {{ .PM_KUBE_PROMETHEUS_STACK_VERSION }}
     provider:
       name: prometheus-community
     resources:
       - name: chart
         type: helmChart
+        relation: local
         version: {{ .KUBE_PROMETHEUS_STACK_VERSION }}
         access:
-          type: helm
-          helmChart: kube-prometheus-stack:{{ .KUBE_PROMETHEUS_STACK_VERSION }}
-          helmRepository: https://prometheus-community.github.io/helm-charts
+          type: ociArtifact
+          imageReference: ghcr.io/platform-mesh/ocm/charts/kube-prometheus-stack:{{ .KUBE_PROMETHEUS_STACK_VERSION }}
   - name: github.com/open-telemetry/opentelemetry-operator
-    version: {{ .OPENTELEMETRY_OPERATOR_VERSION }}
+    version: {{ .PM_OPENTELEMETRY_OPERATOR_VERSION }}
     provider:
       name: open-telemetry
     resources:
       - name: chart
         type: helmChart
+        relation: local
         version: {{ .OPENTELEMETRY_OPERATOR_VERSION }}
         access:
           type: ociArtifact
@@ -227,13 +231,13 @@ components:
         version: {{ .KEYCLOAK_OPERATOR_VERSION }}
       - name: kcp-operator
         componentName: github.com/kcp-dev/kcp-operator
-        version: {{ .KCP_OPERATOR_CHART_VERSION }}
+        version: {{ .PM_KCP_OPERATOR_VERSION }}
       - name: kcp
         componentName: github.com/kcp-dev/kcp
-        version: {{ .KCP_VERSION }}
+        version: {{ .PM_KCP_VERSION }}
       - name: init-agent
         componentName: github.com/kcp-dev/init-agent
-        version: {{ .INIT_AGENT_CHART_VERSION }}
+        version: {{ .PM_INIT_AGENT_VERSION }}
       - name: kubernetes-graphql-gateway
         componentName: github.com/platform-mesh/kubernetes-graphql-gateway
         version: {{ .KUBERNETES_GRAPHQL_GATEWAY_VERSION }}
@@ -266,28 +270,28 @@ components:
         version: {{ .MARKETPLACE_UI_VERSION }}
       - name: gateway-api
         componentName: github.com/kubernetes-sigs/gateway-api
-        version: {{ .GATEWAY_API_VERSION }}
+        version: {{ .PM_GATEWAY_API_VERSION }}
       - name: traefik
         componentName: github.com/traefik/traefik
-        version: {{ .TRAEFIK_VERSION }}
+        version: {{ .PM_TRAEFIK_VERSION }}
       - name: terminal-controller-manager
         componentName: github.com/platform-mesh/terminal-controller-manager
         version: {{ .TERMINAL_CONTROLLER_MANAGER_VERSION }}
       - name: cert-manager
         componentName: github.com/cert-manager/cert-manager
-        version: {{ .CERT_MANAGER_VERSION }}
+        version: {{ .PM_CERT_MANAGER_VERSION }}
       - name: observability
         componentName: github.com/platform-mesh/observability
         version: {{ .OBSERVABILITY_VERSION }}
       - name: cnpg-operator
         componentName: github.com/cloudnative-pg/cloudnative-pg
-        version: {{ .CNPG_OPERATOR_CHART_VERSION }}
+        version: {{ .PM_CNPG_OPERATOR_VERSION }}
       - name: prometheus-operator-crds
         componentName: github.com/prometheus-community/prometheus-operator-crds
-        version: {{ .PROMETHEUS_OPERATOR_CRDS_VERSION }}
+        version: {{ .PM_PROMETHEUS_OPERATOR_CRDS_VERSION }}
       - name: kube-prometheus-stack
         componentName: github.com/prometheus-community/kube-prometheus-stack
-        version: {{ .KUBE_PROMETHEUS_STACK_VERSION }}
+        version: {{ .PM_KUBE_PROMETHEUS_STACK_VERSION }}
       - name: opentelemetry-operator
         componentName: github.com/open-telemetry/opentelemetry-operator
-        version: {{ .OPENTELEMETRY_OPERATOR_VERSION }}
+        version: {{ .PM_OPENTELEMETRY_OPERATOR_VERSION }}

--- a/hack/demo-oci-migration.sh
+++ b/hack/demo-oci-migration.sh
@@ -1,0 +1,416 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Demonstrates why migrating OCM resources from type:helm to type:ociArtifact requires
+# pre-mirroring charts to an OCI registry — the OCM toolkit alone is not sufficient.
+#
+# The script builds the same two-component structure twice:
+#
+#   BEFORE  — cert-manager with  type: helm   (HTTP Helm repo reference)
+#   AFTER   — cert-manager with  type: ociArtifact + relation: local  (OCI mirror)
+#
+# Then it runs ocm transfer ctf --copy-local-resources on both and shows that:
+#   BEFORE: charts are NOT embedded — the access reference remains a Helm HTTP URL
+#   AFTER:  charts ARE embedded     — the access reference becomes a local OCI blob
+#
+# Usage:
+#   ./hack/demo-oci-migration.sh             # uses defaults from ocm.yaml
+#   ./hack/demo-oci-migration.sh --dry-run   # leave the local registry + CTFs running for inspection
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+DRY_RUN=false
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true
+
+# ── Versions ──────────────────────────────────────────────────────────────────
+
+if ! command -v yq &>/dev/null; then
+  echo "Error: yq is required. Install from https://github.com/mikefarah/yq" >&2
+  exit 1
+fi
+if ! command -v ocm &>/dev/null; then
+  echo "Error: ocm CLI not found. Install from https://github.com/open-component-model/ocm/releases" >&2
+  exit 1
+fi
+if ! command -v docker &>/dev/null; then
+  echo "Error: docker is required to run a local OCI registry for the demo." >&2
+  exit 1
+fi
+
+# This demo relies on the legacy ocm CLI (open-component-model/ocm, v0.x).
+# OCM v2 (ocm.software, v2.x) renamed `ocm transfer ctf` to `ocm transfer component-version`
+# and removed `--copy-local-resources` and `ocm get resources`. If the ocm on PATH is v2,
+# look for the legacy binary in well-known locations and prefer it.
+ocm_is_legacy() {
+  "$1" transfer ctf --help >/dev/null 2>&1
+}
+
+OCM="$(command -v ocm)"
+if ! ocm_is_legacy "$OCM"; then
+  for candidate in /usr/local/bin/ocm /usr/bin/ocm /opt/ocm/bin/ocm; do
+    if [[ -x "$candidate" ]] && ocm_is_legacy "$candidate"; then
+      OCM="$candidate"
+      echo "Note: ocm on PATH is OCM v2 (no --copy-local-resources). Using legacy CLI: $OCM"
+      break
+    fi
+  done
+fi
+if ! ocm_is_legacy "$OCM"; then
+  echo "Error: this demo requires the legacy ocm CLI (open-component-model/ocm v0.x)." >&2
+  echo "  The CLI on PATH ($(command -v ocm)) is OCM v2, which removed --copy-local-resources." >&2
+  echo "  Install v0.x from https://github.com/open-component-model/ocm/releases and put it ahead on PATH." >&2
+  exit 1
+fi
+
+OCM_YAML="$REPO_ROOT/.github/workflows/ocm.yaml"
+CERT_MANAGER_VERSION="${CERT_MANAGER_VERSION:-$(yq eval '.jobs.ocm.env.CERT_MANAGER_VERSION' "$OCM_YAML")}"
+
+# The OCI mirror location — produced by the mirror-helm-chart.yaml workflow in this repo.
+# This must already exist before running the AFTER scenario.
+OCI_CHART_REF="ghcr.io/platform-mesh/ocm/charts/cert-manager-demo:${CERT_MANAGER_VERSION}"
+# Real production mirror (already published):
+OCI_CHART_REF_REAL="quay.io/jetstack/charts/cert-manager:${CERT_MANAGER_VERSION}"
+
+PM_VERSION="${PM_VERSION:-0.0.0-demo}"
+
+echo "╔══════════════════════════════════════════════════════════════════╗"
+echo "║          OCM Helm → OCI migration demo                          ║"
+echo "╠══════════════════════════════════════════════════════════════════╣"
+echo "  cert-manager version : $CERT_MANAGER_VERSION"
+echo "  platform-mesh version: $PM_VERSION"
+echo "  dry-run              : $DRY_RUN"
+echo ""
+
+WORK_DIR=$(mktemp -d)
+
+# Spin up a throwaway local OCI registry so we can show what actually lands
+# in the "target" — the ultimate destination for an air-gapped transfer.
+REG_PORT="${REG_PORT:-5005}"
+REG_NAME="ocm-demo-registry-$$"
+REG_HOST="localhost:${REG_PORT}"
+
+cleanup() {
+  echo ""
+  echo "Cleaning up local registry container..."
+  docker rm -f "$REG_NAME" >/dev/null 2>&1 || true
+  rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+echo "Starting local OCI registry at $REG_HOST (container: $REG_NAME) ..."
+docker run -d --rm --name "$REG_NAME" -p "${REG_PORT}:5000" registry:2 >/dev/null
+
+# Wait for the registry to accept requests
+for i in {1..20}; do
+  if curl -sf "http://${REG_HOST}/v2/" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.3
+done
+if ! curl -sf "http://${REG_HOST}/v2/" >/dev/null 2>&1; then
+  echo "Error: local registry did not become ready at $REG_HOST" >&2
+  exit 1
+fi
+echo "Local registry ready."
+echo ""
+
+CTF_BEFORE="$WORK_DIR/before.ctf"
+CTF_AFTER="$WORK_DIR/after.ctf"
+
+# OCM repo specs for the local registry. The JSON form is the only supported way
+# to point OCM at a plain-HTTP registry on a non-standard port. Each scenario uses
+# a different subPath so the BEFORE and AFTER artifacts land under distinct paths.
+REPO_BEFORE='{"baseUrl":"http://'"${REG_HOST}"'","subPath":"before","type":"OCIRegistry"}'
+REPO_AFTER='{"baseUrl":"http://'"${REG_HOST}"'","subPath":"after","type":"OCIRegistry"}'
+
+# Helper: list every artifact tag in the local registry under a given path prefix
+# AND verify each tag's manifest is actually fetchable (HEAD /v2/<repo>/manifests/<tag>
+# must return 200 with a Docker-Content-Digest header). This is what proves the bytes
+# advertised in /v2/_catalog and /v2/<repo>/tags/list are real, not just placeholders.
+list_registry_contents() {
+  local label="$1"
+  echo "$label"
+  local catalog
+  catalog=$(curl -sf "http://${REG_HOST}/v2/_catalog" || echo '{"repositories":[]}')
+  local repos
+  repos=$(echo "$catalog" | python3 -c "import json,sys; print('\n'.join(json.load(sys.stdin).get('repositories',[])))")
+  if [[ -z "$repos" ]]; then
+    echo "  (registry is empty)"
+    return
+  fi
+  local accept='application/vnd.oci.image.manifest.v1+json,application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.list.v2+json'
+  while IFS= read -r repo; do
+    [[ -z "$repo" ]] && continue
+    local tags
+    tags=$(curl -sf "http://${REG_HOST}/v2/${repo}/tags/list" \
+      | python3 -c "import json,sys; d=json.load(sys.stdin); print(' '.join(d.get('tags') or []))" 2>/dev/null || true)
+    if [[ -z "$tags" ]]; then
+      echo "  ${repo}:  (no tags)"
+      continue
+    fi
+    echo "  ${repo}:"
+    for tag in $tags; do
+      local headers status digest
+      headers=$(curl -sI -H "Accept: ${accept}" "http://${REG_HOST}/v2/${repo}/manifests/${tag}" || true)
+      status=$(echo "$headers" | awk 'NR==1 {print $2}')
+      digest=$(echo "$headers" | awk -F': ' 'tolower($1)=="docker-content-digest" {print $2}' | tr -d '\r\n ')
+      if [[ "$status" == "200" && -n "$digest" ]]; then
+        echo "    ${tag}  ✓ HTTP ${status}  ${digest}"
+      else
+        echo "    ${tag}  ✗ HTTP ${status:-?}  digest=${digest:-<missing>}"
+      fi
+    done
+  done <<< "$repos"
+}
+
+# ══════════════════════════════════════════════════════════════════════════════
+# BEFORE — type: helm  (HTTP Helm repository reference)
+# ══════════════════════════════════════════════════════════════════════════════
+cat > "$WORK_DIR/before.yaml" <<EOF
+components:
+  - name: github.com/cert-manager/cert-manager
+    version: ${CERT_MANAGER_VERSION}
+    provider:
+      name: cert-manager
+    resources:
+      - name: chart
+        type: helmChart
+        # No relation: field → OCM defaults to relation: external
+        version: ${CERT_MANAGER_VERSION}
+        access:
+          type: helm
+          helmChart: cert-manager:${CERT_MANAGER_VERSION}
+          helmRepository: https://charts.jetstack.io
+      - name: controller-image
+        type: ociImage
+        relation: local
+        version: ${CERT_MANAGER_VERSION}
+        access:
+          type: ociArtifact
+          imageReference: "quay.io/jetstack/cert-manager-controller:${CERT_MANAGER_VERSION}"
+
+  - name: github.com/platform-mesh/platform-mesh
+    version: ${PM_VERSION}
+    provider:
+      name: The Platform Mesh Team
+    componentReferences:
+      - name: cert-manager
+        componentName: github.com/cert-manager/cert-manager
+        version: ${CERT_MANAGER_VERSION}
+EOF
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "BEFORE  type: helm  (no OCI mirror)"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "Building CTF..."
+"$OCM" add components -c --templater=none --file "$CTF_BEFORE" "$WORK_DIR/before.yaml"
+
+echo ""
+echo "All resource access in the CTF (before transfer):"
+"$OCM" get resources "github.com/cert-manager/cert-manager:${CERT_MANAGER_VERSION}" \
+  --repo "$CTF_BEFORE" -o json \
+  | python3 -c "
+import json, sys
+items = json.load(sys.stdin)['items']
+for it in items:
+    e = it['element']
+    print(f\"  {e['name']:20} relation={e.get('relation','external'):8} access.type={e['access']['type']}\")
+    for k,v in e['access'].items():
+        if k != 'type':
+            print(f\"    {k}: {v}\")
+"
+
+echo ""
+echo "Running: ocm transfer ctf --copy-local-resources  →  http://${REG_HOST}/before"
+"$OCM" transfer ctf --copy-local-resources "$CTF_BEFORE" "$REPO_BEFORE" 2>&1 || true
+
+echo ""
+list_registry_contents "Target registry contents AFTER transfer (path: /before/...):"
+
+echo ""
+echo "All resource access AS SEEN FROM THE TARGET REGISTRY (--copy-local-resources):"
+"$OCM" get resources \
+  "github.com/cert-manager/cert-manager:${CERT_MANAGER_VERSION}" \
+  --repo "$REPO_BEFORE" -o json \
+  | python3 -c "
+import json, sys
+items = json.load(sys.stdin)['items']
+for it in items:
+    e = it['element']
+    print(f\"  {e['name']:20} relation={e.get('relation','external'):8} access.type={e['access']['type']}\")
+    for k,v in e['access'].items():
+        if k != 'type':
+            print(f\"    {k}: {v}\")
+"
+
+echo ""
+echo "☝  Look at the target registry contents above:"
+echo "   - controller-image  IS in the registry (relation=local, type=ociArtifact → embedded)"
+echo "   - chart             is NOT in the registry — its component descriptor still points"
+echo "                       at https://charts.jetstack.io (access.type=helm preserved)"
+echo ""
+echo "   --copy-local-resources copied the OCI image but skipped the helm chart entirely"
+echo "   because its access type forces relation=external. An air-gapped consumer pulling"
+echo "   from this registry would fail to install: the chart bytes simply aren't there."
+
+# ══════════════════════════════════════════════════════════════════════════════
+# AFTER — type: ociArtifact + relation: local  (OCI mirror)
+# ══════════════════════════════════════════════════════════════════════════════
+cat > "$WORK_DIR/after.yaml" <<EOF
+components:
+  - name: github.com/cert-manager/cert-manager
+    version: ${CERT_MANAGER_VERSION}-pm.1
+    provider:
+      name: cert-manager
+    resources:
+      - name: chart
+        type: helmChart
+        relation: local
+        # ↑ relation: local tells OCM "copy this resource by-value on transfer"
+        version: ${CERT_MANAGER_VERSION}
+        access:
+          type: ociArtifact
+          # ↑ ociArtifact — OCM can pull this during transfer; helm HTTP it cannot
+          imageReference: "${OCI_CHART_REF_REAL}"
+          # This OCI artifact was produced by the mirror-helm-chart.yaml workflow:
+          #   helm pull cert-manager --repo https://charts.jetstack.io
+          #   helm push cert-manager-${CERT_MANAGER_VERSION}.tgz oci://quay.io/jetstack/charts
+      - name: controller-image
+        type: ociImage
+        relation: local
+        version: ${CERT_MANAGER_VERSION}
+        access:
+          type: ociArtifact
+          imageReference: "quay.io/jetstack/cert-manager-controller:${CERT_MANAGER_VERSION}"
+
+  - name: github.com/platform-mesh/platform-mesh
+    version: ${PM_VERSION}
+    provider:
+      name: The Platform Mesh Team
+    componentReferences:
+      - name: cert-manager
+        componentName: github.com/cert-manager/cert-manager
+        version: ${CERT_MANAGER_VERSION}-pm.1
+EOF
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "AFTER   type: ociArtifact + relation: local  (with OCI mirror)"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "Building CTF..."
+"$OCM" add components -c --templater=none --file "$CTF_AFTER" "$WORK_DIR/after.yaml"
+
+echo ""
+echo "All resource access in the CTF (before transfer):"
+"$OCM" get resources "github.com/cert-manager/cert-manager:${CERT_MANAGER_VERSION}-pm.1" \
+  --repo "$CTF_AFTER" -o json \
+  | python3 -c "
+import json, sys
+items = json.load(sys.stdin)['items']
+for it in items:
+    e = it['element']
+    print(f\"  {e['name']:20} relation={e.get('relation','external'):8} access.type={e['access']['type']}\")
+    for k,v in e['access'].items():
+        if k != 'type':
+            print(f\"    {k}: {v}\")
+"
+
+echo ""
+echo "Running: ocm transfer ctf --copy-local-resources  →  http://${REG_HOST}/after"
+"$OCM" transfer ctf --copy-local-resources "$CTF_AFTER" "$REPO_AFTER" 2>&1
+
+echo ""
+list_registry_contents "Target registry contents AFTER transfer (path: /after/...):"
+
+echo ""
+echo "All resource access AS SEEN FROM THE TARGET REGISTRY (--copy-local-resources):"
+"$OCM" get resources \
+  "github.com/cert-manager/cert-manager:${CERT_MANAGER_VERSION}-pm.1" \
+  --repo "$REPO_AFTER" -o json \
+  | python3 -c "
+import json, sys
+items = json.load(sys.stdin)['items']
+for it in items:
+    e = it['element']
+    print(f\"  {e['name']:20} relation={e.get('relation','external'):8} access.type={e['access']['type']}\")
+    for k,v in e['access'].items():
+        if k != 'type':
+            print(f\"    {k}: {v}\")
+"
+
+echo ""
+echo "☝  Look at the target registry contents above:"
+echo "   - controller-image  IS in the registry (embedded ociArtifact)"
+echo "   - chart             IS in the registry (embedded ociArtifact, same mechanism)"
+echo ""
+echo "   Both resources are now reachable through the target registry alone. An air-gapped"
+echo "   consumer can install cert-manager without ever touching charts.jetstack.io or"
+echo "   quay.io. The CTF + target registry are fully self-contained."
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Summary
+# ══════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Why the OCM toolkit alone is not enough"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+cat <<'EXPLANATION'
+
+  type: helm  access points at an HTTP Helm repository (e.g. https://charts.jetstack.io).
+
+  Two transfer modes, two different problems for our delivery pipeline:
+
+    --copy-local-resources  skips type:helm entirely.
+                            The helm access type has relation=external by definition; OCM's
+                            CopyModeLocalBlobResources handler does not touch external resources.
+                            Result: chart access remains "type: helm / helmRepository: https://..."
+                            in the target registry. Air-gap is broken silently.
+
+    --copy-resources        Embeds the chart, but as a localBlob NOT a discoverable OCI artifact.
+                            OCM fetches the .tgz from the HTTP Helm repo (at `ocm add components`
+                            time — i.e. CI must reach charts.jetstack.io) and stores it inline in
+                            the component descriptor manifest with mediaType
+                            "application/vnd.cncf.helm.chart.content.v1.tar+gzip" and access.type
+                            "localBlob".
+
+                            Why this isn't useful for us:
+                            - The chart blob is reachable only by SHA digest inside the descriptor,
+                              not as an addressable OCI tag. `helm pull oci://...` won't find it.
+                            - Our consumer (platform-mesh-operator's ResourceSubroutine) builds a
+                              FluxCD HelmRelease from access.helmRepository, access.repoUrl, or
+                              access.imageReference. localBlob has none of these — installation
+                              fails with "no helmRepository, repoUrl, or imageReference found".
+                            - The upstream HTTP fetch happens during CI builds, so a broken or
+                              re-tagged upstream silently affects every build.
+
+  Why pre-mirroring is the correct solution:
+
+  Pre-publishing the chart as an OCI artifact gives every consumer a stable, addressable URL:
+
+    1. helm pull <chart> --repo <http-repo>          # one-time download from HTTP
+    2. helm push <chart>.tgz oci://<oci-registry>    # publish as OCI artifact
+
+  The constructor then references that OCI URL with relation: local:
+
+    access:
+      type: ociArtifact
+      imageReference: <oci-registry>/<chart>:<version>
+
+  --copy-local-resources copies the OCI artifact by-value into the target registry. The result:
+    - access.imageReference is rewritten to the target registry (FluxCD can pull it over OCI)
+    - the chart content is content-addressed and pinned (the tag is immutable in our registry)
+    - no internet access is required at install time AND no live HTTP fetch happens during
+      OCM build — the upstream is contacted only by the dedicated mirror workflow
+
+EXPLANATION
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "Dry-run complete."
+  echo "  CTFs left in: $WORK_DIR"
+  echo "  Local registry left running:  http://$REG_HOST  (container: $REG_NAME)"
+  echo "  Stop it with: docker rm -f $REG_NAME"
+  trap - EXIT
+fi


### PR DESCRIPTION
### Summary

This PR introduces changes to the OCM component structure and versioning to facilitate Helm to OCI migration of the Kubernetes resources.

### Changes

- change OCM resource types from `type: helm` to `type: ociArtifact` and `relation: local`. This instructs the ocm cli to copy those resources to the platform-mesh OCI registry during the **build** and **transfer** steps. It also means the created k8s Resources will produce OCIRepository objects and be consumed in the same manner as other OCI resources in PM.

- decouple component and resource versions. This change introduces new version of the external OCM components which can be independently changed from the version of the component resources. This enables the structure of OCM to be changed while keeping the resource versions the same.


Also bash script to verify these changes locally is included.

> [!NOTE]
> OCM cli doesn't copy resources with `type: helm`. Therefore to enable the change above, external helm charts hosted in helm repository were migrated to OCI resources using the **Mirror Helm Chart to OCI** Action in this repository.


refers to https://github.com/platform-mesh/helm-charts/issues/1452

superseeds https://github.com/platform-mesh/ocm/pull/129