### PR TITLE
fix: update kcp-operator image reference to mirrored location

### DIFF
--- a/.ocm/component-constructor-aggregate.yaml
+++ b/.ocm/component-constructor-aggregate.yaml
@@ -109,7 +109,7 @@ components:
         version: {{ .KCP_OPERATOR_CHART_VERSION }}
         access:
           type: ociArtifact
-          imageReference: ghcr.io/platform-mesh/ocm/charts/kcp-operator:{{ .KCP_OPERATOR_CHART_VERSION }}
+          imageReference: ghcr.io/platform-mesh/helm-charts/charts/mirrored/kcp-operator:{{ .KCP_OPERATOR_CHART_VERSION }}
       - name: image
         type: ociImage
         relation: local


### PR DESCRIPTION
kcp-operator 0.7.4 was mirrored to this location: `ghcr.io/platform-mesh/helm-charts/charts/mirrored/kcp-operator:0.7.4`