### PR TITLE
fix: update workflow job references to latest commit hashes

### DIFF
--- a/.github/workflows/pipeline-chart.yml
+++ b/.github/workflows/pipeline-chart.yml
@@ -136,7 +136,7 @@ jobs:
   release:
     if: ${{ always() && github.ref == format('refs/heads/{0}', inputs.release_branch) && (needs.verify-version.result == 'success' || needs.verify-version.result == 'skipped') }}
     needs: [verify-version]
-    uses: platform-mesh/.github/.github/workflows/job-release-chart.yml@9ddacafbe3260312cb1cc3f9974ad2fece8effe0
+    uses: platform-mesh/.github/.github/workflows/job-release-chart.yml@068efd5c6c7a6d0c4b28f5887de7ca156cb5f7b8
     secrets: inherit
     permissions:
       contents: write
@@ -151,7 +151,7 @@ jobs:
   ocm:
     if: ${{ !inputs.disableOCM && github.ref == format('refs/heads/{0}', inputs.release_branch) }}
     needs: [verify-version, release]
-    uses: platform-mesh/.github/.github/workflows/job-ocm.yml@9ddacafbe3260312cb1cc3f9974ad2fece8effe0
+    uses: platform-mesh/.github/.github/workflows/job-ocm.yml@068efd5c6c7a6d0c4b28f5887de7ca156cb5f7b8
     secrets: inherit
     permissions:
       contents: read
@@ -167,5 +167,5 @@ jobs:
   pm-ocm:
     if: ${{ !inputs.chartOnly && !inputs.disableOCM && github.ref == format('refs/heads/{0}', inputs.release_branch) }}
     needs: [ocm]
-    uses: platform-mesh/.github/.github/workflows/job-ocm-version-update.yml@9ddacafbe3260312cb1cc3f9974ad2fece8effe0
+    uses: platform-mesh/.github/.github/workflows/job-ocm-version-update.yml@068efd5c6c7a6d0c4b28f5887de7ca156cb5f7b8
     secrets: inherit


### PR DESCRIPTION
Updates wf references to not trigger actions in archived `ocm` repo.