### PR TITLE
feat: add sharding into e2e tests

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -220,7 +220,9 @@ tasks:
       - cp .ocm/component-constructor-aggregate.yaml .ocm/component-constructor-prerelease.yaml
       - sed 's/name:\ github.com\/platform-mesh\/platform-mesh/name:\ github.com\/platform-mesh\/prerelease/' .ocm/component-constructor-prerelease.yaml > .ocm/component-constructor-prerelease.yaml.tmp && mv .ocm/component-constructor-prerelease.yaml.tmp .ocm/component-constructor-prerelease.yaml
 
-  test:portal-e2e:
+  # Internal task to run portal tests for a specific org/account
+  test:portal-e2e:run:
+    internal: true
     vars:
       ORG_NAME: '{{.ORG_NAME | default "default"}}'
       TEST_ACCOUNT_NAME: '{{.TEST_ACCOUNT_NAME | default ""}}'
@@ -295,22 +297,25 @@ tasks:
       - ORG_NAME={{.ORG_NAME}} {{if .TEST_ACCOUNT_NAME}}TEST_ACCOUNT_NAME={{.TEST_ACCOUNT_NAME}}{{end}} npx playwright test portal-authorization.test.ts {{if .HEADED}}--headed{{end}}
 
   test:portal-e2e:headed:
+    desc: Run portal e2e tests with browser visible
     vars:
-      ORG_NAME: '{{.ORG_NAME | default "default"}}'
+      ORG_NAME: '{{.ORG_NAME | default ""}}'
       TEST_ACCOUNT_NAME: '{{.TEST_ACCOUNT_NAME | default ""}}'
     cmds:
       - task: test:portal-e2e
         vars: { ORG_NAME: '{{.ORG_NAME}}', TEST_ACCOUNT_NAME: '{{.TEST_ACCOUNT_NAME}}', HEADED: 'true' }
 
   test:portal-e2e:video:
+    desc: Run portal e2e tests with video recording (sharded, sequential)
     vars:
-      ORG_NAME: '{{.ORG_NAME | default "default"}}'
-      TEST_ACCOUNT_NAME: '{{.TEST_ACCOUNT_NAME | default ""}}'
-      PLAYWRIGHT_WORKERS: '{{.PLAYWRIGHT_WORKERS | default ""}}'
+      TEST_RUN_ID: '{{.TEST_RUN_ID | default (now | unixEpoch | printf "%.8s")}}'
     deps: [test:portal-e2e:setup]
     dir: local-setup/e2e
     cmds:
-      - VIDEO=true ORG_NAME={{.ORG_NAME}} {{if .TEST_ACCOUNT_NAME}}TEST_ACCOUNT_NAME={{.TEST_ACCOUNT_NAME}}{{end}} npx playwright test portal-marketplace-ui.test.ts portal-httpbins.test.ts portal-account-kubeconfig.test.ts portal-authorization.test.ts portal-account-deletion.test.ts {{if .PLAYWRIGHT_WORKERS}}--workers={{.PLAYWRIGHT_WORKERS}}{{else}}--workers=1{{end}}
+      - VIDEO=true TEST_RUN_ID={{.TEST_RUN_ID}} SHARDING_ORG_SHARD=root npx playwright test test-register-and-navigate.test.ts
+      - VIDEO=true TEST_RUN_ID={{.TEST_RUN_ID}} SHARDING_ORG_SHARD=triton npx playwright test test-register-and-navigate.test.ts
+      - VIDEO=true ORG_NAME=org-root-{{.TEST_RUN_ID}} TEST_ACCOUNT_NAME=acc-root-{{.TEST_RUN_ID}} npx playwright test portal-*.test.ts --workers=1
+      - VIDEO=true ORG_NAME=org-triton-{{.TEST_RUN_ID}} TEST_ACCOUNT_NAME=acc-triton-{{.TEST_RUN_ID}} npx playwright test portal-*.test.ts --workers=1
 
   test:portal-e2e:deletion:
     vars:
@@ -323,18 +328,18 @@ tasks:
       - ORG_NAME={{.ORG_NAME}} {{if .TEST_ACCOUNT_NAME}}TEST_ACCOUNT_NAME={{.TEST_ACCOUNT_NAME}}{{end}} npx playwright test portal-account-deletion.test.ts {{if .HEADED}}--headed{{end}}
 
 
-  test:portal-e2e:sharded:
+  test:portal-e2e:
     desc: Run portal e2e tests with workspaces on different shards (2 orgs in parallel, 2 accounts each)
     vars:
       TEST_RUN_ID: '{{.TEST_RUN_ID | default (now | unixEpoch | printf "%.8s")}}'
       HEADED: '{{.HEADED | default ""}}'
     deps:
-      - task: test:portal-e2e:sharded:root
+      - task: test:portal-e2e:shard:root
         vars: { TEST_RUN_ID: '{{.TEST_RUN_ID}}', HEADED: '{{.HEADED}}' }
-      - task: test:portal-e2e:sharded:triton
+      - task: test:portal-e2e:shard:triton
         vars: { TEST_RUN_ID: '{{.TEST_RUN_ID}}', HEADED: '{{.HEADED}}' }
 
-  test:portal-e2e:sharded:root:
+  test:portal-e2e:shard:root:
     desc: Run portal e2e tests with org on root shard
     vars:
       TEST_RUN_ID: '{{.TEST_RUN_ID | default (now | unixEpoch | printf "%.8s")}}'
@@ -342,21 +347,21 @@ tasks:
     cmds:
       - task: test:portal-e2e:sharding-setup
         vars: { TEST_RUN_ID: '{{.TEST_RUN_ID}}', SHARDING_ORG_SHARD: 'root', HEADED: '{{.HEADED}}' }
-      - task: test:portal-e2e:sharded:root:accounts
+      - task: test:portal-e2e:shard:root:accounts
         vars: { TEST_RUN_ID: '{{.TEST_RUN_ID}}', HEADED: '{{.HEADED}}' }
 
-  test:portal-e2e:sharded:root:accounts:
+  test:portal-e2e:shard:root:accounts:
     internal: true
     vars:
       TEST_RUN_ID: '{{.TEST_RUN_ID}}'
       HEADED: '{{.HEADED | default ""}}'
     deps:
-      - task: test:portal-e2e
+      - task: test:portal-e2e:run
         vars: { ORG_NAME: 'org-root-{{.TEST_RUN_ID}}', TEST_ACCOUNT_NAME: 'acc-triton-{{.TEST_RUN_ID}}', HEADED: '{{.HEADED}}' }
-      - task: test:portal-e2e
+      - task: test:portal-e2e:run
         vars: { ORG_NAME: 'org-root-{{.TEST_RUN_ID}}', TEST_ACCOUNT_NAME: 'acc-root-{{.TEST_RUN_ID}}', HEADED: '{{.HEADED}}' }
 
-  test:portal-e2e:sharded:triton:
+  test:portal-e2e:shard:triton:
     desc: Run portal e2e tests with org on triton shard
     vars:
       TEST_RUN_ID: '{{.TEST_RUN_ID | default (now | unixEpoch | printf "%.8s")}}'
@@ -364,18 +369,18 @@ tasks:
     cmds:
       - task: test:portal-e2e:sharding-setup
         vars: { TEST_RUN_ID: '{{.TEST_RUN_ID}}', SHARDING_ORG_SHARD: 'triton', HEADED: '{{.HEADED}}' }
-      - task: test:portal-e2e:sharded:triton:accounts
+      - task: test:portal-e2e:shard:triton:accounts
         vars: { TEST_RUN_ID: '{{.TEST_RUN_ID}}', HEADED: '{{.HEADED}}' }
 
-  test:portal-e2e:sharded:triton:accounts:
+  test:portal-e2e:shard:triton:accounts:
     internal: true
     vars:
       TEST_RUN_ID: '{{.TEST_RUN_ID}}'
       HEADED: '{{.HEADED | default ""}}'
     deps:
-      - task: test:portal-e2e
+      - task: test:portal-e2e:run
         vars: { ORG_NAME: 'org-triton-{{.TEST_RUN_ID}}', TEST_ACCOUNT_NAME: 'acc-triton-{{.TEST_RUN_ID}}', HEADED: '{{.HEADED}}' }
-      - task: test:portal-e2e
+      - task: test:portal-e2e:run
         vars: { ORG_NAME: 'org-triton-{{.TEST_RUN_ID}}', TEST_ACCOUNT_NAME: 'acc-root-{{.TEST_RUN_ID}}', HEADED: '{{.HEADED}}' }
 
   test:portal-e2e:sharding-setup:
@@ -394,6 +399,7 @@ tasks:
       - ./local-setup/scripts/check-backend-resources.sh
 
   test:local-setup:
+    desc: Run backend resource checks and portal e2e tests
     cmds:
       - task: test:backend-resources
       - task: test:portal-e2e

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -223,18 +223,19 @@ tasks:
   test:portal-e2e:
     vars:
       ORG_NAME: '{{.ORG_NAME | default "default"}}'
+      TEST_ACCOUNT_NAME: '{{.TEST_ACCOUNT_NAME | default ""}}'
       HEADED: '{{.HEADED | default ""}}'
     cmds:
       - task: test:portal-e2e:marketplace-ui
-        vars: { ORG_NAME: '{{.ORG_NAME}}', HEADED: '{{.HEADED}}' }
+        vars: { ORG_NAME: '{{.ORG_NAME}}', TEST_ACCOUNT_NAME: '{{.TEST_ACCOUNT_NAME}}', HEADED: '{{.HEADED}}' }
       - task: test:portal-e2e:httpbins
-        vars: { ORG_NAME: '{{.ORG_NAME}}', HEADED: '{{.HEADED}}' }
+        vars: { ORG_NAME: '{{.ORG_NAME}}', TEST_ACCOUNT_NAME: '{{.TEST_ACCOUNT_NAME}}', HEADED: '{{.HEADED}}' }
       - task: test:portal-e2e:account-kubeconfig
-        vars: { ORG_NAME: '{{.ORG_NAME}}', HEADED: '{{.HEADED}}' }
+        vars: { ORG_NAME: '{{.ORG_NAME}}', TEST_ACCOUNT_NAME: '{{.TEST_ACCOUNT_NAME}}', HEADED: '{{.HEADED}}' }
       - task: test:portal-e2e:authorization
-        vars: { ORG_NAME: '{{.ORG_NAME}}', HEADED: '{{.HEADED}}' }
+        vars: { ORG_NAME: '{{.ORG_NAME}}', TEST_ACCOUNT_NAME: '{{.TEST_ACCOUNT_NAME}}', HEADED: '{{.HEADED}}' }
       - task: test:portal-e2e:deletion
-        vars: { ORG_NAME: '{{.ORG_NAME}}', HEADED: '{{.HEADED}}' }
+        vars: { ORG_NAME: '{{.ORG_NAME}}', TEST_ACCOUNT_NAME: '{{.TEST_ACCOUNT_NAME}}', HEADED: '{{.HEADED}}' }
 
   test:portal-e2e:setup:
     run: once
@@ -247,71 +248,146 @@ tasks:
   test:portal-e2e:httpbins:
     vars:
       ORG_NAME: '{{.ORG_NAME | default "default"}}'
+      TEST_ACCOUNT_NAME: '{{.TEST_ACCOUNT_NAME | default ""}}'
       HEADED: '{{.HEADED | default ""}}'
     deps: [test:portal-e2e:setup]
     dir: local-setup/e2e
     cmds:
-      - ORG_NAME={{.ORG_NAME}} npx playwright test portal-httpbins.test.ts {{if .HEADED}}--headed{{end}}
+      - ORG_NAME={{.ORG_NAME}} {{if .TEST_ACCOUNT_NAME}}TEST_ACCOUNT_NAME={{.TEST_ACCOUNT_NAME}}{{end}} npx playwright test portal-httpbins.test.ts {{if .HEADED}}--headed{{end}}
 
   test:portal-e2e:marketplace:
     vars:
       ORG_NAME: '{{.ORG_NAME | default "default"}}'
+      TEST_ACCOUNT_NAME: '{{.TEST_ACCOUNT_NAME | default ""}}'
       HEADED: '{{.HEADED | default ""}}'
     cmds:
       - task: test:portal-e2e:marketplace-ui
-        vars: { ORG_NAME: '{{.ORG_NAME}}', HEADED: '{{.HEADED}}' }
+        vars: { ORG_NAME: '{{.ORG_NAME}}', TEST_ACCOUNT_NAME: '{{.TEST_ACCOUNT_NAME}}', HEADED: '{{.HEADED}}' }
 
   test:portal-e2e:marketplace-ui:
     vars:
       ORG_NAME: '{{.ORG_NAME | default "default"}}'
+      TEST_ACCOUNT_NAME: '{{.TEST_ACCOUNT_NAME | default ""}}'
       HEADED: '{{.HEADED | default ""}}'
     deps: [test:portal-e2e:setup]
     dir: local-setup/e2e
     cmds:
-      - ORG_NAME={{.ORG_NAME}} npx playwright test portal-marketplace-ui.test.ts {{if .HEADED}}--headed{{end}}
+      - ORG_NAME={{.ORG_NAME}} {{if .TEST_ACCOUNT_NAME}}TEST_ACCOUNT_NAME={{.TEST_ACCOUNT_NAME}}{{end}} npx playwright test portal-marketplace-ui.test.ts {{if .HEADED}}--headed{{end}}
 
   test:portal-e2e:account-kubeconfig:
     vars:
       ORG_NAME: '{{.ORG_NAME | default "default"}}'
+      TEST_ACCOUNT_NAME: '{{.TEST_ACCOUNT_NAME | default ""}}'
       HEADED: '{{.HEADED | default ""}}'
     deps: [test:portal-e2e:setup]
     dir: local-setup/e2e
     cmds:
-      - ORG_NAME={{.ORG_NAME}} npx playwright test portal-account-kubeconfig.test.ts {{if .HEADED}}--headed{{end}}
+      - ORG_NAME={{.ORG_NAME}} {{if .TEST_ACCOUNT_NAME}}TEST_ACCOUNT_NAME={{.TEST_ACCOUNT_NAME}}{{end}} npx playwright test portal-account-kubeconfig.test.ts {{if .HEADED}}--headed{{end}}
 
   test:portal-e2e:authorization:
     vars:
       ORG_NAME: '{{.ORG_NAME | default "default"}}'
+      TEST_ACCOUNT_NAME: '{{.TEST_ACCOUNT_NAME | default ""}}'
       HEADED: '{{.HEADED | default ""}}'
     deps: [test:portal-e2e:setup]
     dir: local-setup/e2e
     cmds:
-      - ORG_NAME={{.ORG_NAME}} npx playwright test portal-authorization.test.ts {{if .HEADED}}--headed{{end}}
+      - ORG_NAME={{.ORG_NAME}} {{if .TEST_ACCOUNT_NAME}}TEST_ACCOUNT_NAME={{.TEST_ACCOUNT_NAME}}{{end}} npx playwright test portal-authorization.test.ts {{if .HEADED}}--headed{{end}}
 
   test:portal-e2e:headed:
     vars:
       ORG_NAME: '{{.ORG_NAME | default "default"}}'
+      TEST_ACCOUNT_NAME: '{{.TEST_ACCOUNT_NAME | default ""}}'
     cmds:
       - task: test:portal-e2e
-        vars: { ORG_NAME: '{{.ORG_NAME}}', HEADED: 'true' }
+        vars: { ORG_NAME: '{{.ORG_NAME}}', TEST_ACCOUNT_NAME: '{{.TEST_ACCOUNT_NAME}}', HEADED: 'true' }
 
   test:portal-e2e:video:
     vars:
       ORG_NAME: '{{.ORG_NAME | default "default"}}'
+      TEST_ACCOUNT_NAME: '{{.TEST_ACCOUNT_NAME | default ""}}'
       PLAYWRIGHT_WORKERS: '{{.PLAYWRIGHT_WORKERS | default ""}}'
     deps: [test:portal-e2e:setup]
     dir: local-setup/e2e
     cmds:
-      - VIDEO=true ORG_NAME={{.ORG_NAME}} npx playwright test portal-marketplace-ui.test.ts portal-httpbins.test.ts portal-account-kubeconfig.test.ts portal-authorization.test.ts portal-account-deletion.test.ts {{if .PLAYWRIGHT_WORKERS}}--workers={{.PLAYWRIGHT_WORKERS}}{{else}}--workers=1{{end}}
+      - VIDEO=true ORG_NAME={{.ORG_NAME}} {{if .TEST_ACCOUNT_NAME}}TEST_ACCOUNT_NAME={{.TEST_ACCOUNT_NAME}}{{end}} npx playwright test portal-marketplace-ui.test.ts portal-httpbins.test.ts portal-account-kubeconfig.test.ts portal-authorization.test.ts portal-account-deletion.test.ts {{if .PLAYWRIGHT_WORKERS}}--workers={{.PLAYWRIGHT_WORKERS}}{{else}}--workers=1{{end}}
 
   test:portal-e2e:deletion:
     vars:
       ORG_NAME: '{{.ORG_NAME | default "default"}}'
+      TEST_ACCOUNT_NAME: '{{.TEST_ACCOUNT_NAME | default ""}}'
       HEADED: '{{.HEADED | default ""}}'
     deps: [test:portal-e2e:setup]
     dir: local-setup/e2e
     cmds:
-      - ORG_NAME={{.ORG_NAME}} npx playwright test portal-account-deletion.test.ts {{if .HEADED}}--headed{{end}}
+      - ORG_NAME={{.ORG_NAME}} {{if .TEST_ACCOUNT_NAME}}TEST_ACCOUNT_NAME={{.TEST_ACCOUNT_NAME}}{{end}} npx playwright test portal-account-deletion.test.ts {{if .HEADED}}--headed{{end}}
+
+
+  test:portal-e2e:sharded:
+    desc: Run portal e2e tests with workspaces on different shards (2 orgs in parallel, 2 accounts each)
+    vars:
+      TEST_RUN_ID: '{{.TEST_RUN_ID | default (now | unixEpoch | printf "%.8s")}}'
+      HEADED: '{{.HEADED | default ""}}'
+    deps:
+      - task: test:portal-e2e:sharded:root
+        vars: { TEST_RUN_ID: '{{.TEST_RUN_ID}}', HEADED: '{{.HEADED}}' }
+      - task: test:portal-e2e:sharded:triton
+        vars: { TEST_RUN_ID: '{{.TEST_RUN_ID}}', HEADED: '{{.HEADED}}' }
+
+  test:portal-e2e:sharded:root:
+    desc: Run portal e2e tests with org on root shard
+    vars:
+      TEST_RUN_ID: '{{.TEST_RUN_ID | default (now | unixEpoch | printf "%.8s")}}'
+      HEADED: '{{.HEADED | default ""}}'
+    cmds:
+      - task: test:portal-e2e:sharding-setup
+        vars: { TEST_RUN_ID: '{{.TEST_RUN_ID}}', SHARDING_ORG_SHARD: 'root', HEADED: '{{.HEADED}}' }
+      - task: test:portal-e2e:sharded:root:accounts
+        vars: { TEST_RUN_ID: '{{.TEST_RUN_ID}}', HEADED: '{{.HEADED}}' }
+
+  test:portal-e2e:sharded:root:accounts:
+    internal: true
+    vars:
+      TEST_RUN_ID: '{{.TEST_RUN_ID}}'
+      HEADED: '{{.HEADED | default ""}}'
+    deps:
+      - task: test:portal-e2e
+        vars: { ORG_NAME: 'org-root-{{.TEST_RUN_ID}}', TEST_ACCOUNT_NAME: 'acc-triton-{{.TEST_RUN_ID}}', HEADED: '{{.HEADED}}' }
+      - task: test:portal-e2e
+        vars: { ORG_NAME: 'org-root-{{.TEST_RUN_ID}}', TEST_ACCOUNT_NAME: 'acc-root-{{.TEST_RUN_ID}}', HEADED: '{{.HEADED}}' }
+
+  test:portal-e2e:sharded:triton:
+    desc: Run portal e2e tests with org on triton shard
+    vars:
+      TEST_RUN_ID: '{{.TEST_RUN_ID | default (now | unixEpoch | printf "%.8s")}}'
+      HEADED: '{{.HEADED | default ""}}'
+    cmds:
+      - task: test:portal-e2e:sharding-setup
+        vars: { TEST_RUN_ID: '{{.TEST_RUN_ID}}', SHARDING_ORG_SHARD: 'triton', HEADED: '{{.HEADED}}' }
+      - task: test:portal-e2e:sharded:triton:accounts
+        vars: { TEST_RUN_ID: '{{.TEST_RUN_ID}}', HEADED: '{{.HEADED}}' }
+
+  test:portal-e2e:sharded:triton:accounts:
+    internal: true
+    vars:
+      TEST_RUN_ID: '{{.TEST_RUN_ID}}'
+      HEADED: '{{.HEADED | default ""}}'
+    deps:
+      - task: test:portal-e2e
+        vars: { ORG_NAME: 'org-triton-{{.TEST_RUN_ID}}', TEST_ACCOUNT_NAME: 'acc-triton-{{.TEST_RUN_ID}}', HEADED: '{{.HEADED}}' }
+      - task: test:portal-e2e
+        vars: { ORG_NAME: 'org-triton-{{.TEST_RUN_ID}}', TEST_ACCOUNT_NAME: 'acc-root-{{.TEST_RUN_ID}}', HEADED: '{{.HEADED}}' }
+
+  test:portal-e2e:sharding-setup:
+    desc: Setup sharded org and accounts for e2e tests
+    vars:
+      TEST_RUN_ID: '{{.TEST_RUN_ID | default (now | unixEpoch | printf "%.8s")}}'
+      SHARDING_ORG_SHARD: '{{.SHARDING_ORG_SHARD | default "triton"}}'
+      HEADED: '{{.HEADED | default ""}}'
+    deps: [test:portal-e2e:setup]
+    dir: local-setup/e2e
+    cmds:
+      - TEST_RUN_ID={{.TEST_RUN_ID}} SHARDING_ORG_SHARD={{.SHARDING_ORG_SHARD}} npx playwright test test-register-and-navigate.test.ts {{if .HEADED}}--headed{{end}}
 
   test:backend-resources:
     cmds:

--- a/local-setup/e2e/helpers/account.ts
+++ b/local-setup/e2e/helpers/account.ts
@@ -4,15 +4,15 @@ import path from 'node:path';
 
 import { expect, Locator, Page } from '@playwright/test';
 
-import { newOrgName, testAccountName } from './constants';
+import { newOrgName, testAccountName as defaultAccountName } from './constants';
 import { waitForAccountDeleted, waitForAccountExists, waitForAccountReady, normalizeDownloadedKubeconfig } from './backend';
 import { clickRobust } from './httpbins';
 import { logStep, portalOrgUrl } from './log';
 
-async function openAccountsView(page: Page): Promise<void> {
+async function openAccountsView(page: Page, orgName?: string): Promise<void> {
   const createButton = page.getByRole('button', { name: 'Create', exact: true });
   const heading = page.getByRole('heading', { name: 'Accounts', exact: true });
-  const accountsUrl = portalOrgUrl('/home/accounts');
+  const accountsUrl = portalOrgUrl('/home/accounts', orgName);
 
   logStep(`openAccountsView:navigate url=${accountsUrl}`);
   await page.goto(accountsUrl, { waitUntil: 'domcontentloaded' });
@@ -42,21 +42,24 @@ async function ensureListRowVisible(page: Page, row: Locator): Promise<void> {
   }
 }
 
-async function ensureAccountExists(page: Page): Promise<string> {
-  logStep(`ensureAccountExists:start account=${testAccountName}`);
-  await openAccountsView(page);
-  const accountRow = page.getByRole('row').filter({ hasText: testAccountName }).first();
+async function ensureAccountExists(page: Page, orgName?: string, accountName?: string): Promise<string> {
+  const org = orgName ?? newOrgName;
+  const account = accountName ?? defaultAccountName;
+
+  logStep(`ensureAccountExists:start account=${account}`);
+  await openAccountsView(page, org);
+  const accountRow = page.getByRole('row').filter({ hasText: account }).first();
   const createDialog = page.locator('ui5-dialog[open]').first();
 
   await ensureListRowVisible(page, accountRow);
 
   if (!await accountRow.isVisible().catch(() => false)) {
-    logStep(`ensureAccountExists:create account=${testAccountName}`);
+    logStep(`ensureAccountExists:create account=${account}`);
     await page.getByRole('button', { name: 'Create', exact: true }).click();
     await createDialog.waitFor({ state: 'visible', timeout: 10000 });
 
     const nameField = page.getByRole('textbox').first();
-    await nameField.fill(testAccountName);
+    await nameField.fill(account);
 
     // The account create form has a required ui5-select for "Type" with a single value "account".
     // Save stays disabled until it is filled. The first ui5-select on the page is the pagination
@@ -102,7 +105,7 @@ async function ensureAccountExists(page: Page): Promise<string> {
     }
 
     const submitButton = page.getByRole('button', { name: /^(Save|Submit)$/ }).first();
-    const alreadyExistsAlert = page.getByText(`accounts.core.platform-mesh.io "${testAccountName}" already exists`);
+    const alreadyExistsAlert = page.getByText(`accounts.core.platform-mesh.io "${account}" already exists`);
     const transientWebhookAlert = page.getByText(/failed calling webhook|connection refused|Internal error occurred/i);
 
     for (let attempt = 0; attempt < 4; attempt++) {
@@ -152,18 +155,20 @@ async function ensureAccountExists(page: Page): Promise<string> {
     await alertCloseButton.click();
   }
 
-  waitForAccountExists();
-  logStep(`ensureAccountExists:wait-ready account=${testAccountName}`);
-  waitForAccountReady();
-  const accountUrl = `https://${newOrgName}.portal.localhost:8443/home/accounts/${testAccountName}/dashboard`;
-  logStep(`ensureAccountExists:navigate-direct account=${testAccountName} url=${accountUrl}`);
+  waitForAccountExists(org, account);
+  logStep(`ensureAccountExists:wait-ready account=${account}`);
+  waitForAccountReady(org, account);
+  const accountUrl = `https://${org}.portal.localhost:8443/home/accounts/${account}/dashboard`;
+  logStep(`ensureAccountExists:navigate-direct account=${account} url=${accountUrl}`);
   await page.goto(accountUrl, { waitUntil: 'domcontentloaded' });
   await expect(page.getByRole('button', { name: 'Download kubeconfig' })).toBeVisible({ timeout: 30000 });
-  logStep(`ensureAccountExists:done account=${testAccountName}`);
+  logStep(`ensureAccountExists:done account=${account}`);
   return accountUrl;
 }
 
-async function downloadAccountKubeconfig(page: Page): Promise<string> {
+async function downloadAccountKubeconfig(page: Page, orgName?: string, accountName?: string): Promise<string> {
+  const account = accountName ?? defaultAccountName;
+
   const downloadButton = page.getByRole('button', { name: 'Download kubeconfig' });
   let download = null;
 
@@ -189,15 +194,18 @@ async function downloadAccountKubeconfig(page: Page): Promise<string> {
     mkdirSync(targetDir, { recursive: true });
   }
 
-  const kubeconfigPath = path.join(targetDir, `${testAccountName}-oidc.kubeconfig`);
+  const kubeconfigPath = path.join(targetDir, `${account}-oidc.kubeconfig`);
   await download!.saveAs(kubeconfigPath);
   normalizeDownloadedKubeconfig(kubeconfigPath);
   return kubeconfigPath;
 }
 
-async function deleteAccount(page: Page, accountUrl: string): Promise<void> {
+async function deleteAccount(page: Page, accountUrl: string, orgName?: string, accountName?: string): Promise<void> {
+  const org = orgName ?? newOrgName;
+  const account = accountName ?? defaultAccountName;
+
   logStep(`deleteAccount:start url=${accountUrl}`);
-  waitForAccountReady();
+  waitForAccountReady(org, account);
   await page.goto(accountUrl, { waitUntil: 'domcontentloaded' });
 
   for (let attempt = 0; attempt < 3; attempt++) {
@@ -273,16 +281,6 @@ async function deleteAccount(page: Page, accountUrl: string): Promise<void> {
     throw new Error(`Could not find account delete button on the account detail page, buttons=${JSON.stringify(visibleButtons)}`);
   }
 
-  const confirmButtons = [
-    page.getByRole('button', { name: 'Submit', exact: true }).last(),
-    page.getByRole('button', { name: 'Confirm', exact: true }).last(),
-    page.getByRole('button', { name: 'Delete', exact: true }).last(),
-    page.getByRole('button', { name: /submit/i }).last(),
-    page.getByRole('button', { name: /delete/i }).last(),
-    page.getByRole('button', { name: /remove/i }).last(),
-    page.locator('[test-id="delete-resource-confirm"]').first(),
-  ];
-
   const confirmInputSelectors = [
     'input[placeholder="Type name"]',
     '[test-id="delete-resource-name-confirmation"] input',
@@ -293,44 +291,18 @@ async function deleteAccount(page: Page, accountUrl: string): Promise<void> {
   for (const selector of confirmInputSelectors) {
     const input = page.locator(selector).last();
     if (await input.isVisible().catch(() => false)) {
-      await input.fill(testAccountName);
+      await input.fill(account);
       logStep(`deleteAccount:typed-confirmation selector=${selector}`);
+      await page.waitForTimeout(500);
       break;
     }
   }
 
-  const visibleDialogText = await page.locator('body').innerText().catch(() => '');
-  logStep(`deleteAccount:confirm-body=${JSON.stringify(visibleDialogText.slice(0, 500))}`);
-
-  const visibleButtons = await page.locator('button').evaluateAll((nodes) => nodes
-    .map((node) => ({
-      text: (node.textContent || '').trim(),
-      ariaLabel: node.getAttribute('aria-label') || '',
-      title: node.getAttribute('title') || '',
-    }))
-    .filter((entry) => entry.text || entry.ariaLabel || entry.title));
-  logStep(`deleteAccount:buttons=${JSON.stringify(visibleButtons)}`);
-
-  let confirmedDelete = false;
-  for (let index = 0; index < confirmButtons.length; index++) {
-    const button = confirmButtons[index];
-    if (await button.isVisible().catch(() => false)) {
-      logStep(`deleteAccount:clicked-confirm index=${index}`);
-      await clickRobust(button);
-      confirmedDelete = true;
-      break;
-    }
-  }
-
-  if (!confirmedDelete) {
-    throw new Error(`Could not find account delete confirmation button, buttons=${JSON.stringify(visibleButtons)}`);
-  }
-
-  waitForAccountDeleted();
-  await openAccountsView(page);
-  const accountRow = page.getByRole('row').filter({ hasText: testAccountName }).first();
-  await expect(accountRow).not.toBeVisible({ timeout: 30000 });
-  logStep(`deleteAccount:done url=${accountUrl}`);
+  const confirmButton = page.locator('[test-id="delete-resource-confirm"]').first();
+  await expect(confirmButton).toBeVisible({ timeout: 5000 });
+  await expect(confirmButton).toBeEnabled({ timeout: 5000 });
+  await clickRobust(confirmButton);
+  logStep('deleteAccount:clicked-confirm');
 }
 
 export { deleteAccount, downloadAccountKubeconfig, ensureAccountExists };

--- a/local-setup/e2e/helpers/account.ts
+++ b/local-setup/e2e/helpers/account.ts
@@ -167,6 +167,7 @@ async function ensureAccountExists(page: Page, orgName?: string, accountName?: s
 }
 
 async function downloadAccountKubeconfig(page: Page, orgName?: string, accountName?: string): Promise<string> {
+  const org = orgName ?? newOrgName;
   const account = accountName ?? defaultAccountName;
 
   const downloadButton = page.getByRole('button', { name: 'Download kubeconfig' });
@@ -194,7 +195,7 @@ async function downloadAccountKubeconfig(page: Page, orgName?: string, accountNa
     mkdirSync(targetDir, { recursive: true });
   }
 
-  const kubeconfigPath = path.join(targetDir, `${account}-oidc.kubeconfig`);
+  const kubeconfigPath = path.join(targetDir, `${org}-${account}-oidc.kubeconfig`);
   await download!.saveAs(kubeconfigPath);
   normalizeDownloadedKubeconfig(kubeconfigPath);
   return kubeconfigPath;

--- a/local-setup/e2e/helpers/account.ts
+++ b/local-setup/e2e/helpers/account.ts
@@ -282,24 +282,22 @@ async function deleteAccount(page: Page, accountUrl: string, orgName?: string, a
     throw new Error(`Could not find account delete button on the account detail page, buttons=${JSON.stringify(visibleButtons)}`);
   }
 
-  const confirmInputSelectors = [
-    'input[placeholder="Type name"]',
-    '[test-id="delete-resource-name-confirmation"] input',
-    '[test-id="delete-resource-confirmation-input"] input',
-    'input',
-  ];
+  // Wait for the delete confirmation dialog to appear using test-id
+  const deleteDialog = page.locator('[test-id="delete-resource-dialog"]');
+  await expect(deleteDialog).toBeVisible({ timeout: 10000 });
 
-  for (const selector of confirmInputSelectors) {
-    const input = page.locator(selector).last();
-    if (await input.isVisible().catch(() => false)) {
-      await input.fill(account);
-      logStep(`deleteAccount:typed-confirmation selector=${selector}`);
-      await page.waitForTimeout(500);
-      break;
-    }
-  }
+  // Find and fill the confirmation input inside the dialog using test-id
+  // UI5 web components have shadow DOM, so we need to target the inner input element
+  const confirmInput = page.locator('[test-id="delete-resource-input"]');
+  await expect(confirmInput).toBeVisible({ timeout: 5000 });
 
-  const confirmButton = page.locator('[test-id="delete-resource-confirm"]').first();
+  // Fill the input by targeting the actual input element inside the ui5-input shadow root
+  const innerInput = confirmInput.locator('input');
+  await innerInput.fill(account);
+  logStep(`deleteAccount:typed-confirmation account=${account}`);
+  await page.waitForTimeout(500);
+
+  const confirmButton = page.locator('[test-id="delete-resource-confirm"]');
   await expect(confirmButton).toBeVisible({ timeout: 5000 });
   await expect(confirmButton).toBeEnabled({ timeout: 5000 });
   await clickRobust(confirmButton);

--- a/local-setup/e2e/helpers/auth.ts
+++ b/local-setup/e2e/helpers/auth.ts
@@ -315,9 +315,10 @@ async function ensureWelcomePage(page: Page, user: TestUser): Promise<void> {
   }
 }
 
-async function ensurePortalHome(page: Page, user?: TestUser): Promise<void> {
+async function ensurePortalHome(page: Page, user?: TestUser, orgName?: string): Promise<void> {
+  const org = orgName ?? newOrgName;
   const welcome = page.getByText("Welcome! Let's get started.", { exact: true });
-  const orgPortalBaseUrl = `https://${newOrgName}.portal.localhost:8443/`;
+  const orgPortalBaseUrl = `https://${org}.portal.localhost:8443/`;
 
   logStep(`ensurePortalHome:start url=${page.url()}`);
   if (!page.url().startsWith(orgPortalBaseUrl)) {
@@ -338,36 +339,37 @@ async function ensurePortalHome(page: Page, user?: TestUser): Promise<void> {
   logStep(`ensurePortalHome:done url=${page.url()}`);
 }
 
-async function switchToOrganization(page: Page, user: TestUser, createIfMissing: boolean): Promise<void> {
+async function switchToOrganization(page: Page, user: TestUser, createIfMissing: boolean, orgName?: string): Promise<void> {
+  const org = orgName ?? newOrgName;
   const switchButton = page.locator('[test-id="organization-management-switch-button"]').locator('button');
-  const orgPortalUrl = `https://${newOrgName}.portal.localhost:8443/home`;
-  const orgPortalBaseUrl = `https://${newOrgName}.portal.localhost:8443/`;
-  const existingOrgAlert = page.getByText(new RegExp(`organization.*${newOrgName}.*already exists|${newOrgName}.*already exists`, 'i')).first();
+  const orgPortalUrl = `https://${org}.portal.localhost:8443/home`;
+  const orgPortalBaseUrl = `https://${org}.portal.localhost:8443/`;
+  const existingOrgAlert = page.getByText(new RegExp(`organization.*${org}.*already exists|${org}.*already exists`, 'i')).first();
   const alertCloseButton = page.getByRole('button', { name: 'Close' }).first();
 
-  let orgSelected = await selectExistingOrganization(page, newOrgName);
+  let orgSelected = await selectExistingOrganization(page, org);
 
   if (createIfMissing) {
     const onboardButton = page.locator('[test-id="organization-management-onboard-button"]').locator('button');
     if (!orgSelected && await onboardButton.isVisible().catch(() => false)) {
-      logStep(`switchToOrganization:onboard-missing-org org=${newOrgName}`);
-      await fillOrganizationField(page, newOrgName);
+      logStep(`switchToOrganization:onboard-missing-org org=${org}`);
+      await fillOrganizationField(page, org);
       await onboardButton.click();
 
       if (await existingOrgAlert.isVisible().catch(() => false)) {
-        logStep(`switchToOrganization:org-already-exists org=${newOrgName}`);
+        logStep(`switchToOrganization:org-already-exists org=${org}`);
         if (await alertCloseButton.isVisible().catch(() => false)) {
           await alertCloseButton.click().catch(() => {});
         }
       }
 
-      orgSelected = await selectExistingOrganization(page, newOrgName);
+      orgSelected = await selectExistingOrganization(page, org);
       await waitForOrganizationSwitchReady(page);
     }
   }
 
   if (!orgSelected) {
-    throw new Error(`Organization ${newOrgName} was not found in the switch dropdown`);
+    throw new Error(`Organization ${org} was not found in the switch dropdown`);
   }
 
   await switchButton.waitFor({ state: 'visible', timeout: 60000 });
@@ -385,7 +387,48 @@ async function switchToOrganization(page: Page, user: TestUser, createIfMissing:
     throw new Error(`Organization switch did not land on ${orgPortalBaseUrl}, final URL=${page.url()}`);
   }
 
-  await ensurePortalHome(page, user);
+  await ensurePortalHome(page, user, org);
 }
 
-export { ensurePortalHome, ensureWelcomePage, switchToOrganization };
+async function inviteUserToOrg(page: Page, userEmailToInvite: string): Promise<void> {
+  logStep(`inviteUserToOrg:start email=${userEmailToInvite}`);
+
+  await page.locator('[data-testid="members_members"]').click();
+  await page.waitForLoadState('networkidle', { timeout: 10000 });
+
+  const membersFrame = page.frameLocator('iframe[src*="organization/members"]');
+  const addButton = membersFrame.locator('[data-testid="app-iam-member-list-add-button"]');
+  await addButton.waitFor({ state: 'visible', timeout: 10000 });
+  await expect(addButton).toBeEnabled({ timeout: 10000 });
+  await addButton.scrollIntoViewIfNeeded();
+  await addButton.click();
+
+  const addMembersFrame = page.frameLocator('iframe[src*="organization/add-members"]');
+  const userInput = addMembersFrame.locator('[data-testid="app-iam-member-add-dialog-user-search-input"]').locator('input');
+  await userInput.waitFor({ state: 'visible', timeout: 10000 });
+  await userInput.fill(userEmailToInvite);
+  await addMembersFrame.getByRole('button', { name: 'Select Options' }).click();
+  await page.waitForTimeout(1000);
+
+  const inviteInFrame = addMembersFrame.locator('li.fd-combobox-list-item').filter({ hasText: 'Invite' }).filter({ hasText: userEmailToInvite });
+  const inviteInPage = page.locator('li.fd-combobox-list-item').filter({ hasText: 'Invite' }).filter({ hasText: userEmailToInvite });
+  const inviteOption = inviteInFrame.or(inviteInPage);
+  await inviteOption.waitFor({ state: 'visible', timeout: 10000 });
+  await inviteOption.click();
+  await expect(addMembersFrame.getByRole('row').filter({ hasText: userEmailToInvite })).toBeVisible({ timeout: 15000 });
+  await addMembersFrame.locator('[data-testid="app-iam-member-add-dialog-add-button"]').click();
+
+  const memberEmailInList = membersFrame.locator('span.member-extra-information').filter({ hasText: userEmailToInvite });
+  await expect(memberEmailInList).toBeVisible({ timeout: 15000 });
+
+  logStep(`inviteUserToOrg:done email=${userEmailToInvite}`);
+}
+
+export {
+  ensurePortalHome,
+  ensureWelcomePage,
+  fillOrganizationField,
+  inviteUserToOrg,
+  selectExistingOrganization,
+  switchToOrganization,
+};

--- a/local-setup/e2e/helpers/backend.ts
+++ b/local-setup/e2e/helpers/backend.ts
@@ -18,52 +18,60 @@ import {
   mkcertCaPath,
   newOrgName,
   primaryUser,
-  testAccountName,
+  testAccountName as defaultAccountName,
   type TestUser,
 } from './constants';
 import { logStep } from './log';
 import { runAdminKubectl, runKubectlWithKubeconfig } from './runtime';
 
-function waitForAccountReady(): void {
-  logStep(`waitForAccountReady:start account=${testAccountName} timeout=${accountReadyTimeoutSeconds}s`);
+function waitForAccountReady(orgName?: string, accountName?: string): void {
+  const org = orgName ?? newOrgName;
+  const account = accountName ?? defaultAccountName;
+  logStep(`waitForAccountReady:start account=${account} timeout=${accountReadyTimeoutSeconds}s`);
   runAdminKubectl([
     'wait',
     '--server',
-    kcpClusterServer(`root:orgs:${newOrgName}`),
+    kcpClusterServer(`root:orgs:${org}`),
     '--for=condition=Ready',
     `--timeout=${accountReadyTimeoutSeconds}s`,
-    `accounts.core.platform-mesh.io/${testAccountName}`,
+    `accounts.core.platform-mesh.io/${account}`,
   ]);
-  logStep(`waitForAccountReady:done account=${testAccountName}`);
+  logStep(`waitForAccountReady:done account=${account}`);
 }
 
-function waitForAccountExists(): void {
-  logStep(`waitForAccountExists:start account=${testAccountName} timeout=${accountReadyTimeoutSeconds}s`);
+function waitForAccountExists(orgName?: string, accountName?: string): void {
+  const org = orgName ?? newOrgName;
+  const account = accountName ?? defaultAccountName;
+  logStep(`waitForAccountExists:start account=${account} timeout=${accountReadyTimeoutSeconds}s`);
   runAdminKubectl([
     'wait',
     '--server',
-    kcpClusterServer(`root:orgs:${newOrgName}`),
+    kcpClusterServer(`root:orgs:${org}`),
     '--for=jsonpath={.metadata.name}',
     `--timeout=${accountReadyTimeoutSeconds}s`,
-    `accounts.core.platform-mesh.io/${testAccountName}`,
+    `accounts.core.platform-mesh.io/${account}`,
   ]);
-  logStep(`waitForAccountExists:done account=${testAccountName}`);
+  logStep(`waitForAccountExists:done account=${account}`);
 }
 
-function waitForAccountDeleted(): void {
-  logStep(`waitForAccountDeleted:start account=${testAccountName} timeout=${accountReadyTimeoutSeconds}s`);
+function waitForAccountDeleted(orgName?: string, accountName?: string, timeoutSeconds?: number): void {
+  const org = orgName ?? newOrgName;
+  const account = accountName ?? defaultAccountName;
+  const timeout = timeoutSeconds ?? Number(accountReadyTimeoutSeconds);
+  logStep(`waitForAccountDeleted:start account=${account} timeout=${timeout}s`);
   runAdminKubectl([
     'wait',
     '--server',
-    kcpClusterServer(`root:orgs:${newOrgName}`),
+    kcpClusterServer(`root:orgs:${org}`),
     '--for=delete',
-    `--timeout=${accountReadyTimeoutSeconds}s`,
-    `accounts.core.platform-mesh.io/${testAccountName}`,
+    `--timeout=${timeout}s`,
+    `accounts.core.platform-mesh.io/${account}`,
   ]);
-  logStep(`waitForAccountDeleted:done account=${testAccountName}`);
+  logStep(`waitForAccountDeleted:done account=${account}`);
 }
 
-function ensureInvitedUserExists(user: TestUser): void {
+function ensureInvitedUserExists(user: TestUser, orgName?: string): void {
+  const org = orgName ?? newOrgName;
   logStep(`ensureInvitedUserExists:start email=${user.email}`);
 
   const manifest = [
@@ -79,7 +87,7 @@ function ensureInvitedUserExists(user: TestUser): void {
   runAdminKubectl([
     'apply',
     '--server',
-    kcpClusterServer(`root:orgs:${newOrgName}`),
+    kcpClusterServer(`root:orgs:${org}`),
     '-f',
     '-',
   ], manifest);
@@ -87,7 +95,7 @@ function ensureInvitedUserExists(user: TestUser): void {
   runAdminKubectl([
     'wait',
     '--server',
-    kcpClusterServer(`root:orgs:${newOrgName}`),
+    kcpClusterServer(`root:orgs:${org}`),
     '--for=condition=Ready',
     `--timeout=${accountReadyTimeoutSeconds}s`,
     `invites.core.platform-mesh.io/${inviteName}`,
@@ -190,6 +198,18 @@ function extractOidcClientId(kubeconfigPath: string): string {
   return match[1].trim();
 }
 
+function extractOidcRealm(kubeconfigPath: string): string {
+  const kubeconfig = readFileSync(kubeconfigPath, 'utf8');
+  // Extract realm from --oidc-issuer-url=https://portal.localhost:8443/keycloak/realms/<realm>
+  const match = kubeconfig.match(/--oidc-issuer-url=.*\/keycloak\/realms\/([^\s\n]+)/);
+  if (!match) {
+    // Fall back to default realm if not found
+    return 'default';
+  }
+
+  return match[1].trim();
+}
+
 async function ensurePortalHostnameResolves(): Promise<void> {
   const kcpApiHostname = new URL(kcpUrl).hostname;
   for (const hostname of ['portal.localhost', kcpApiHostname]) {
@@ -235,18 +255,18 @@ function getKeycloakAdminToken(): string {
   return parsed.access_token;
 }
 
-function ensureKubectlClientAllowsDirectGrants(clientId: string): void {
+function ensureKubectlClientAllowsDirectGrants(clientId: string, realm: string = 'default'): void {
   const token = getKeycloakAdminToken();
   const response = keycloakApiRequest(
     'GET',
-    `${keycloakBaseUrl}/admin/realms/default/clients?clientId=${encodeURIComponent(clientId)}`,
+    `${keycloakBaseUrl}/admin/realms/${realm}/clients?clientId=${encodeURIComponent(clientId)}`,
     undefined,
     token,
   );
   const clients = JSON.parse(response);
 
   if (!Array.isArray(clients) || clients.length === 0) {
-    throw new Error(`Unable to find Keycloak client ${clientId}`);
+    throw new Error(`Unable to find Keycloak client ${clientId} in realm ${realm}`);
   }
 
   const client = clients[0];
@@ -257,7 +277,7 @@ function ensureKubectlClientAllowsDirectGrants(clientId: string): void {
   client.directAccessGrantsEnabled = true;
   keycloakApiRequest(
     'PUT',
-    `${keycloakBaseUrl}/admin/realms/default/clients/${client.id}`,
+    `${keycloakBaseUrl}/admin/realms/${realm}/clients/${client.id}`,
     JSON.stringify(client),
     token,
   );
@@ -267,7 +287,9 @@ async function verifyDownloadedKubeconfig(kubeconfigPath: string): Promise<void>
   logStep(`verifyDownloadedKubeconfig:start path=${kubeconfigPath}`);
   normalizeDownloadedKubeconfig(kubeconfigPath);
   await ensurePortalHostnameResolves();
-  ensureKubectlClientAllowsDirectGrants(extractOidcClientId(kubeconfigPath));
+  const clientId = extractOidcClientId(kubeconfigPath);
+  const realm = extractOidcRealm(kubeconfigPath);
+  ensureKubectlClientAllowsDirectGrants(clientId, realm);
 
   const manifest = [
     'apiVersion: v1',

--- a/local-setup/e2e/helpers/httpbins.ts
+++ b/local-setup/e2e/helpers/httpbins.ts
@@ -15,7 +15,7 @@ import {
   testNamespaceHttpBinName,
   testNamespaceName,
 } from './constants';
-import { logStep, portalOrgUrl } from './log';
+import { logStep } from './log';
 import { runAdminKubectl, runInfraKubectl, runRuntimeKubectl } from './runtime';
 
 async function clickRobust(locator: Locator): Promise<void> {
@@ -155,7 +155,10 @@ function ensureExampleHttpbinProviderWorkspace(): void {
   }
 }
 
-function ensureHttpBinExistsViaBackend(namespaceName: string, httpBinName: string): void {
+function ensureHttpBinExistsViaBackend(namespaceName: string, httpBinName: string, orgName?: string, accountName?: string): void {
+  const org = orgName ?? newOrgName;
+  const account = accountName ?? testAccountName;
+
   const manifest = [
     'apiVersion: orchestrate.platform-mesh.io/v1alpha1',
     'kind: HttpBin',
@@ -168,7 +171,7 @@ function ensureHttpBinExistsViaBackend(namespaceName: string, httpBinName: strin
   runAdminKubectl([
     'apply',
     '--server',
-    kcpClusterServer(`root:orgs:${newOrgName}:${testAccountName}`),
+    kcpClusterServer(`root:orgs:${org}:${account}`),
     '-f',
     '-',
   ], manifest);
@@ -176,7 +179,7 @@ function ensureHttpBinExistsViaBackend(namespaceName: string, httpBinName: strin
   runAdminKubectl([
     'wait',
     '--server',
-    kcpClusterServer(`root:orgs:${newOrgName}:${testAccountName}`),
+    kcpClusterServer(`root:orgs:${org}:${account}`),
     '--for=condition=Ready',
     '--timeout=120s',
     '-n',
@@ -185,9 +188,13 @@ function ensureHttpBinExistsViaBackend(namespaceName: string, httpBinName: strin
   ]);
 }
 
-async function ensureExampleHttpbinProvider(page: Page): Promise<void> {
+async function ensureExampleHttpbinProvider(page: Page, orgName?: string, accountName?: string): Promise<void> {
+  const org = orgName ?? newOrgName;
+  const account = accountName ?? testAccountName;
+
   ensureExampleHttpbinProviderWorkspace();
-  await page.goto(portalOrgUrl(`/home/accounts/${testAccountName}/orchestrate_platform-mesh_io_httpbins`), { waitUntil: 'domcontentloaded' });
+  const url = `https://${org}.portal.localhost:8443/home/accounts/${account}/orchestrate_platform-mesh_io_httpbins`;
+  await page.goto(url, { waitUntil: 'domcontentloaded' });
   await page.waitForLoadState('load', { timeout: 10000 }).catch(() => {});
 }
 
@@ -255,8 +262,8 @@ async function ensureNamespaceExists(page: Page, namespaceName: string): Promise
   logStep(`ensureNamespaceExists:done namespace=${namespaceName}`);
 }
 
-async function openHttpBinsView(page: Page): Promise<void> {
-  await ensureExampleHttpbinProvider(page);
+async function openHttpBinsView(page: Page, orgName?: string, accountName?: string): Promise<void> {
+  await ensureExampleHttpbinProvider(page, orgName, accountName);
 
   const httpBinsReadyLocators = [
     page.locator('[data-testid="namespace-selection-combobox"]').first(),
@@ -302,10 +309,10 @@ async function selectNamespaceScope(page: Page, namespaceName: string): Promise<
   throw new Error(`Unable to select namespace scope ${namespaceName}`);
 }
 
-async function ensureHttpBinExists(page: Page, namespaceName: string, httpBinName: string): Promise<void> {
+async function ensureHttpBinExists(page: Page, namespaceName: string, httpBinName: string, orgName?: string, accountName?: string): Promise<void> {
   logStep(`ensureHttpBinExists:start namespace=${namespaceName} name=${httpBinName}`);
   for (let attempt = 0; attempt < 2; attempt++) {
-    await openHttpBinsView(page);
+    await openHttpBinsView(page, orgName, accountName);
     await selectNamespaceScope(page, namespaceName);
 
     const httpBinRow = page.getByRole('row').filter({ hasText: httpBinName }).first();
@@ -315,6 +322,19 @@ async function ensureHttpBinExists(page: Page, namespaceName: string, httpBinNam
       await createDialog.waitFor({ state: "visible", timeout: 10000 });
 
       await page.getByRole('textbox').first().fill(httpBinName);
+
+      // Select namespace in the create dialog dropdown
+      const namespaceSelect = page.locator('[test-id="generic-form-field-metadata.namespace"]').first();
+      if (await namespaceSelect.isVisible().catch(() => false)) {
+        await namespaceSelect.click();
+        await page.waitForTimeout(300);
+
+        // Click on the namespace option
+        const namespaceOption = page.locator(`[test-id="generic-form-field-metadata.namespace-option-${namespaceName}"]`).first();
+        await expect(namespaceOption).toBeVisible({ timeout: 5000 });
+        await namespaceOption.click();
+        await page.waitForTimeout(300);
+      }
 
       const submitButton = page.getByRole('button', { name: /^(Save|Submit)$/ }).first();
       for (let attempt = 0; attempt < 3; attempt++) {
@@ -349,7 +369,7 @@ async function ensureHttpBinExists(page: Page, namespaceName: string, httpBinNam
     }
 
     if (await httpBinRow.isVisible().catch(() => false)) {
-      ensureHttpBinExistsViaBackend(namespaceName, httpBinName);
+      ensureHttpBinExistsViaBackend(namespaceName, httpBinName, orgName, accountName);
       logStep(`ensureHttpBinExists:done namespace=${namespaceName} name=${httpBinName}`);
       return;
     }
@@ -359,17 +379,17 @@ async function ensureHttpBinExists(page: Page, namespaceName: string, httpBinNam
     await page.waitForTimeout(3000);
   }
 
-  ensureHttpBinExistsViaBackend(namespaceName, httpBinName);
-  await openHttpBinsView(page);
+  ensureHttpBinExistsViaBackend(namespaceName, httpBinName, orgName, accountName);
+  await openHttpBinsView(page, orgName, accountName);
   await selectNamespaceScope(page, namespaceName);
   const nameCell = page.getByRole('row').filter({ hasText: httpBinName }).first();
   await expect(nameCell).toBeVisible({ timeout: 30000 });
   logStep(`ensureHttpBinExists:done namespace=${namespaceName} name=${httpBinName}`);
 }
 
-async function assertHttpBinLinkWorks(page: Page, namespaceName: string, httpBinName: string): Promise<void> {
+async function assertHttpBinLinkWorks(page: Page, namespaceName: string, httpBinName: string, orgName?: string, accountName?: string): Promise<void> {
   logStep(`assertHttpBinLinkWorks:start namespace=${namespaceName} name=${httpBinName}`);
-  await openHttpBinsView(page);
+  await openHttpBinsView(page, orgName, accountName);
   await selectNamespaceScope(page, namespaceName);
 
   const row = page.getByRole('row').filter({ hasText: httpBinName }).first();

--- a/local-setup/e2e/helpers/log.ts
+++ b/local-setup/e2e/helpers/log.ts
@@ -4,8 +4,9 @@ function logStep(step: string): void {
   console.log(`[portal-e2e] ${new Date().toISOString()} ${step}`);
 }
 
-function portalOrgUrl(pathname = ''): string {
-  return `https://${newOrgName}.portal.localhost:8443/${pathname.replace(/^\//, '')}`;
+function portalOrgUrl(pathname = '', orgName?: string): string {
+  const org = orgName ?? newOrgName;
+  return `https://${org}.portal.localhost:8443/${pathname.replace(/^\//, '')}`;
 }
 
 export { logStep, portalOrgUrl };

--- a/local-setup/e2e/helpers/marketplace.ts
+++ b/local-setup/e2e/helpers/marketplace.ts
@@ -1,6 +1,6 @@
 import { expect, Page } from '@playwright/test';
 
-import { exampleMarketplaceEntryName, exampleProviderDisplayName, testAccountName } from './constants';
+import { exampleMarketplaceEntryName, exampleProviderDisplayName, testAccountName as defaultAccountName } from './constants';
 import { logStep, portalOrgUrl } from './log';
 
 const marketplaceFrameSelector = 'iframe[src*="/ui/marketplace/ui/"]';
@@ -11,24 +11,26 @@ async function waitForMarketplaceFrame(page: Page, srcPattern: RegExp = /\/ui\/m
   await expect(marketplaceFrame).toHaveAttribute('src', srcPattern);
 }
 
-async function openOrganizationMarketplace(page: Page): Promise<void> {
-  const marketplaceUrl = portalOrgUrl('/home/marketplace');
+async function openOrganizationMarketplace(page: Page, orgName?: string): Promise<void> {
+  const marketplaceUrl = portalOrgUrl('/home/marketplace', orgName);
   logStep(`openOrganizationMarketplace:url=${marketplaceUrl}`);
   await page.goto(marketplaceUrl, { waitUntil: 'domcontentloaded' });
   await page.waitForLoadState('load', { timeout: 10000 }).catch(() => {});
   await waitForMarketplaceFrame(page);
 }
 
-async function openAccountMarketplace(page: Page): Promise<void> {
-  const marketplaceUrl = portalOrgUrl(`/home/accounts/${testAccountName}/marketplace`);
+async function openAccountMarketplace(page: Page, orgName?: string, accountName?: string): Promise<void> {
+  const account = accountName ?? defaultAccountName;
+  const marketplaceUrl = portalOrgUrl(`/home/accounts/${account}/marketplace`, orgName);
   logStep(`openAccountMarketplace:url=${marketplaceUrl}`);
   await page.goto(marketplaceUrl, { waitUntil: 'domcontentloaded' });
   await page.waitForLoadState('load', { timeout: 10000 }).catch(() => {});
   await waitForMarketplaceFrame(page);
 }
 
-async function openAccountMarketplaceProvider(page: Page): Promise<void> {
-  const providerUrl = portalOrgUrl(`/home/accounts/${testAccountName}/provider/${exampleMarketplaceEntryName}`);
+async function openAccountMarketplaceProvider(page: Page, orgName?: string, accountName?: string): Promise<void> {
+  const account = accountName ?? defaultAccountName;
+  const providerUrl = portalOrgUrl(`/home/accounts/${account}/provider/${exampleMarketplaceEntryName}`, orgName);
   logStep(`openAccountMarketplaceProvider:url=${providerUrl}`);
   await page.goto(providerUrl, { waitUntil: 'domcontentloaded' });
   await page.waitForLoadState('load', { timeout: 10000 }).catch(() => {});
@@ -81,9 +83,9 @@ async function expectMarketplaceActionVisible(page: Page, action: 'Enable' | 'Di
   await expect(marketplaceActionButton(page, action)).toBeVisible({ timeout: 30000 });
 }
 
-async function waitForMarketplaceAction(page: Page, action: 'Enable' | 'Disable'): Promise<void> {
+async function waitForMarketplaceAction(page: Page, action: 'Enable' | 'Disable', orgName?: string, accountName?: string): Promise<void> {
   for (let attempt = 0; attempt < 10; attempt++) {
-    await openAccountMarketplaceProvider(page);
+    await openAccountMarketplaceProvider(page, orgName, accountName);
     const button = marketplaceActionButton(page, action);
     if (await button.isVisible().catch(() => false)) {
       logStep(`waitForMarketplaceAction:done action=${action} attempt=${attempt}`);
@@ -92,7 +94,7 @@ async function waitForMarketplaceAction(page: Page, action: 'Enable' | 'Disable'
     logStep(`waitForMarketplaceAction:retry action=${action} attempt=${attempt}`);
     await page.waitForTimeout(3000);
   }
-  await openAccountMarketplaceProvider(page);
+  await openAccountMarketplaceProvider(page, orgName, accountName);
   await expectMarketplaceActionVisible(page, action);
 }
 

--- a/local-setup/e2e/helpers/portal.ts
+++ b/local-setup/e2e/helpers/portal.ts
@@ -7,13 +7,16 @@ export {
 } from './constants';
 export type { TestUser } from './constants';
 
-export { logStep } from './log';
+export { logStep, portalOrgUrl } from './log';
 
-export { ensureWelcomePage, switchToOrganization } from './auth';
+export { ensureWelcomePage, inviteUserToOrg, switchToOrganization } from './auth';
 
 export {
   ensureInvitedUserExists,
   verifyDownloadedKubeconfig,
+  waitForAccountReady,
+  waitForAccountExists,
+  waitForAccountDeleted,
 } from './backend';
 
 export {

--- a/local-setup/e2e/helpers/sharding.ts
+++ b/local-setup/e2e/helpers/sharding.ts
@@ -1,0 +1,194 @@
+import { execFileSync } from 'node:child_process';
+
+import { adminKubeconfigPath, kcpClusterServer } from './constants';
+import { logStep } from './log';
+
+type ShardName = 'root' | 'triton';
+
+function runKubectl(args: string[], input?: string): string {
+  return execFileSync('kubectl', args, {
+    encoding: 'utf8',
+    input,
+    env: { ...process.env, KUBECONFIG: adminKubeconfigPath },
+  }).trim();
+}
+
+// pre-creates workspace type for organization workspace with minimum data in it
+// account-operator than patches it with the rest of the data 
+// it's needed to pre-create workspace with sharding selector
+function createWorkspaceType(typeName: string, parentPath: string): void {
+  logStep(`createWorkspaceType:start type=${typeName} parent=${parentPath}`);
+
+  const manifest = `apiVersion: tenancy.kcp.io/v1alpha1
+kind: WorkspaceType
+metadata:
+  name: ${typeName}
+spec:
+  extend:
+    with:
+    - name: org
+      path: root
+`;
+
+  runKubectl(['apply', '--server', kcpClusterServer(parentPath), '-f', '-'], manifest);
+  logStep(`createWorkspaceType:done type=${typeName}`);
+}
+
+// pre-creates workspace to allocate it on the specified shard
+function createWorkspaceWithShard(
+  workspaceName: string,
+  parentPath: string,
+  shardName: ShardName,
+  typeName: string,
+  typePath: string,
+): void {
+  logStep(`createWorkspaceWithShard:start workspace=${workspaceName} shard=${shardName}`);
+
+  const manifest = `apiVersion: tenancy.kcp.io/v1alpha1
+kind: Workspace
+metadata:
+  name: ${workspaceName}
+spec:
+  type:
+    name: ${typeName}
+    path: ${typePath}
+  location:
+    selector:
+      matchLabels:
+        name: ${shardName}
+`;
+
+  runKubectl(['apply', '--server', kcpClusterServer(parentPath), '-f', '-'], manifest);
+  logStep(`createWorkspaceWithShard:done workspace=${workspaceName} shard=${shardName}`);
+}
+
+function getWorkspaceShardFromAnnotation(workspaceName: string, parentPath: string): string {
+  try {
+    return runKubectl([
+      'get', `workspaces.tenancy.kcp.io/${workspaceName}`,
+      '--server', kcpClusterServer(parentPath),
+      '-o', 'jsonpath={.metadata.annotations.core\\.kcp\\.io/shard}',
+    ]);
+  } catch {
+    return '';
+  }
+}
+
+function waitForWorkspaceOnShard(
+  workspaceName: string,
+  parentPath: string,
+  expectedShard: ShardName,
+  timeoutSeconds = 180,
+): void {
+  logStep(`waitForWorkspaceOnShard:start workspace=${workspaceName} shard=${expectedShard} timeout=${timeoutSeconds}s`);
+
+  const server = kcpClusterServer(parentPath);
+  const startTime = Date.now();
+  const timeoutMs = timeoutSeconds * 1000;
+
+  while (Date.now() - startTime < timeoutMs) {
+    try {
+      const result = runKubectl([
+        'get', `workspaces.tenancy.kcp.io/${workspaceName}`,
+        '--server', server,
+        '-o', 'jsonpath={.status.phase},{.metadata.annotations.core\\.kcp\\.io/shard}',
+      ]);
+
+      const [phase, currentShard] = result.split(',');
+
+      if (phase === 'Ready' && currentShard === expectedShard) {
+        logStep(`waitForWorkspaceOnShard:done workspace=${workspaceName} shard=${currentShard}`);
+        return;
+      }
+
+      execFileSync('sleep', ['2']);
+    } catch {
+      execFileSync('sleep', ['2']);
+    }
+  }
+
+  throw new Error(`Workspace ${workspaceName} did not become ready on shard=${expectedShard} within ${timeoutSeconds}s`);
+}
+
+function waitForAccountReadyInOrg(accountName: string, orgName: string, timeoutSeconds = 180): void {
+  logStep(`waitForAccountReadyInOrg:start account=${accountName} org=${orgName}`);
+
+  runKubectl([
+    'wait', '--server', kcpClusterServer(`root:orgs:${orgName}`),
+    '--for=condition=Ready', `--timeout=${timeoutSeconds}s`,
+    `accounts.core.platform-mesh.io/${accountName}`,
+  ]);
+
+  logStep(`waitForAccountReadyInOrg:done account=${accountName}`);
+}
+
+function preCreateShardedOrgWorkspace(orgName: string, orgShard: ShardName): void {
+  logStep(`preCreateShardedOrgWorkspace:start org=${orgName} shard=${orgShard}`);
+
+  const typeName = `${orgName}-org`;
+  createWorkspaceType(typeName, 'root:orgs');
+  createWorkspaceWithShard(orgName, 'root:orgs', orgShard, typeName, 'root:orgs');
+
+  logStep(`preCreateShardedOrgWorkspace:done org=${orgName} shard=${orgShard}`);
+}
+
+function preCreateShardedAccountWorkspace(accountName: string, orgName: string, accountShard: ShardName): void {
+  logStep(`preCreateShardedAccountWorkspace:start account=${accountName} shard=${accountShard}`);
+
+  createWorkspaceWithShard(
+    accountName,
+    `root:orgs:${orgName}`,
+    accountShard,
+    `${orgName}-account`,
+    'root:orgs',
+  );
+
+  logStep(`preCreateShardedAccountWorkspace:done account=${accountName} shard=${accountShard}`);
+}
+
+function waitForShardedAccountReady(
+  accountName: string,
+  orgName: string,
+  expectedShard: ShardName,
+  timeoutSeconds = 180,
+): void {
+  logStep(`waitForShardedAccountReady:start account=${accountName} shard=${expectedShard}`);
+
+  waitForWorkspaceOnShard(accountName, `root:orgs:${orgName}`, expectedShard, timeoutSeconds);
+  waitForAccountReadyInOrg(accountName, orgName, timeoutSeconds);
+
+  logStep(`waitForShardedAccountReady:done account=${accountName}`);
+}
+
+function verifyShardAssignments(
+  orgName: string,
+  orgShard: ShardName,
+  accounts: Array<{ name: string; shard: ShardName }>,
+): void {
+  logStep('verifyShardAssignments:start');
+
+  const actualOrgShard = getWorkspaceShardFromAnnotation(orgName, 'root:orgs');
+  if (actualOrgShard !== orgShard) {
+    throw new Error(`Org ${orgName} on wrong shard: expected ${orgShard}, got ${actualOrgShard}`);
+  }
+  logStep(`verifyShardAssignments:org org=${orgName} shard=${actualOrgShard} ✓`);
+
+  for (const account of accounts) {
+    const actualShard = getWorkspaceShardFromAnnotation(account.name, `root:orgs:${orgName}`);
+    if (actualShard !== account.shard) {
+      throw new Error(`Account ${account.name} on wrong shard: expected ${account.shard}, got ${actualShard}`);
+    }
+    logStep(`verifyShardAssignments:account account=${account.name} shard=${actualShard} ✓`);
+  }
+
+  logStep('verifyShardAssignments:done');
+}
+
+export {
+  type ShardName,
+  preCreateShardedOrgWorkspace,
+  preCreateShardedAccountWorkspace,
+  waitForShardedAccountReady,
+  waitForWorkspaceOnShard,
+  verifyShardAssignments,
+};

--- a/local-setup/e2e/portal-account-deletion.test.ts
+++ b/local-setup/e2e/portal-account-deletion.test.ts
@@ -7,8 +7,10 @@ import {
   ensureExampleHttpbinProviderWorkspace,
   ensureAccountExists,
   deleteAccount,
+  waitForAccountDeleted,
   logStep,
 } from './helpers/portal';
+import { newOrgName, testAccountName } from './helpers/constants';
 
 test.describe('Portal Account Deletion', () => {
   test.setTimeout(600000);
@@ -19,8 +21,11 @@ test.describe('Portal Account Deletion', () => {
     await switchToOrganization(page, primaryUser, true);
     ensureExampleHttpbinProviderWorkspace();
 
-    const accountUrl = await ensureAccountExists(page);
-    await deleteAccount(page, accountUrl);
+    const url = await ensureAccountExists(page);
+    await deleteAccount(page, url);
+    waitForAccountDeleted(newOrgName, testAccountName, 120);
+    logStep(`deleteAccount:done account=${testAccountName}`);
+
     logStep('test:account-deletion:done');
   });
 });

--- a/local-setup/e2e/portal-httpbins.test.ts
+++ b/local-setup/e2e/portal-httpbins.test.ts
@@ -3,7 +3,6 @@ import test from '@playwright/test';
 import {
   primaryUser,
   testNamespaceName,
-  defaultHttpBinName,
   testNamespaceHttpBinName,
   ensureWelcomePage,
   switchToOrganization,
@@ -27,10 +26,9 @@ test.describe('Portal HTTPBins', () => {
 
     await ensureAccountExists(page);
     await ensureNamespaceExists(page, testNamespaceName);
-    await ensureHttpBinExists(page, 'default', defaultHttpBinName);
-    await assertHttpBinLinkWorks(page, 'default', defaultHttpBinName);
     await ensureHttpBinExists(page, testNamespaceName, testNamespaceHttpBinName);
     await selectNamespaceScope(page, testNamespaceName);
+    await assertHttpBinLinkWorks(page, testNamespaceName, testNamespaceHttpBinName);
     logStep('test:httpbins:done');
   });
 });

--- a/local-setup/e2e/test-register-and-navigate.test.ts
+++ b/local-setup/e2e/test-register-and-navigate.test.ts
@@ -1,290 +1,108 @@
 import test, { expect, Page } from '@playwright/test';
 
-const portalBaseUrl = 'https://portal.localhost:8443/';
-const testAccountName = 'testaccount';
-const userEmail = 'username@sap.com';
-const userPassword = 'MyPass1234';
-const firstName = 'Firstname';
-const lastName = 'Lastname';
-const newOrgName = process.env.ORG_NAME || 'default';
-const inviteUserName = 'inviteusername@sap.com';
-const testHttpBinName = 'test';
+import { inviteUserToOrg, selectExistingOrganization, ensureWelcomePage } from './helpers/auth';
+import { invitedUser, primaryUser, runId } from './helpers/constants';
+import { logStep } from './helpers/log';
+import { ensureAccountExists } from './helpers/account';
+import {
+  type ShardName,
+  preCreateShardedOrgWorkspace,
+  preCreateShardedAccountWorkspace,
+  waitForShardedAccountReady,
+  waitForWorkspaceOnShard,
+  verifyShardAssignments,
+} from './helpers/sharding';
 
-const keycloakPassword = 'password';
+// ORG_SHARD controls which shard to create the org on
+const ORG_SHARD: ShardName = (process.env.SHARDING_ORG_SHARD as ShardName) || 'triton';
+const ACCOUNT_SHARDS: ShardName[] = ['triton', 'root'];
 
+const orgName = `org-${ORG_SHARD}-${runId}`;
+const accounts = ACCOUNT_SHARDS.map((shard) => ({
+  name: `acc-${shard}-${runId}`,
+  shard,
+}));
 
-async function loginUser(page: Page): Promise<void> {
-  await page.getByRole('textbox', { name: 'Email' }).fill(userEmail);
-  await page.getByRole('textbox', { name: 'Password' }).fill(userPassword);
-  await page.getByRole('button', { name: 'Sign In' }).click();
-}
-
-async function registerOrLoginUser(page: Page): Promise<void> {
-  await page.click('text=Register', { timeout: 5000 });
-  await page.fill('input[name="email"]', userEmail);
-  await page.fill('input[id="password"]', userPassword);
-  await page.fill('input[id="password-confirm"]', userPassword);
-  await page.fill('input[id="firstName"]', firstName);
-  await page.fill('input[id="lastName"]', lastName);
-
-  await page.click('input[value="Register"]', { timeout: 5000 });
-
-  // Wait for either successful navigation or "Email already exists" error
-  const emailExistsError = page.getByText('Email already exists.');
-  const welcomeText = page.getByText('Welcome to the Platform Mesh Portal!');
-
-  // Race between success and error conditions
-  const result = await Promise.race([
-    welcomeText.waitFor({ state: 'visible', timeout: 5000 }).then(() => 'success'),
-    emailExistsError.waitFor({ state: 'visible', timeout: 5000 }).then(() => 'exists'),
-  ]).catch(() => 'timeout');
-
-  if (result === 'exists') {
-    // User already exists, go back to login and sign in
-    await page.getByRole('link', { name: 'Back to Login' }).click();
-    await loginUser(page);
-  }
-}
-
-async function completeAccountSetup(page: Page): Promise<void> {
-  // Check if we're on the "Click here to proceed" page or directly on password update
-  const proceedLink = page.getByRole('link', { name: 'Click here to proceed' });
+async function completeKeycloakSetup(page: Page): Promise<void> {
+  // Handle password update flow
   const newPasswordField = page.getByRole('textbox', { name: 'New Password' });
-
-  // Wait for either the proceed link or password field to appear
-  const firstElement = await Promise.race([
-    proceedLink.waitFor({ state: 'visible', timeout: 5000 }).then(() => 'proceed'),
-    newPasswordField.waitFor({ state: 'visible', timeout: 5000 }).then(() => 'password'),
-  ]).catch(() => 'none');
-
-  // Click proceed link if present
-  if (firstElement === 'proceed') {
-    await proceedLink.click();
-    await newPasswordField.waitFor({ state: 'visible', timeout: 5000 });
-  }
-
-  // Fill password fields if visible
-  if (firstElement === 'proceed' || firstElement === 'password') {
-    await newPasswordField.fill(userPassword);
-    await page.getByRole('textbox', { name: 'Confirm password' }).fill(userPassword);
+  if (await newPasswordField.isVisible().catch(() => false)) {
+    await newPasswordField.fill(primaryUser.password);
+    await page.getByRole('textbox', { name: 'Confirm password' }).fill(primaryUser.password);
     await page.getByRole('button', { name: 'Submit' }).click();
   }
 
-  // Check if we need to fill first/last name
+  // Handle profile update flow
   const firstNameField = page.getByRole('textbox', { name: 'First name' });
-  const backToAppLink = page.getByRole('link', { name: 'Back to Application' });
-
-  const nextElement = await Promise.race([
-    firstNameField.waitFor({ state: 'visible', timeout: 5000 }).then(() => 'name'),
-    backToAppLink.waitFor({ state: 'visible', timeout: 5000 }).then(() => 'back'),
-  ]).catch(() => 'none');
-
-  if (nextElement === 'name') {
-    await firstNameField.fill(firstName);
-    await page.getByRole('textbox', { name: 'Last name' }).fill(lastName);
+  if (await firstNameField.isVisible().catch(() => false)) {
+    await firstNameField.fill(primaryUser.firstName);
+    await page.getByRole('textbox', { name: 'Last name' }).fill(primaryUser.lastName);
     await page.getByRole('button', { name: 'Submit' }).click();
   }
 
-  // Click "Back to Application" if present
+  // Handle "back to application" link
   const backLink = page.getByRole('link', { name: 'Back to Application' });
-  const isBackLinkVisible = await backLink.isVisible().catch(() => false);
-  if (isBackLinkVisible) {
+  if (await backLink.isVisible().catch(() => false)) {
     await backLink.click();
   }
 
-  // Final login if we're on the login page
+  // Handle redirect back to login
   const emailField = page.getByRole('textbox', { name: 'Email' });
-  const isLoginPage = await emailField.isVisible().catch(() => false);
-  if (isLoginPage) {
-    await emailField.fill(userEmail);
-    await page.getByRole('textbox', { name: 'Password' }).fill(userPassword);
+  if (await emailField.isVisible().catch(() => false)) {
+    await emailField.fill(primaryUser.email);
+    await page.getByRole('textbox', { name: 'Password' }).fill(primaryUser.password);
     await page.getByRole('button', { name: 'Sign In' }).click();
   }
-}
 
-// Ensures we're on portal and the SPA finished routing
-async function ensurePortalHome(page: Page) {
-  await page.waitForURL('https://'+ newOrgName +'.portal.localhost:8443/**', { timeout: 10000 });
-  await page.waitForLoadState('networkidle', { timeout: 10000 });
-  const welcome = page.getByText("Welcome! Let's get started.", { exact: true });
-  for (let i = 0; i < 3; i++) {
-    try {
-      await expect(welcome).toBeVisible({ timeout: 5000 });
-      return;
-    } catch (e) {
-      if (i === 2) throw e;
-      await page.reload({ waitUntil: 'networkidle' });
-    }
-  }
-}
-
-async function inviteUser(page: Page, userEmailToInvite: string): Promise<void> {
-  // navigate to members page
-  await page.locator('[data-testid="members_members"]').click();
-  await page.waitForLoadState('networkidle', { timeout: 10000 });
-
-  // click on add button to add a new member to the account
-  const membersFrame = page.frameLocator('iframe[src*="organization/members"]');
-  const addButton = membersFrame.locator('[data-testid="app-iam-member-list-add-button"]');
-  await addButton.waitFor({ state: 'visible', timeout: 10000 });
-  await expect(addButton).toBeEnabled({ timeout: 10000 });
-  await addButton.scrollIntoViewIfNeeded();
-  await addButton.click();
-
-  // invite the user email by email 
-  const addMembersFrame = page.frameLocator('iframe[src*="organization/add-members"]');
-  const userInput = addMembersFrame.locator('[data-testid="app-iam-member-add-dialog-user-search-input"]').locator('input');
-  await userInput.waitFor({ state: 'visible', timeout: 10000 });
-  await userInput.fill(userEmailToInvite);
-  await addMembersFrame.getByRole('button', { name: 'Select Options' }).click();
-  await page.waitForTimeout(1000);
-
-  // press add button to add a new member
-  const inviteInFrame = addMembersFrame.locator('li.fd-combobox-list-item').filter({ hasText: 'Invite' }).filter({ hasText: userEmailToInvite });
-  const inviteInPage = page.locator('li.fd-combobox-list-item').filter({ hasText: 'Invite' }).filter({ hasText: userEmailToInvite });
-  const inviteOption = inviteInFrame.or(inviteInPage);
-  await inviteOption.waitFor({ state: 'visible', timeout: 10000 });
-  await inviteOption.click();
-  await expect(addMembersFrame.getByRole('row').filter({ hasText: userEmailToInvite })).toBeVisible({ timeout: 15000 });
-  await addMembersFrame.locator('[data-testid="app-iam-member-add-dialog-add-button"]').click();
-
-  // verify invited user appears in the members list
-  const memberEmailInList = membersFrame.locator('span.member-extra-information').filter({ hasText: userEmailToInvite });
-  await expect(memberEmailInList).toBeVisible({ timeout: 15000 });
-  await expect(memberEmailInList).toHaveText(userEmailToInvite);
+  await page.waitForURL(`https://${orgName}.portal.localhost:8443/**`, { timeout: 30000 });
+  await expect(page.getByText("Welcome! Let's get started.", { exact: true })).toBeVisible({ timeout: 15000 });
 }
 
 test.describe('Home Page', () => {
-
-  test.setTimeout(200000);  // 200 seconds test timeout
+  test.setTimeout(600000);
 
   test('Register and navigate to portal', async ({ page }) => {
-    await page.goto(portalBaseUrl);
+    logStep(`setup:start org=${orgName} shard=${ORG_SHARD}`);
 
-    await registerOrLoginUser(page);
+    // 1. Register/login
+    await ensureWelcomePage(page, primaryUser);
 
-    // Registration/login redirects to the welcome page
-    await page.waitForURL(`${portalBaseUrl}**`, { timeout: 10000 });
-    await page.waitForLoadState('load', { timeout: 10000 });
-    const verificationText = page.getByText("Welcome to the Platform Mesh Portal!");
-    await expect(verificationText).toBeVisible( { timeout: 5000 });
+    // 2. Pre-create org workspace with shard selector
+    preCreateShardedOrgWorkspace(orgName, ORG_SHARD);
 
-    await page.screenshot({ path: 'screenshot-beforeswitch.png' });
-
-    // onboard 'default' organization and switch to it
-    await page.locator('[test-id="organization-management-input"]').locator('input').fill(newOrgName);
+    // 3. Create org via UI
+    await page.locator('[test-id="organization-management-input"]').locator('input').fill(orgName);
     await page.locator('[test-id="organization-management-onboard-button"]').locator('button').click();
 
-    // Verify the newly created org is selected in the combo box
-    const orgInput = page.locator('[test-id="organization-management-input"]').locator('input');
-    await expect(orgInput).toHaveValue(newOrgName, { timeout: 5000 });
+    // 4. Wait for org workspace to be ready on shard
+    waitForWorkspaceOnShard(orgName, 'root:orgs', ORG_SHARD);
 
-    // Wait for the "Switch" button to become visible and enabled (org is ready), then click it
+    // 5. Switch to org
+    await selectExistingOrganization(page, orgName);
     const switchButton = page.locator('[test-id="organization-management-switch-button"]').locator('button');
-    await switchButton.waitFor({ state: 'visible', timeout: 60000 });
     await expect(switchButton).toBeEnabled({ timeout: 100000 });
     await switchButton.click();
 
-    // Login via Keycloak with email and static password
-    await page.getByRole('textbox', { name: 'Email' }).fill(userEmail);
-    await page.getByRole('textbox', { name: 'Password' }).fill(keycloakPassword);
+    // 6. Complete Keycloak login
+    await page.getByRole('textbox', { name: 'Email' }).fill(primaryUser.email);
+    await page.getByRole('textbox', { name: 'Password' }).fill(primaryUser.keycloakPassword);
     await page.getByRole('button', { name: 'Sign In' }).click();
+    await completeKeycloakSetup(page);
 
-    // Complete account setup (handles both new and existing user flows)
-    await completeAccountSetup(page);
+    // 7. Invite user
+    await inviteUserToOrg(page, invitedUser.email);
 
-    // Be explicit: make sure we're on the portal origin and the SPA has rendered
-    await ensurePortalHome(page);
-
-    // verify user invite on organization level
-    await inviteUser(page, inviteUserName);
-
-    await page.locator('[data-testid="accounts_accounts"]').click();
-    // click on "Create" button
-    await page.getByRole('button', { name: 'Create', exact: true }).click();
-
-    const accountCreateDialog = page.locator('ui5-dialog[open]').first();
-    await accountCreateDialog.waitFor({ state: 'visible', timeout: 10000 });
-    await page.getByRole('textbox').first().fill(testAccountName);
-
-    // The account create form has a required ui5-select for "Type" (single value "account").
-    // Open it via mouse click and select via keyboard since ui5-option click events don't
-    // propagate through Playwright's locator-based clicks (popover lives in static area).
-    const typeSelectInfo = await page.evaluate(() => {
-      function find(root: Document | ShadowRoot): { x: number; y: number } | null {
-        for (const el of Array.from(root.querySelectorAll('ui5-select'))) {
-          const value = (el as any).value ?? el.getAttribute('value') ?? '';
-          if (el.hasAttribute('required') && !value) {
-            const rect = (el as HTMLElement).getBoundingClientRect();
-            if (rect.width > 0 && rect.height > 0) {
-              return { x: Math.round(rect.left + rect.width / 2), y: Math.round(rect.top + rect.height / 2) };
-            }
-          }
-        }
-        for (const el of Array.from(root.querySelectorAll('*'))) {
-          if ((el as any).shadowRoot) {
-            const found = find((el as any).shadowRoot);
-            if (found) return found;
-          }
-        }
-        return null;
-      }
-      return find(document);
-    }).catch(() => null);
-    if (typeSelectInfo) {
-      await page.mouse.click(typeSelectInfo.x, typeSelectInfo.y);
-      await page.waitForTimeout(500);
-      await page.keyboard.press('ArrowDown');
-      await page.waitForTimeout(100);
-      await page.keyboard.press('Enter');
-      await page.waitForTimeout(300);
+    // 8. Create accounts with shard selectors
+    for (const account of accounts) {
+      preCreateShardedAccountWorkspace(account.name, orgName, account.shard);
+      await ensureAccountExists(page, orgName, account.name);
+      waitForShardedAccountReady(account.name, orgName, account.shard);
+      logStep(`setup:account-created ${account.name}@${account.shard}`);
     }
 
-    const accountSaveButton = page.getByRole('button', { name: /^(Save|Submit)$/ }).first();
-    await expect(accountSaveButton).toBeEnabled({ timeout: 10000 });
-    await accountSaveButton.click();
+    // 9. Verify shard assignments
+    verifyShardAssignments(orgName, ORG_SHARD, accounts);
 
-    const accountElement = page.getByRole('row').filter({ hasText: testAccountName }).first();
-    await expect(accountElement).toBeVisible( { timeout: 30000 } );
-
-    // Wait for the account to be ready: navigate directly to account dashboard
-    await accountElement.click();
-    const downloadButton = page.getByRole('button', { name: 'Download kubeconfig' });
-    await expect(downloadButton).toBeVisible( { timeout: 60000 } );
-
-    const download1Promise = page.waitForEvent('download');
-    await downloadButton.click();
-    const download = await download1Promise;
-    expect(download).toBeDefined();
-
-    await page.locator('[data-testid="orchestrate_platform-mesh_io_httpbins_httpbins"]').click();
-
-    const scopeCombobox = page.locator('[data-testid="namespace-selection-combobox"]').first();
-    await expect(scopeCombobox).toBeVisible({ timeout: 15000 });
-
-    await scopeCombobox.click();
-    await scopeCombobox.press('F4');
-    await expect(scopeCombobox).toHaveAttribute('open', '');
-
-    const defaultScopeItem = page.locator('[data-testid="namespace-selection-combobox-item-default"]');
-    await defaultScopeItem.waitFor({ state: 'visible', timeout: 10000 });
-    await defaultScopeItem.click();
-    await expect(scopeCombobox).toContainText('default');
-
-    await page.getByRole('button', { name: 'Create' }).click();
-    const httpBinCreateDialog = page.locator('ui5-dialog[open]').first();
-    await httpBinCreateDialog.waitFor({ state: 'visible', timeout: 10000 });
-    await page.getByRole('textbox').first().fill(testHttpBinName);
-    await page.waitForTimeout(1000);
-    const httpBinSaveButton = page.getByRole('button', { name: /^(Save|Submit)$/ }).first();
-    await expect(httpBinSaveButton).toBeEnabled({ timeout: 5000 });
-    await httpBinSaveButton.click();
-
-    // Wait for dialog to close
-    await httpBinCreateDialog.waitFor({ state: 'hidden', timeout: 30000 });
-
-    // Ensure http bin resource was created and appears in the list
-    const httpBinNameCell = page.getByRole('row').filter({ hasText: testHttpBinName }).first();
-    await expect(httpBinNameCell).toBeVisible({ timeout: 30000 });
+    logStep(`setup:done org=${orgName}`);
   });
 });


### PR DESCRIPTION
On-behalf-of: SAP aleh.yarshou@sap.com

Changes:
1. Now tests run 2 organizations on different shards, also create 2 accounts on different shards within each organization.
2. Force workspace distribution on shards by pre-creating workspaces with `spec.location` selector
3. Use sharded tests as a default portal tests

This pr is related to https://github.com/platform-mesh/helm-charts/issues/2083