### PR TITLE
Faster local-setup + stati output for future dissecting

### DIFF
--- a/.github/workflows/kind-localsetup.yaml
+++ b/.github/workflows/kind-localsetup.yaml
@@ -92,7 +92,7 @@ jobs:
           kubectl krew install oidc-login
       - name: Run local-setup with sharded example data
         run: |
-          task local-setup:example-data
+          task local-setup:concurrent:example-data
       - name: Check/wait for all components to be ready
         run: |
           sleep 10

--- a/.github/workflows/nightly-local-setup.yaml
+++ b/.github/workflows/nightly-local-setup.yaml
@@ -46,7 +46,7 @@ jobs:
           kubectl krew install oidc-login
       - name: Run local-setup with sharded example data
         run: |
-          task local-setup:example-data
+          task local-setup:concurrent:example-data
       - name: Check/wait for all components to be ready
         run: |
           sleep 10

--- a/local-setup/scripts/ocm-build-component.sh
+++ b/local-setup/scripts/ocm-build-component.sh
@@ -185,11 +185,11 @@ resolve_component_versions() {
     export MARKETPLACE_UI_CHART_VERSION=$(get_ocm_resource_version "github.com/platform-mesh/helm-charts/marketplace-ui" '.items[0].element | .version')
     export MARKETPLACE_UI_IMAGE_VERSION=$(get_ocm_resource_version "github.com/platform-mesh/images/marketplace-ui" '.items[0].element | .version')
 
-    kubectl exec $(get_kubectl_exec_flags) ocm-transfer-pod -- ocm transfer componentversion --overwrite --copy-resources --no-update europe-docker.pkg.dev/gardener-project/releases//github.com/gardener/etcd-druid:$GARDENER_ETCD_DRUID_VERSION oci-registry-docker-registry.registry.svc.cluster.local/platform-mesh &
+    kubectl exec -i ocm-transfer-pod -- ocm transfer componentversion --overwrite --copy-resources --no-update europe-docker.pkg.dev/gardener-project/releases//github.com/gardener/etcd-druid:$GARDENER_ETCD_DRUID_VERSION oci-registry-docker-registry.registry.svc.cluster.local/platform-mesh &
     # TODO: the api-syncagent OCM CV must be updated
-    kubectl exec $(get_kubectl_exec_flags) ocm-transfer-pod -- ocm transfer componentversion --overwrite ghcr.io/platform-mesh//github.com/kcp-dev/api-syncagent:0.4.4 oci-registry-docker-registry.registry.svc.cluster.local/platform-mesh --recursive &
-    kubectl exec $(get_kubectl_exec_flags) ocm-transfer-pod -- ocm transfer componentversion --overwrite ghcr.io/platform-mesh//github.com/platform-mesh/helm-charts/marketplace-ui:$MARKETPLACE_UI_CHART_VERSION oci-registry-docker-registry.registry.svc.cluster.local/platform-mesh --recursive &
-    kubectl exec $(get_kubectl_exec_flags) ocm-transfer-pod -- ocm transfer componentversion --overwrite ghcr.io/platform-mesh//github.com/platform-mesh/images/marketplace-ui:$MARKETPLACE_UI_IMAGE_VERSION oci-registry-docker-registry.registry.svc.cluster.local/platform-mesh --recursive &
+    kubectl exec -i ocm-transfer-pod -- ocm transfer componentversion --overwrite ghcr.io/platform-mesh//github.com/kcp-dev/api-syncagent:0.4.4 oci-registry-docker-registry.registry.svc.cluster.local/platform-mesh --recursive &
+    kubectl exec -i ocm-transfer-pod -- ocm transfer componentversion --overwrite ghcr.io/platform-mesh//github.com/platform-mesh/helm-charts/marketplace-ui:$MARKETPLACE_UI_CHART_VERSION oci-registry-docker-registry.registry.svc.cluster.local/platform-mesh --recursive &
+    kubectl exec -i ocm-transfer-pod -- ocm transfer componentversion --overwrite ghcr.io/platform-mesh//github.com/platform-mesh/images/marketplace-ui:$MARKETPLACE_UI_IMAGE_VERSION oci-registry-docker-registry.registry.svc.cluster.local/platform-mesh --recursive &
     wait
 
     echo -e "${COL}[$(date '+%H:%M:%S')] Finished resolving component versions${COL_RES}"

--- a/local-setup/scripts/ocm-build-component.sh
+++ b/local-setup/scripts/ocm-build-component.sh
@@ -185,11 +185,12 @@ resolve_component_versions() {
     export MARKETPLACE_UI_CHART_VERSION=$(get_ocm_resource_version "github.com/platform-mesh/helm-charts/marketplace-ui" '.items[0].element | .version')
     export MARKETPLACE_UI_IMAGE_VERSION=$(get_ocm_resource_version "github.com/platform-mesh/images/marketplace-ui" '.items[0].element | .version')
 
-    kubectl exec $(get_kubectl_exec_flags) ocm-transfer-pod -- ocm transfer componentversion --overwrite --copy-resources --no-update europe-docker.pkg.dev/gardener-project/releases//github.com/gardener/etcd-druid:$GARDENER_ETCD_DRUID_VERSION oci-registry-docker-registry.registry.svc.cluster.local/platform-mesh
+    kubectl exec $(get_kubectl_exec_flags) ocm-transfer-pod -- ocm transfer componentversion --overwrite --copy-resources --no-update europe-docker.pkg.dev/gardener-project/releases//github.com/gardener/etcd-druid:$GARDENER_ETCD_DRUID_VERSION oci-registry-docker-registry.registry.svc.cluster.local/platform-mesh &
     # TODO: the api-syncagent OCM CV must be updated
-    kubectl exec $(get_kubectl_exec_flags) ocm-transfer-pod -- ocm transfer componentversion --overwrite ghcr.io/platform-mesh//github.com/kcp-dev/api-syncagent:0.4.4 oci-registry-docker-registry.registry.svc.cluster.local/platform-mesh --recursive
-    kubectl exec $(get_kubectl_exec_flags) ocm-transfer-pod -- ocm transfer componentversion --overwrite ghcr.io/platform-mesh//github.com/platform-mesh/helm-charts/marketplace-ui:$MARKETPLACE_UI_CHART_VERSION oci-registry-docker-registry.registry.svc.cluster.local/platform-mesh --recursive
-    kubectl exec $(get_kubectl_exec_flags) ocm-transfer-pod -- ocm transfer componentversion --overwrite ghcr.io/platform-mesh//github.com/platform-mesh/images/marketplace-ui:$MARKETPLACE_UI_IMAGE_VERSION oci-registry-docker-registry.registry.svc.cluster.local/platform-mesh --recursive
+    kubectl exec $(get_kubectl_exec_flags) ocm-transfer-pod -- ocm transfer componentversion --overwrite ghcr.io/platform-mesh//github.com/kcp-dev/api-syncagent:0.4.4 oci-registry-docker-registry.registry.svc.cluster.local/platform-mesh --recursive &
+    kubectl exec $(get_kubectl_exec_flags) ocm-transfer-pod -- ocm transfer componentversion --overwrite ghcr.io/platform-mesh//github.com/platform-mesh/helm-charts/marketplace-ui:$MARKETPLACE_UI_CHART_VERSION oci-registry-docker-registry.registry.svc.cluster.local/platform-mesh --recursive &
+    kubectl exec $(get_kubectl_exec_flags) ocm-transfer-pod -- ocm transfer componentversion --overwrite ghcr.io/platform-mesh//github.com/platform-mesh/images/marketplace-ui:$MARKETPLACE_UI_IMAGE_VERSION oci-registry-docker-registry.registry.svc.cluster.local/platform-mesh --recursive &
+    wait
 
     echo -e "${COL}[$(date '+%H:%M:%S')] Finished resolving component versions${COL_RES}"
 }

--- a/local-setup/scripts/ocm-build-component.sh
+++ b/local-setup/scripts/ocm-build-component.sh
@@ -157,34 +157,33 @@ resolve_component_versions() {
 
     echo -e "${COL}[$(date '+%H:%M:%S')] Resolving third-party component versions...${COL_RES}"
 
-    # Third-party components (always remote)
+    # Third-party version pins live in .github/workflows/ocm-aggregator.yaml's env block.
+    local agg="$PROJECT_ROOT/.github/workflows/ocm-aggregator.yaml"
+    export KCP_OPERATOR_CHART_VERSION=$(yq -r '.jobs.ocm.env.KCP_OPERATOR_CHART_VERSION' "$agg")
+    export KCP_OPERATOR_IMAGE_VERSION=$(yq -r '.jobs.ocm.env.KCP_OPERATOR_IMAGE_VERSION' "$agg")
+    export KCP_VERSION=$(yq -r '.jobs.ocm.env.KCP_VERSION' "$agg")
+    export INIT_AGENT_CHART_VERSION=$(yq -r '.jobs.ocm.env.INIT_AGENT_CHART_VERSION' "$agg")
+    export INIT_AGENT_IMAGE_VERSION=$(yq -r '.jobs.ocm.env.INIT_AGENT_IMAGE_VERSION' "$agg")
+    export OPENFGA_VERSION=$(yq -r '.jobs.ocm.env.OPENFGA_VERSION' "$agg")
+    export OPENFGA_IMAGE_VERSION=$(yq -r '.jobs.ocm.env.OPENFGA_IMAGE_VERSION' "$agg")
+    export OPENFGA_POSTGRESQL_IMAGE_VERSION=$(yq -r '.jobs.ocm.env.OPENFGA_POSTGRESQL_IMAGE_VERSION' "$agg")
+    export GATEWAY_API_VERSION=$(yq -r '.jobs.ocm.env.GATEWAY_API_VERSION' "$agg")
+    export GATEWAY_API_COMMIT=$(yq -r '.jobs.ocm.env.GATEWAY_API_COMMIT' "$agg")
+    export TRAEFIK_VERSION=$(yq -r '.jobs.ocm.env.TRAEFIK_VERSION' "$agg")
+    export TRAEFIK_CHART_VERSION=$(yq -r '.jobs.ocm.env.TRAEFIK_CHART_VERSION' "$agg")
+    export TRAEFIK_IMAGE_VERSION=$(yq -r '.jobs.ocm.env.TRAEFIK_IMAGE_VERSION' "$agg")
+    export TRAEFIK_CRD_VERSION=$(yq -r '.jobs.ocm.env.TRAEFIK_CRD_VERSION' "$agg")
+    export CERT_MANAGER_VERSION=$(yq -r '.jobs.ocm.env.CERT_MANAGER_VERSION' "$agg")
+    export CNPG_OPERATOR_CHART_VERSION=$(yq -r '.jobs.ocm.env.CNPG_OPERATOR_CHART_VERSION' "$agg")
+    export CNPG_OPERATOR_IMAGE_VERSION=$(yq -r '.jobs.ocm.env.CNPG_OPERATOR_IMAGE_VERSION' "$agg")
+    export PROMETHEUS_OPERATOR_CRDS_VERSION=$(yq -r '.jobs.ocm.env.PROMETHEUS_OPERATOR_CRDS_VERSION' "$agg")
+    export KUBE_PROMETHEUS_STACK_VERSION=$(yq -r '.jobs.ocm.env.KUBE_PROMETHEUS_STACK_VERSION' "$agg")
+    export OPENTELEMETRY_OPERATOR_VERSION=$(yq -r '.jobs.ocm.env.OPENTELEMETRY_OPERATOR_VERSION' "$agg")
+
+    # Versions not pinned in the aggregator: keep remote lookups.
     export GARDENER_ETCD_DRUID_VERSION=$(get_external_component_version github.com/gardener/etcd-druid europe-docker.pkg.dev/gardener-project/releases)
-    export ISTIO_VERSION=$(get_ocm_resource_version "github.com/istio/istio/base" '.items[0].element["version"]')
-    export OPENFGA_VERSION=$(get_ocm_resource_version "github.com/openfga/openfga" '.items[0].element["version"]')
-    export CNPG_OPERATOR_VERSION=$(get_ocm_resource_version "github.com/cloudnative-pg/cloudnative-pg" '.items[0].element["version"]')
-    export CNPG_OPERATOR_CHART_VERSION=$(get_ocm_resource_version "github.com/cloudnative-pg/cloudnative-pg" '.items[] | select(.element.name == "chart") | .element.version')
-    export CNPG_OPERATOR_IMAGE_VERSION=$(get_ocm_resource_version "github.com/cloudnative-pg/cloudnative-pg" '.items[] | select(.element.type == "ociImage") | .element.version')
-    export KCP_OPERATOR_VERSION=$(get_ocm_resource_version "github.com/kcp-dev/kcp-operator" '.items[0].element["version"]')
-    export KCP_IMAGE_VERSION=$(get_ocm_resource_version "github.com/kcp-dev/kcp-operator" '.items[] | select(.element.type == "ociImage") | .element.version' | sed 's/^0\.0\.0-//')
-    export GATEWAY_API_VERSION=$(get_ocm_resource_version "github.com/kubernetes-sigs/gateway-api" '.items[0].element["version"]')
-    export GATEWAY_API_COMMIT=$(get_ocm_resource_version "github.com/kubernetes-sigs/gateway-api" '.items[0].element.access["commit"]')
-    export TRAEFIK_VERSION=$(get_ocm_resource_version "github.com/traefik/traefik" '.items[0].element["version"]')
-    export TRAEFIK_CHART_VERSION=$(get_ocm_resource_version "github.com/traefik/traefik" '.items[] | select(.element.name == "chart") | .element.version')
-    export TRAEFIK_CRD_VERSION=$(get_ocm_resource_version "github.com/traefik/traefik" '.items[1].element["version"]')
-    export CERT_MANAGER_VERSION=$(get_ocm_resource_version "github.com/cert-manager/cert-manager" '.items[0].element["version"]')
-    export KCP_OPERATOR_CHART_VERSION=$(get_ocm_resource_version "github.com/kcp-dev/kcp-operator" '.items[0].element["version"]')
-    export KCP_OPERATOR_IMAGE_VERSION=$(get_ocm_resource_version "github.com/kcp-dev/kcp-operator" '.items[] | select(.element.type == "ociImage") | .element.version')
-    export KCP_VERSION=$(get_ocm_resource_version "github.com/kcp-dev/kcp" '.items[0].element["version"]')
-    export INIT_AGENT_CHART_VERSION=$(get_ocm_resource_version "github.com/kcp-dev/init-agent" '.items[0].element["version"]')
-    export INIT_AGENT_IMAGE_VERSION=$(get_ocm_resource_version "github.com/kcp-dev/init-agent" '.items[] | select(.element.type == "ociImage") | .element.version')
-    export TRAEFIK_IMAGE_VERSION=$(get_ocm_resource_version "github.com/traefik/traefik" '.items[] | select(.element.type == "ociImage" and .element.name == "image") | .element.version')
-    export OPENFGA_IMAGE_VERSION=$(get_ocm_resource_version "github.com/openfga/openfga" '.items[] | select(.element.type == "ociImage" and .element.name == "image") | .element.version')
-    export OPENFGA_POSTGRESQL_IMAGE_VERSION=$(get_ocm_resource_version "github.com/openfga/openfga" '.items[] | select(.element.type == "ociImage" and .element.name == "postgresql-image") | .element.version')
     export MARKETPLACE_UI_CHART_VERSION=$(get_ocm_resource_version "github.com/platform-mesh/helm-charts/marketplace-ui" '.items[0].element | .version')
     export MARKETPLACE_UI_IMAGE_VERSION=$(get_ocm_resource_version "github.com/platform-mesh/images/marketplace-ui" '.items[0].element | .version')
-    export PROMETHEUS_OPERATOR_CRDS_VERSION=$(get_ocm_resource_version "github.com/prometheus-community/prometheus-operator-crds" '.items[0].element["version"]')
-    export KUBE_PROMETHEUS_STACK_VERSION=$(get_ocm_resource_version "github.com/prometheus-community/kube-prometheus-stack" '.items[0].element["version"]')
-    export OPENTELEMETRY_OPERATOR_VERSION=$(get_ocm_resource_version "github.com/open-telemetry/opentelemetry-operator" '.items[0].element["version"]')
 
     kubectl exec $(get_kubectl_exec_flags) ocm-transfer-pod -- ocm transfer componentversion --overwrite --copy-resources --no-update europe-docker.pkg.dev/gardener-project/releases//github.com/gardener/etcd-druid:$GARDENER_ETCD_DRUID_VERSION oci-registry-docker-registry.registry.svc.cluster.local/platform-mesh
     # TODO: the api-syncagent OCM CV must be updated
@@ -213,7 +212,6 @@ build_final_component() {
         OPENFGA_VERSION="$OPENFGA_VERSION" \
         PM_OPENFGA_VERSION="$OPENFGA_VERSION" \
         KCP_OPERATOR_VERSION="$KCP_OPERATOR_VERSION" \
-        KCP_IMAGE_VERSION="$KCP_IMAGE_VERSION" \
         GARDENER_ETCD_DRUID_VERSION="$GARDENER_ETCD_DRUID_VERSION" \
         ACCOUNT_OPERATOR_VERSION="$ACCOUNT_OPERATOR_VERSION" \
         PLATFORM_MESH_OPERATOR_VERSION="$PLATFORM_MESH_OPERATOR_VERSION" \

--- a/local-setup/scripts/ocm-build-local-charts.sh
+++ b/local-setup/scripts/ocm-build-local-charts.sh
@@ -281,20 +281,20 @@ build_local_charts() {
             # Start background job
             prepare_and_push_chart "$comp" "$chart_dir" &
             pids+=($!)
-            ((running++))
+            running=$((running + 1))
 
             # Limit concurrency
             if ((running >= MAX_PARALLEL)); then
                 # Wait for any one job to finish
                 wait -n 2>/dev/null || true
-                ((running--))
+                running=$((running - 1))
             fi
         done
 
         # Wait for all remaining jobs to complete
         for pid in "${pids[@]}"; do
             if ! wait "$pid"; then
-                ((failed++))
+                failed=$((failed + 1))
             fi
         done
     else
@@ -304,7 +304,7 @@ build_local_charts() {
             local chart_dir="${pair#*:}"
 
             if ! prepare_and_push_chart "$comp" "$chart_dir"; then
-                ((failed++))
+                failed=$((failed + 1))
             fi
         done
     fi

--- a/local-setup/scripts/start.sh
+++ b/local-setup/scripts/start.sh
@@ -611,9 +611,47 @@ fi
 ###############################################################################
 
 echo -e "${COL}[$(date '+%H:%M:%S')] Waiting for kind: PlatformMesh resource to become ready ${COL_RES}"
+if [[ -n "$CI" ]]; then
+    # Dedupe consecutive watch lines per object.
+    # kubectl emits a row on every resourceVersion bump, we only want rows where status columns changed.
+    # TIME is stripped from the comparison so a refreshed transition time without a status change doesn't reprint.
+    # Key is $2 $3 (NS+NAME for HR, NAME+READY for PM).
+    dedupe_by_object() {
+        awk '{ rest=$0; sub(/^[^ ]+ +/, "", rest); key=$2 FS $3; if (rest != last[key]) { print; last[key]=rest } fflush() }'
+    }
+
+    # Background watcher: log HelmRelease ready-state transitions while we wait,
+    # so the slow chart is visible in CI logs.
+    HR_READY_CONDITION='.status.conditions[?(@.type=="Ready")]'
+    HR_COLUMNS="TIME:${HR_READY_CONDITION}.lastTransitionTime"
+    HR_COLUMNS+=",NS:.metadata.namespace"
+    HR_COLUMNS+=",NAME:.metadata.name"
+    HR_COLUMNS+=",READY:${HR_READY_CONDITION}.status"
+    HR_COLUMNS+=",REASON:${HR_READY_CONDITION}.reason"
+    kubectl "${RUNTIME_KC[@]}" get hr -A -w -o "custom-columns=$HR_COLUMNS" | dedupe_by_object &
+    HR_WATCHER_PID=$!
+
+    # Background watcher: log PlatformMesh ready-state transitions alongside.
+    PM_READY_CONDITION='.status.conditions[?(@.type=="Ready")]'
+    PM_COLUMNS="TIME:${PM_READY_CONDITION}.lastTransitionTime"
+    PM_COLUMNS+=",NAME:.metadata.name"
+    PM_COLUMNS+=",READY:${PM_READY_CONDITION}.status"
+    PM_COLUMNS+=",REASON:${PM_READY_CONDITION}.reason"
+    PM_COLUMNS+=",MESSAGE:${PM_READY_CONDITION}.message"
+    kubectl "${RUNTIME_KC[@]}" get platformmesh -n platform-mesh-system -w -o "custom-columns=$PM_COLUMNS" | dedupe_by_object &
+    PM_WATCHER_PID=$!
+
+    trap "kill $HR_WATCHER_PID $PM_WATCHER_PID 2>/dev/null || true" EXIT
+fi
+
 kubectl "${RUNTIME_KC[@]}" wait --namespace platform-mesh-system \
   --for=condition=Ready platformmesh \
   --timeout=$KUBECTL_WAIT_TIMEOUT platform-mesh
+
+if [[ -n "$HR_WATCHER_PID" ]]; then
+    kill $HR_WATCHER_PID $PM_WATCHER_PID 2>/dev/null || true
+    trap - EXIT
+fi
 
 ###############################################################################
 # Remote: post-install waits


### PR DESCRIPTION
1. Use --concurrent in workflow
2. Resolve versions locally
3. Paralllize the few leftover ocm lookups
4. Log CR stati to inspect later