### PR TITLE
More CI improvements

### DIFF
--- a/.github/workflows/kind-localsetup.yaml
+++ b/.github/workflows/kind-localsetup.yaml
@@ -116,6 +116,12 @@ jobs:
           cache: 'npm'
           cache-dependency-path: 'local-setup/e2e'
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('local-setup/e2e/package-lock.json') }}
+
       - name: Run e2e tests
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/kind-localsetup.yaml
+++ b/.github/workflows/kind-localsetup.yaml
@@ -101,14 +101,6 @@ jobs:
           kubectl wait --for=condition=ready --timeout=10m hr --all -A
           kubectl wait --for=condition=Available --timeout=10m deployment --all -A
 
-      - name: Cache node modules
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: ~/node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
       - name: Setup Node.js 22
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/.github/workflows/nightly-local-setup.yaml
+++ b/.github/workflows/nightly-local-setup.yaml
@@ -70,6 +70,12 @@ jobs:
           cache: 'npm'
           cache-dependency-path: 'local-setup/e2e'
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('local-setup/e2e/package-lock.json') }}
+
       - name: Run e2e tests with video recording
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly-local-setup.yaml
+++ b/.github/workflows/nightly-local-setup.yaml
@@ -55,14 +55,6 @@ jobs:
           kubectl wait --for=condition=ready --timeout=10m hr --all -A
           kubectl wait --for=condition=Available --timeout=10m deployment --all -A
 
-      - name: Cache node modules
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: ~/node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
       - name: Setup Node.js 22
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -306,16 +306,25 @@ tasks:
         vars: { ORG_NAME: '{{.ORG_NAME}}', TEST_ACCOUNT_NAME: '{{.TEST_ACCOUNT_NAME}}', HEADED: 'true' }
 
   test:portal-e2e:video:
-    desc: Run portal e2e tests with video recording (sharded, sequential)
+    desc: Run portal e2e tests with video recording (sharded, parallel)
     vars:
       TEST_RUN_ID: '{{.TEST_RUN_ID | default (now | unixEpoch | printf "%.8s")}}'
+    deps:
+      - task: test:portal-e2e:video:shard
+        vars: { TEST_RUN_ID: '{{.TEST_RUN_ID}}', SHARDING_ORG_SHARD: 'root' }
+      - task: test:portal-e2e:video:shard
+        vars: { TEST_RUN_ID: '{{.TEST_RUN_ID}}', SHARDING_ORG_SHARD: 'triton' }
+
+  test:portal-e2e:video:shard:
+    internal: true
+    vars:
+      TEST_RUN_ID: '{{.TEST_RUN_ID}}'
+      SHARDING_ORG_SHARD: '{{.SHARDING_ORG_SHARD}}'
     deps: [test:portal-e2e:setup]
     dir: local-setup/e2e
     cmds:
-      - VIDEO=true TEST_RUN_ID={{.TEST_RUN_ID}} SHARDING_ORG_SHARD=root npx playwright test test-register-and-navigate.test.ts
-      - VIDEO=true TEST_RUN_ID={{.TEST_RUN_ID}} SHARDING_ORG_SHARD=triton npx playwright test test-register-and-navigate.test.ts
-      - VIDEO=true ORG_NAME=org-root-{{.TEST_RUN_ID}} TEST_ACCOUNT_NAME=acc-root-{{.TEST_RUN_ID}} npx playwright test portal-*.test.ts --workers=1
-      - VIDEO=true ORG_NAME=org-triton-{{.TEST_RUN_ID}} TEST_ACCOUNT_NAME=acc-triton-{{.TEST_RUN_ID}} npx playwright test portal-*.test.ts --workers=1
+      - VIDEO=true TEST_RUN_ID={{.TEST_RUN_ID}} SHARDING_ORG_SHARD={{.SHARDING_ORG_SHARD}} npx playwright test test-register-and-navigate.test.ts
+      - VIDEO=true ORG_NAME=org-{{.SHARDING_ORG_SHARD}}-{{.TEST_RUN_ID}} TEST_ACCOUNT_NAME=acc-{{.SHARDING_ORG_SHARD}}-{{.TEST_RUN_ID}} npx playwright test portal-*.test.ts --workers=1
 
   test:portal-e2e:deletion:
     vars:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -245,7 +245,7 @@ tasks:
     dir: local-setup/e2e
     cmds:
       - npm ci
-      - npx playwright install
+      - npx playwright install chromium ffmpeg
 
   test:portal-e2e:httpbins:
     vars:


### PR DESCRIPTION
1. Run e2e video in parallel like the non-video tests
2. Install playwright with chromium and cache it
3. Drop the node_module caching, node modules live in a subdir of the repo, not ~/node_modules and are cached by setup-node