### PR TITLE
Cache etcd-druid OCM CV

### DIFF
--- a/.github/workflows/kind-localsetup.yaml
+++ b/.github/workflows/kind-localsetup.yaml
@@ -90,6 +90,14 @@ jobs:
           kubectl krew install kcp-dev/ws
           kubectl krew install kcp-dev/create-workspace
           kubectl krew install oidc-login
+      - name: Resolve third-party OCM versions
+        id: ocm-versions
+        run: local-setup/scripts/ocm-resolve-thirdparty-versions.sh
+      - name: Cache OCM etcd-druid
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: .ocm/cache/etcd-druid
+          key: ocm-thirdparty-etcd-druid-${{ steps.ocm-versions.outputs.etcd_druid }}
       - name: Run local-setup with sharded example data
         run: |
           task local-setup:concurrent:example-data

--- a/.github/workflows/nightly-local-setup.yaml
+++ b/.github/workflows/nightly-local-setup.yaml
@@ -44,6 +44,14 @@ jobs:
           kubectl krew install kcp-dev/ws
           kubectl krew install kcp-dev/create-workspace
           kubectl krew install oidc-login
+      - name: Resolve third-party OCM versions
+        id: ocm-versions
+        run: local-setup/scripts/ocm-resolve-thirdparty-versions.sh
+      - name: Cache OCM etcd-druid
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: .ocm/cache/etcd-druid
+          key: ocm-thirdparty-etcd-druid-${{ steps.ocm-versions.outputs.etcd_druid }}
       - name: Run local-setup with sharded example data
         run: |
           task local-setup:concurrent:example-data

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ local-setup/scripts/certs
 *.log
 *.pid
 .ocm/transport.ctf/
+.ocm/cache/
 ocm/.ocm/transport.ctf/
 .ocm/component-constructor-prerelease.yaml
 ./*.tgz

--- a/local-setup/e2e/helpers/constants.ts
+++ b/local-setup/e2e/helpers/constants.ts
@@ -46,8 +46,12 @@ type TestUser = {
   keycloakPassword: string;
 };
 
+const primaryUserShard = process.env.SHARDING_ORG_SHARD
+  || process.env.ORG_NAME?.match(/^org-(root|triton)-/)?.[1]
+  || '';
+const primaryUserEmailShard = primaryUserShard ? `-${primaryUserShard}` : '';
 const primaryUser: TestUser = {
-  email: process.env.TEST_USER_EMAIL || 'username@sap.com',
+  email: process.env.TEST_USER_EMAIL || `username${primaryUserEmailShard}@sap.com`,
   password: process.env.TEST_USER_PASSWORD || 'MyPass1234',
   firstName: process.env.TEST_USER_FIRST_NAME || 'Firstname',
   lastName: process.env.TEST_USER_LAST_NAME || 'Lastname',

--- a/local-setup/scripts/ocm-build-component.sh
+++ b/local-setup/scripts/ocm-build-component.sh
@@ -132,6 +132,37 @@ get_external_component_version() {
     "$LOCAL_BIN/ocm" --config "$OCM_DIR/config" get componentversions --latest "$component" --repo "$repo" -o json | jq -r '.items[0].component.version'
 }
 
+# Transfer etcd-druid into the cluster OCI registry, via a host-side CTF cache
+# directory. On CI cache hit the upstream pull is skipped — we just push the
+# cached CTF into the cluster registry. On miss the upstream transfer
+# populates the cache directory for future runs (actions/cache saves it
+# post-job if its key didn't match on restore).
+transfer_etcd_druid_with_cache() {
+    local cache_dir="$OCM_DIR/cache/etcd-druid"
+    local ref="europe-docker.pkg.dev/gardener-project/releases//github.com/gardener/etcd-druid:$GARDENER_ETCD_DRUID_VERSION"
+    local cluster_oci="$LOCAL_REGISTRY/platform-mesh"
+
+    if [ -d "$cache_dir" ] && [ -n "$(ls -A "$cache_dir" 2>/dev/null)" ]; then
+        echo -e "${COL}[$(date '+%H:%M:%S')] etcd-druid: using cached CTF at $cache_dir${COL_RES}"
+    else
+        echo -e "${COL}[$(date '+%H:%M:%S')] etcd-druid: cache miss, transferring from gardener registry${COL_RES}"
+        rm -rf "$cache_dir"
+        mkdir -p "$(dirname "$cache_dir")"
+        "$LOCAL_BIN/ocm" --config "$OCM_DIR/config" transfer componentversion \
+            --overwrite --copy-resources --no-update "$ref" "$cache_dir"
+    fi
+
+    # Push from the host cache directory into the in-cluster OCI registry via
+    # the transfer pod (the pod is the only thing that can reach the cluster
+    # registry's TLS service over its self-signed cert chain).
+    local pod_path=".ocm/cache-etcd-druid"
+    kubectl exec -i ocm-transfer-pod -- rm -rf "$pod_path"
+    kubectl exec -i ocm-transfer-pod -- mkdir -p "$pod_path"
+    kubectl cp "$cache_dir" -n default "ocm-transfer-pod:$pod_path/"
+    kubectl exec -i ocm-transfer-pod -- ocm transfer ctf --overwrite \
+        "$pod_path/$(basename "$cache_dir")" "$cluster_oci"
+}
+
 # Resolve all component versions
 resolve_component_versions() {
     echo -e "${COL}[$(date '+%H:%M:%S')] Resolving component versions...${COL_RES}"
@@ -185,11 +216,11 @@ resolve_component_versions() {
     export MARKETPLACE_UI_CHART_VERSION=$(get_ocm_resource_version "github.com/platform-mesh/helm-charts/marketplace-ui" '.items[0].element | .version')
     export MARKETPLACE_UI_IMAGE_VERSION=$(get_ocm_resource_version "github.com/platform-mesh/images/marketplace-ui" '.items[0].element | .version')
 
-    kubectl exec -i ocm-transfer-pod -- ocm transfer componentversion --overwrite --copy-resources --no-update europe-docker.pkg.dev/gardener-project/releases//github.com/gardener/etcd-druid:$GARDENER_ETCD_DRUID_VERSION oci-registry-docker-registry.registry.svc.cluster.local/platform-mesh &
     # TODO: the api-syncagent OCM CV must be updated
     kubectl exec -i ocm-transfer-pod -- ocm transfer componentversion --overwrite ghcr.io/platform-mesh//github.com/kcp-dev/api-syncagent:0.4.4 oci-registry-docker-registry.registry.svc.cluster.local/platform-mesh --recursive &
     kubectl exec -i ocm-transfer-pod -- ocm transfer componentversion --overwrite ghcr.io/platform-mesh//github.com/platform-mesh/helm-charts/marketplace-ui:$MARKETPLACE_UI_CHART_VERSION oci-registry-docker-registry.registry.svc.cluster.local/platform-mesh --recursive &
     kubectl exec -i ocm-transfer-pod -- ocm transfer componentversion --overwrite ghcr.io/platform-mesh//github.com/platform-mesh/images/marketplace-ui:$MARKETPLACE_UI_IMAGE_VERSION oci-registry-docker-registry.registry.svc.cluster.local/platform-mesh --recursive &
+    transfer_etcd_druid_with_cache &
     wait
 
     echo -e "${COL}[$(date '+%H:%M:%S')] Finished resolving component versions${COL_RES}"

--- a/local-setup/scripts/ocm-resolve-thirdparty-versions.sh
+++ b/local-setup/scripts/ocm-resolve-thirdparty-versions.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Resolve third-party OCM component versions that vary at runtime, before any
+# transfers happen. Used in CI to compute actions/cache keys; can also be run
+# locally to inspect resolved versions.
+#
+# Output:
+#   - prints "<name>=<version>" lines to stdout (one per resolved component)
+#   - if $GITHUB_OUTPUT is set, appends the same as step outputs
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/ocm-setup.sh"
+
+LOCAL_BIN="${LOCAL_BIN:-$PROJECT_ROOT/bin}"
+OCM_DIR="${OCM_DIR:-$PROJECT_ROOT/.ocm}"
+
+setup_ocm_cli >/dev/null
+export_ocm_path
+
+# etcd-druid: --latest from gardener releases
+ETCD_DRUID_VERSION=$("$LOCAL_BIN/ocm" --config "$OCM_DIR/config" get componentversions --latest \
+    github.com/gardener/etcd-druid --repo europe-docker.pkg.dev/gardener-project/releases -o json \
+    | jq -r '.items[0].component.version')
+
+if [ -z "$ETCD_DRUID_VERSION" ] || [ "$ETCD_DRUID_VERSION" = "null" ]; then
+    echo "Failed to resolve etcd-druid version" >&2
+    exit 1
+fi
+
+echo "etcd_druid=$ETCD_DRUID_VERSION"
+
+if [ -n "$GITHUB_OUTPUT" ]; then
+    echo "etcd_druid=$ETCD_DRUID_VERSION" >> "$GITHUB_OUTPUT"
+fi


### PR DESCRIPTION
We pull etcd-druid on every local-setup and CI run.
By caching in `.ocm/cache` we skip this for local-setups as long as the version doesn't change and for CI we can cache the version instead of pushing into the in-cluster registry on every run and instead copy from the cache.

fixes: https://github.com/platform-mesh/helm-charts/issues/2107 