### PR TITLE
fix: RootShard and TLSRoute not using kcp.external.hostname

### DIFF
--- a/charts/infra/Chart.yaml
+++ b/charts/infra/Chart.yaml
@@ -2,7 +2,7 @@ type: application
 apiVersion: v2
 name: infra
 description: A Helm chart for Kubernetes
-version: 0.31.0
+version: 0.31.1
 appVersion: "0.0.0"
 
 dependencies:

--- a/charts/infra/Chart.yaml
+++ b/charts/infra/Chart.yaml
@@ -2,7 +2,7 @@ type: application
 apiVersion: v2
 name: infra
 description: A Helm chart for Kubernetes
-version: 0.31.1
+version: 0.32.0
 appVersion: "0.0.0"
 
 dependencies:

--- a/charts/infra/README.md
+++ b/charts/infra/README.md
@@ -114,9 +114,10 @@ A Helm chart for Kubernetes
 | kcp.image.tag | string | `""` |  |
 | kcp.namespace | string | `"platform-mesh-system"` |  |
 | kcp.rootShard.extraArgs[0] | string | `"--feature-gates=WorkspaceAuthentication=true"` |  |
+| kcp.rootShard.hostname | string | `"root.kcp.localhost"` | Hostname for the root shard. Defaults to "root.kcp.<kcp.external.hostname>" when unset. |
 | kcp.rootShard.replicas | int | `1` |  |
 | kcp.rootShard.resources | object | `{}` | Optional resource requests and limits for the root shard |
-| kcp.rootShard.shardBaseURL | string | `"https://root.kcp.localhost:8443/"` |  |
+| kcp.rootShard.shardBaseURL | string | `"https://root.kcp.localhost:8443/"` | Base URL the root shard advertises. Defaults to "https://<rootShard.hostname>:<kcp.external.port>/" when unset. |
 | kcp.shards[0].name | string | `"nereus"` |  |
 | kcp.shards[1].name | string | `"triton"` |  |
 | kcp.webhook.authorizationWebhookSecretName | string | `"kcp-webhook-secret"` |  |

--- a/charts/infra/templates/kcp/root-shard.yaml
+++ b/charts/infra/templates/kcp/root-shard.yaml
@@ -1,3 +1,5 @@
+{{- $rootShardHostname := printf "root.kcp.%s" .Values.kcp.external.hostname }}
+{{- $rootShardBaseURL := printf "https://%s:%v/" $rootShardHostname .Values.kcp.external.port }}
 {{ include "kcp.etcd" (dict "name" (.Values.kcp.etcd.name | default "etcd-kcp-client") "namespace" (.Values.kcp.namespace | default "kcp-system") "etcd" .Values.kcp.etcd) }}
 ---
 apiVersion: operator.kcp.io/v1alpha1
@@ -6,7 +8,7 @@ metadata:
   name: root
   namespace: {{ .Values.kcp.namespace | default "kcp-system" }}
 spec:
-{{- include "kcp.shard.spec" (dict "root" $ "replicas" .Values.kcp.rootShard.replicas "shardBaseURL" .Values.kcp.rootShard.shardBaseURL "extraArgs" .Values.kcp.rootShard.extraArgs "resources" .Values.kcp.rootShard.resources "hostname" .Values.kcp.external.hostname "port" .Values.kcp.external.port "webhookPort" .Values.kcp.webhook.port) | nindent 2 }}
+{{- include "kcp.shard.spec" (dict "root" $ "replicas" .Values.kcp.rootShard.replicas "shardBaseURL" $rootShardBaseURL "extraArgs" .Values.kcp.rootShard.extraArgs "resources" .Values.kcp.rootShard.resources "hostname" .Values.kcp.external.hostname "port" .Values.kcp.external.port "webhookPort" .Values.kcp.webhook.port) | nindent 2 }}
   certificates:
     issuerRef:
       group: cert-manager.io

--- a/charts/infra/templates/kcp/root-shard.yaml
+++ b/charts/infra/templates/kcp/root-shard.yaml
@@ -1,5 +1,5 @@
-{{- $rootShardHostname := printf "root.kcp.%s" .Values.kcp.external.hostname }}
-{{- $rootShardBaseURL := printf "https://%s:%v/" $rootShardHostname .Values.kcp.external.port }}
+{{- $rootShardHostname := .Values.kcp.rootShard.hostname | default (printf "root.kcp.%s" .Values.kcp.external.hostname) }}
+{{- $rootShardBaseURL := .Values.kcp.rootShard.shardBaseURL | default (printf "https://%s:%v/" $rootShardHostname .Values.kcp.external.port) }}
 {{ include "kcp.etcd" (dict "name" (.Values.kcp.etcd.name | default "etcd-kcp-client") "namespace" (.Values.kcp.namespace | default "kcp-system") "etcd" .Values.kcp.etcd) }}
 ---
 apiVersion: operator.kcp.io/v1alpha1
@@ -27,6 +27,6 @@ spec:
           - root-kcp
           - root-kcp.{{ .Values.kcp.namespace | default "kcp-system" }}
           - root-kcp.{{ .Values.kcp.namespace | default "kcp-system" }}.svc.cluster.local
-          - root.kcp.{{ .Values.kcp.external.hostname }}
+          - {{ $rootShardHostname }}
 ---
-{{ include "kcp.tlsroute" (dict "name" "kcp-root-shard-tlsroute" "hostname" (printf "root.kcp.%s" .Values.kcp.external.hostname) "serviceName" "root-kcp" "namespace" (.Values.kcp.namespace | default "kcp-system") "gatewayName" .Values.gatewayApi.name) }}
+{{ include "kcp.tlsroute" (dict "name" "kcp-root-shard-tlsroute" "hostname" $rootShardHostname "serviceName" "root-kcp" "namespace" (.Values.kcp.namespace | default "kcp-system") "gatewayName" .Values.gatewayApi.name) }}

--- a/charts/infra/templates/kcp/root-shard.yaml
+++ b/charts/infra/templates/kcp/root-shard.yaml
@@ -25,6 +25,6 @@ spec:
           - root-kcp
           - root-kcp.{{ .Values.kcp.namespace | default "kcp-system" }}
           - root-kcp.{{ .Values.kcp.namespace | default "kcp-system" }}.svc.cluster.local
-          - root.kcp.localhost
+          - root.kcp.{{ .Values.kcp.external.hostname }}
 ---
-{{ include "kcp.tlsroute" (dict "name" "kcp-root-shard-tlsroute" "hostname" "root.kcp.localhost" "serviceName" "root-kcp" "namespace" (.Values.kcp.namespace | default "kcp-system") "gatewayName" .Values.gatewayApi.name) }}
+{{ include "kcp.tlsroute" (dict "name" "kcp-root-shard-tlsroute" "hostname" (printf "root.kcp.%s" .Values.kcp.external.hostname) "serviceName" "root-kcp" "namespace" (.Values.kcp.namespace | default "kcp-system") "gatewayName" .Values.gatewayApi.name) }}

--- a/charts/infra/tests/application_test.yaml
+++ b/charts/infra/tests/application_test.yaml
@@ -113,6 +113,9 @@ tests:
       external:
         hostname: example.com
         port: 8443
+      rootShard:
+        hostname: null
+        shardBaseURL: null
   asserts:
   - documentIndex: 2
     equal:
@@ -126,11 +129,66 @@ tests:
       external:
         hostname: example.com
         port: 8443
+      rootShard:
+        hostname: null
+        shardBaseURL: null
   asserts:
   - documentIndex: 1
     equal:
       path: spec.shardBaseURL
       value: https://root.kcp.example.com:8443/
+- it: root-shard defaults to root.kcp.localhost
+  templates:
+    - kcp/root-shard.yaml
+  asserts:
+  - documentIndex: 1
+    equal:
+      path: spec.shardBaseURL
+      value: https://root.kcp.localhost:8443/
+  - documentIndex: 2
+    equal:
+      path: spec.hostnames[0]
+      value: root.kcp.localhost
+  - documentIndex: 1
+    contains:
+      path: spec.certificateTemplates.server.spec.dnsNames
+      content: root.kcp.localhost
+- it: root-shard honors explicit kcp.rootShard.hostname override
+  templates:
+    - kcp/root-shard.yaml
+  set:
+    kcp:
+      external:
+        hostname: example.com
+        port: 8443
+      rootShard:
+        hostname: my-root.example.org
+        shardBaseURL: null
+  asserts:
+  - documentIndex: 1
+    equal:
+      path: spec.shardBaseURL
+      value: https://my-root.example.org:8443/
+  - documentIndex: 2
+    equal:
+      path: spec.hostnames[0]
+      value: my-root.example.org
+- it: root-shard honors explicit kcp.rootShard.shardBaseURL override
+  templates:
+    - kcp/root-shard.yaml
+  set:
+    kcp:
+      external:
+        hostname: example.com
+        port: 8443
+      rootShard:
+        hostname: null
+        shardBaseURL: https://custom-shard.example.org:9999/
+  asserts:
+  - documentIndex: 1
+    equal:
+      path: spec.shardBaseURL
+      value: https://custom-shard.example.org:9999/
 - it: configure etcd backup store
   templates:
     - kcp/root-shard.yaml

--- a/charts/infra/tests/application_test.yaml
+++ b/charts/infra/tests/application_test.yaml
@@ -118,6 +118,19 @@ tests:
     equal:
       path: spec.hostnames[0]
       value: root.kcp.example.com
+- it: root-shard shardBaseURL derived from kcp.external.hostname
+  templates:
+    - kcp/root-shard.yaml
+  set:
+    kcp:
+      external:
+        hostname: example.com
+        port: 8443
+  asserts:
+  - documentIndex: 1
+    equal:
+      path: spec.shardBaseURL
+      value: https://root.kcp.example.com:8443/
 - it: configure etcd backup store
   templates:
     - kcp/root-shard.yaml

--- a/charts/infra/tests/application_test.yaml
+++ b/charts/infra/tests/application_test.yaml
@@ -105,6 +105,19 @@ tests:
             memory: 256Mi
   asserts:
   - matchSnapshot: {}
+- it: root-shard TLSRoute uses kcp.external.hostname
+  templates:
+    - kcp/root-shard.yaml
+  set:
+    kcp:
+      external:
+        hostname: example.com
+        port: 8443
+  asserts:
+  - documentIndex: 2
+    equal:
+      path: spec.hostnames[0]
+      value: root.kcp.example.com
 - it: configure etcd backup store
   templates:
     - kcp/root-shard.yaml

--- a/charts/infra/values.yaml
+++ b/charts/infra/values.yaml
@@ -96,6 +96,9 @@ kcp:
 
   rootShard:
     replicas: 1
+    # -- Hostname for the root shard. Defaults to "root.kcp.<kcp.external.hostname>" when unset.
+    hostname: root.kcp.localhost
+    # -- Base URL the root shard advertises. Defaults to "https://<rootShard.hostname>:<kcp.external.port>/" when unset.
     shardBaseURL: https://root.kcp.localhost:8443/
     # -- Optional resource requests and limits for the root shard
     resources: {}


### PR DESCRIPTION
There is a hard-coded localhost used as value to be applied to the kcp.tlsroute template.
Also the root shard template is relying on the hard-coded defaults.

If someone specifies kcp.external.hostname this value should be taken instead. Otherwise, the TLSRoute does not configure the hosts correctly. Same same with the root shard.

This change introduces the usage of the kcp.external.hostname template variable for both resources.

refers to [#issue](https://github.com/platform-mesh/platform-mesh-operator/issues/674)
