### PR TITLE
Include app and chart version in bump branch names

### DIFF
--- a/.github/workflows/update-chart-parameters.yaml
+++ b/.github/workflows/update-chart-parameters.yaml
@@ -72,7 +72,7 @@ jobs:
 
           new_chart_version=$(yq '.version' "$chart_file")
           new_app_version=$(yq '.appVersion' "$chart_file" | tr -d '"')
-          branch="bump/${INPUT_CHART}-${new_chart_version}"
+          branch="bump/${INPUT_CHART}-${new_app_version}--${new_chart_version}"
           git checkout -b "$branch"
           git add "$chart_file"
           git commit -s -m "Set $new_chart_version / $new_app_version in $chart_file"


### PR DESCRIPTION
Update the bump branch name format in the update-chart-parameters workflow to `bump/<component>-<app-version>--<chart-version>` (e.g. `bump/portal-0.14.1--1.2.3`) so both versions are visible in the branch name.