### PR TITLE
Pin keycloak and etcd-druid + renovate manager

### DIFF
--- a/.github/workflows/ocm-aggregator.yaml
+++ b/.github/workflows/ocm-aggregator.yaml
@@ -65,7 +65,6 @@ jobs:
       KCP_VERSION: "v0.32.0"
       INIT_AGENT_CHART_VERSION: "0.2.0"
       INIT_AGENT_IMAGE_VERSION: "v0.2.0"
-      PM_KEYCLOAK_VERSION: "26.6.0"
       OPENFGA_VERSION: "0.2.62"
       OPENFGA_IMAGE_VERSION: "v1.14.0"
       OPENFGA_POSTGRESQL_IMAGE_VERSION: "17.9.0-debian-12-r3"
@@ -80,6 +79,10 @@ jobs:
       CNPG_OPERATOR_IMAGE_VERSION: "1.29.0"
       PROMETHEUS_OPERATOR_CRDS_VERSION: "29.0.0"
       KUBE_PROMETHEUS_STACK_VERSION: "27.0.0"
+      # renovate: datasource=docker depName=europe-docker.pkg.dev/gardener-project/releases/component-descriptors/github.com/gardener/etcd-druid
+      GARDENER_ETCD_DRUID_VERSION: "v0.36.4"
+      # renovate: datasource=docker depName=ghcr.io/platform-mesh/component-descriptors/github.com/platform-mesh/keycloak
+      PM_KEYCLOAK_VERSION: "26.6.0"
       # PM-stamped component descriptor versions for third-party components.
       # Bump these to publish a new descriptor without touching resource versions. If resource
       # versions change, make sure to bump those as well.
@@ -180,9 +183,8 @@ jobs:
           echo KEYCLOAK_OPERATOR_VERSION=$(yq '.version' charts/keycloak-operator/Chart.yaml) >> $GITHUB_ENV
           echo OBSERVABILITY_VERSION=$(yq '.version' charts/observability/Chart.yaml) >> $GITHUB_ENV
 
-          # Remote components
-          echo KEYCLOAK_VERSION=$(./ocm get componentversions --latest github.com/platform-mesh/keycloak --repo ghcr.io/platform-mesh -o json | jq -r '.items[0].component.version') >> $GITHUB_ENV
-          echo GARDENER_ETCD_DRUID_VERSION=$(./ocm get componentversions --latest github.com/gardener/etcd-druid --repo europe-docker.pkg.dev/gardener-project/releases -o json | jq -r '.items[0].component.version') >> $GITHUB_ENV
+          # KEYCLOAK_VERSION (the platform-mesh keycloak component descriptor) tracks PM_KEYCLOAK_VERSION above.
+          echo KEYCLOAK_VERSION=${PM_KEYCLOAK_VERSION} >> $GITHUB_ENV
 
           # Get current platform-mesh version
           PM_VERSION=$(./ocm get componentversions --latest github.com/platform-mesh/platform-mesh --repo ghcr.io/platform-mesh -o json | jq -r '.items[0].component.version')

--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,17 @@
       "versioningTemplate": "semver",
       "depNameTemplate": "ghcr.io/open-component-model/kubernetes/controller/chart",
       "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": "Pinned third-party OCM component versions in the aggregator workflow",
+      "managerFilePatterns": [
+        "/(^|/)\\.github/workflows/ocm-aggregator\\.yaml$/"
+      ],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(?:\\s+versioning=(?<versioning>\\S+))?\\s*\\n\\s*\\S+:\\s*\"?(?<currentValue>[^\"\\s]+)\"?"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{versioning}}{{else}}semver{{/if}}"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
Drop the dynamic resolution of etcd-druid.
Keycloak was already pinned but still resolved.
Both are updated by a renovate custom manager.

Required for reproducible versions and so e.g. backported versions don't cause unwanted side-effects like upgrading keycloak.