### PR TITLE
Add missing permissions to package OCM

### DIFF
--- a/.github/workflows/pipeline-chart.yml
+++ b/.github/workflows/pipeline-chart.yml
@@ -169,3 +169,6 @@ jobs:
     needs: [ocm]
     uses: ./.github/workflows/ocm-aggregator.yaml
     secrets: inherit
+    permissions:
+      contents: read
+      packages: write


### PR DESCRIPTION
Because the workflow is now used directly instead of via `gh workflow run` the permissions needed to set as well.