### PR TITLE
chore: bump httpbin operator version

### DIFF
--- a/charts/example-httpbin-operator/Chart.yaml
+++ b/charts/example-httpbin-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: example-httpbin-operator
 description: A Helm chart for deploying the httpbin operator and its CRDs
 type: application
-version: 0.6.2
+version: 0.6.3
 appVersion: "v0.6.2"
 annotations:
   # Automatically install and upgrade CRDs


### PR DESCRIPTION
On-behalf-of: SAP aleh.yarshou@sap.com

Bump httpbin-operator version to build a new version of httpbin-operator component with new apisync-agent