### PR TITLE
fix: remove external field from Shard CR spec (DXPFRAME-2416)

### DIFF
--- a/charts/infra/templates/kcp/_kcp-helpers.tpl
+++ b/charts/infra/templates/kcp/_kcp-helpers.tpl
@@ -117,9 +117,11 @@ auth:
   {{- end }}
   {{- end }}
 {{- end }}
+{{- if .includeExternal }}
 external:
   hostname: {{ .hostname }}
   port: {{ .port }}
+{{- end }}
 {{- if (.root.Values.kcp.webhook).enabled }}
 authorization:
   webhook:

--- a/charts/infra/templates/kcp/root-shard.yaml
+++ b/charts/infra/templates/kcp/root-shard.yaml
@@ -8,7 +8,7 @@ metadata:
   name: root
   namespace: {{ .Values.kcp.namespace | default "kcp-system" }}
 spec:
-{{- include "kcp.shard.spec" (dict "root" $ "replicas" .Values.kcp.rootShard.replicas "shardBaseURL" $rootShardBaseURL "extraArgs" .Values.kcp.rootShard.extraArgs "resources" .Values.kcp.rootShard.resources "hostname" .Values.kcp.external.hostname "port" .Values.kcp.external.port "webhookPort" .Values.kcp.webhook.port) | nindent 2 }}
+{{- include "kcp.shard.spec" (dict "root" $ "replicas" .Values.kcp.rootShard.replicas "shardBaseURL" $rootShardBaseURL "extraArgs" .Values.kcp.rootShard.extraArgs "resources" .Values.kcp.rootShard.resources "hostname" .Values.kcp.external.hostname "port" .Values.kcp.external.port "webhookPort" .Values.kcp.webhook.port "includeExternal" true) | nindent 2 }}
   certificates:
     issuerRef:
       group: cert-manager.io

--- a/charts/infra/tests/__snapshot__/application_test.yaml.snap
+++ b/charts/infra/tests/__snapshot__/application_test.yaml.snap
@@ -429,9 +429,6 @@ Gateway API enabled:
       etcd:
         endpoints:
           - http://etcd-kcp-nereus-client.platform-mesh-system.svc.cluster.local:2379
-      external:
-        hostname: localhost
-        port: 8443
       extraArgs:
         - --feature-gates=WorkspaceAuthentication=true
       proxy:
@@ -556,9 +553,6 @@ Gateway API enabled:
       etcd:
         endpoints:
           - http://etcd-kcp-triton-client.platform-mesh-system.svc.cluster.local:2379
-      external:
-        hostname: localhost
-        port: 8443
       extraArgs:
         - --feature-gates=WorkspaceAuthentication=true
       proxy:
@@ -1090,9 +1084,6 @@ Istio disabled:
       etcd:
         endpoints:
           - http://etcd-kcp-nereus-client.platform-mesh-system.svc.cluster.local:2379
-      external:
-        hostname: localhost
-        port: 8443
       extraArgs:
         - --feature-gates=WorkspaceAuthentication=true
       proxy:
@@ -1217,9 +1208,6 @@ Istio disabled:
       etcd:
         endpoints:
           - http://etcd-kcp-triton-client.platform-mesh-system.svc.cluster.local:2379
-      external:
-        hostname: localhost
-        port: 8443
       extraArgs:
         - --feature-gates=WorkspaceAuthentication=true
       proxy:
@@ -1751,9 +1739,6 @@ Istio enabled:
       etcd:
         endpoints:
           - http://etcd-kcp-nereus-client.platform-mesh-system.svc.cluster.local:2379
-      external:
-        hostname: localhost
-        port: 8443
       extraArgs:
         - --feature-gates=WorkspaceAuthentication=true
       proxy:
@@ -1878,9 +1863,6 @@ Istio enabled:
       etcd:
         endpoints:
           - http://etcd-kcp-triton-client.platform-mesh-system.svc.cluster.local:2379
-      external:
-        hostname: localhost
-        port: 8443
       extraArgs:
         - --feature-gates=WorkspaceAuthentication=true
       proxy:
@@ -2745,9 +2727,6 @@ match snapshots:
       etcd:
         endpoints:
           - http://etcd-kcp-nereus-client.platform-mesh-system.svc.cluster.local:2379
-      external:
-        hostname: localhost
-        port: 8443
       extraArgs:
         - --feature-gates=WorkspaceAuthentication=true
       image:
@@ -2876,9 +2855,6 @@ match snapshots:
       etcd:
         endpoints:
           - http://etcd-kcp-triton-client.platform-mesh-system.svc.cluster.local:2379
-      external:
-        hostname: localhost
-        port: 8443
       extraArgs:
         - --feature-gates=WorkspaceAuthentication=true
       image:
@@ -3455,9 +3431,6 @@ match snapshots w. hostAliases enabled:
       etcd:
         endpoints:
           - http://etcd-kcp-nereus-client.platform-mesh-system.svc.cluster.local:2379
-      external:
-        hostname: localhost
-        port: 8443
       extraArgs:
         - --feature-gates=WorkspaceAuthentication=true
       proxy:
@@ -3602,9 +3575,6 @@ match snapshots w. hostAliases enabled:
       etcd:
         endpoints:
           - http://etcd-kcp-triton-client.platform-mesh-system.svc.cluster.local:2379
-      external:
-        hostname: localhost
-        port: 8443
       extraArgs:
         - --feature-gates=WorkspaceAuthentication=true
       proxy:
@@ -4154,9 +4124,6 @@ match snapshots w. kcp version:
       etcd:
         endpoints:
           - http://etcd-kcp-nereus-client.platform-mesh-system.svc.cluster.local:2379
-      external:
-        hostname: localhost
-        port: 8443
       extraArgs:
         - --feature-gates=WorkspaceAuthentication=true
       image:
@@ -4285,9 +4252,6 @@ match snapshots w. kcp version:
       etcd:
         endpoints:
           - http://etcd-kcp-triton-client.platform-mesh-system.svc.cluster.local:2379
-      external:
-        hostname: localhost
-        port: 8443
       extraArgs:
         - --feature-gates=WorkspaceAuthentication=true
       image:
@@ -4823,9 +4787,6 @@ match snapshots with mailpit enabled:
       etcd:
         endpoints:
           - http://etcd-kcp-nereus-client.platform-mesh-system.svc.cluster.local:2379
-      external:
-        hostname: localhost
-        port: 8443
       extraArgs:
         - --feature-gates=WorkspaceAuthentication=true
       proxy:
@@ -4950,9 +4911,6 @@ match snapshots with mailpit enabled:
       etcd:
         endpoints:
           - http://etcd-kcp-triton-client.platform-mesh-system.svc.cluster.local:2379
-      external:
-        hostname: localhost
-        port: 8443
       extraArgs:
         - --feature-gates=WorkspaceAuthentication=true
       proxy:
@@ -5145,9 +5103,6 @@ render additional shard with explicit hostname:
       etcd:
         endpoints:
           - http://etcd-kcp-shard-1-client.platform-mesh-system.svc.cluster.local:2379
-      external:
-        hostname: localhost
-        port: 8443
       extraArgs:
         - --feature-gates=WorkspaceAuthentication=true
       proxy:


### PR DESCRIPTION
## Summary

The `kcp.shard.spec` helper template was unconditionally emitting an `external:` block in the spec of every CR it rendered. However, `operator.kcp.io/v1alpha1 Shard` does not declare that field in its schema — only `RootShard` does — causing ArgoCD to fail with:

```
failed to create typed patch object (platform-mesh-system/nereus; operator.kcp.io/v1alpha1, Kind=Shard):
.spec.external: field not declared in schema
```

## Fix

Added an `includeExternal` flag to the `kcp.shard.spec` helper. `root-shard.yaml` passes `includeExternal: true` to keep the block on `RootShard`. `shards.yaml` omits it, so `Shard` CRs no longer include the undeclared field.

## Test plan

- [x] `helm unittest` passes (147 snapshots updated to remove `external:` from `Shard` specs)
- [ ] Verify nereus and triton `Shard` CRs apply cleanly after ArgoCD sync