### PR TITLE
Add triton.kcp.localhost to hostAliases in local-setup rgd

### DIFF
--- a/local-setup/kustomize/base/rgd/rgd.yaml
+++ b/local-setup/kustomize/base/rgd/rgd.yaml
@@ -150,3 +150,4 @@ spec:
               - portal.localhost
               - localhost
               - root.kcp.localhost
+              - triton.kcp.localhost


### PR DESCRIPTION
Adds `triton.kcp.localhost` to rgd, otherwise providers controller ( @ platform-mesh-operator) fails to start.