### PR TITLE
Use GitHub App for approving bot PRs

### DIFF
--- a/.github/workflows/update-chart-parameters.yaml
+++ b/.github/workflows/update-chart-parameters.yaml
@@ -27,6 +27,12 @@ jobs:
           private-key: ${{ secrets.PM_PUBLISHER_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        id: approver-app-token
+        with:
+          app-id: "4247305"
+          private-key: ${{ secrets.PM_APPROVER_PRIVATE_KEY }}
+          permission-pull-requests: write
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -109,10 +115,9 @@ jobs:
           fi
           echo "url=$url" >> "$GITHUB_OUTPUT"
       - name: Approve PR
-        if: steps.bump.outputs.changed == 'true'
+        if: steps.pr.outputs.url != ''
         env:
-          # Approve as github-actions[bot]
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.approver-app-token.outputs.token }}
           PR_URL: ${{ steps.pr.outputs.url }}
         run: |
           gh pr review "$PR_URL" --approve


### PR DESCRIPTION
Use GitHub App for approving Helm chart PRs so that we can use read-only token in GitHub Actions by default.