### PR TITLE
Add write permissions to PR approver app

### DIFF
--- a/.github/workflows/update-chart-parameters.yaml
+++ b/.github/workflows/update-chart-parameters.yaml
@@ -32,6 +32,7 @@ jobs:
         with:
           app-id: "4247305"
           private-key: ${{ secrets.PM_APPROVER_PRIVATE_KEY }}
+          permission-contents: write
           permission-pull-requests: write
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:


### PR DESCRIPTION
The PR got approved, but that approved is not being considered because the app doesn't have write permissions:

> At least 1 approving review is required by reviewers with write access.

Giving the `contents: write` permission to the app should grant it the write access.