### PR TITLE
feat: use existing CA and issuer for the kcp certificate

### DIFF
--- a/charts/infra/Chart.yaml
+++ b/charts/infra/Chart.yaml
@@ -2,7 +2,7 @@ type: application
 apiVersion: v2
 name: infra
 description: A Helm chart for Kubernetes
-version: 0.35.2
+version: 0.36.0
 appVersion: "0.0.0"
 
 dependencies:

--- a/charts/infra/README.md
+++ b/charts/infra/README.md
@@ -97,6 +97,8 @@ A Helm chart for Kubernetes
 | kcp.cacheServer.etcd.service.name | string | `"etcd-cache-client"` |  |
 | kcp.cacheServer.etcd.service.port | int | `2379` |  |
 | kcp.cacheServer.name | string | `"cache-server"` |  |
+| kcp.certificates.caSecretRef | object | `{}` | Existing CA to sign from directly. Secret must be of type kubernetes.io/tls and contain the CA certificate and its private key. Mutually exclusive with issuerRef. |
+| kcp.certificates.issuerRef | object | `{}` | Existing Issuer/ClusterIssuer that signs the kcp certificate chain. It must be able to issue CA certificates. Mutually exclusive with caSecretRef. |
 | kcp.etcd.backup.compression.enabled | bool | `false` |  |
 | kcp.etcd.backup.compression.policy | string | `"gzip"` |  |
 | kcp.etcd.backup.deltaSnapshotMemoryLimit | string | `"1Gi"` |  |

--- a/charts/infra/templates/kcp/_kcp-helpers.tpl
+++ b/charts/infra/templates/kcp/_kcp-helpers.tpl
@@ -172,3 +172,39 @@ deploymentTemplate:
 extraArgs:
 {{ toYaml .extraArgs | indent 2 }}
 {{- end -}}
+
+{{- define "kcp.certificates" -}}
+{{- $certs := .Values.kcp.certificates | default dict -}}
+{{- $issuerRef := $certs.issuerRef | default dict -}}
+{{- $caSecretRef := $certs.caSecretRef | default dict -}}
+{{- if and $issuerRef $caSecretRef -}}
+{{- fail "kcp.certificates.issuerRef and kcp.certificates.caSecretRef are mutually exclusive, set at most one" -}}
+{{- end -}}
+{{- if and $caSecretRef (not $caSecretRef.name) -}}
+{{- fail "kcp.certificates.caSecretRef.name is required when caSecretRef is set" -}}
+{{- end -}}
+{{- if and $issuerRef (not $issuerRef.name) -}}
+{{- fail "kcp.certificates.issuerRef.name is required when issuerRef is set" -}}
+{{- end -}}
+{{- if $caSecretRef -}}
+caSecretRef:
+  name: {{ $caSecretRef.name }}
+{{- else if $issuerRef -}}
+issuerRef:
+  group: {{ $issuerRef.group | default "cert-manager.io" }}
+  kind: {{ $issuerRef.kind | default "Issuer" }}
+  name: {{ $issuerRef.name }}
+{{- else -}}
+issuerRef:
+  group: cert-manager.io
+  kind: Issuer
+  name: selfsigned
+{{- end -}}
+{{- end -}}
+
+{{- define "kcp.certificates.createIssuer" -}}
+{{- $certs := .Values.kcp.certificates | default dict -}}
+{{- if not (or ($certs.issuerRef | default dict) ($certs.caSecretRef | default dict)) -}}
+true
+{{- end -}}
+{{- end -}}

--- a/charts/infra/templates/kcp/cache-server.yaml
+++ b/charts/infra/templates/kcp/cache-server.yaml
@@ -11,8 +11,5 @@ spec:
     endpoints:
       - http://{{ .Values.kcp.cacheServer.etcd.service.name }}.{{ .Values.kcp.namespace | default "kcp-system" }}.svc.cluster.local:{{ .Values.kcp.cacheServer.etcd.service.port }}
   certificates:
-    issuerRef:
-      name: selfsigned
-      kind: Issuer
-      group: cert-manager.io
+{{- include "kcp.certificates" $ | nindent 4 }}
   {{- with (include "kcp.image.block" .Values.kcp.image) }}{{ . | nindent 2 }}{{- end }}

--- a/charts/infra/templates/kcp/issuer.yaml
+++ b/charts/infra/templates/kcp/issuer.yaml
@@ -1,3 +1,4 @@
+{{- if include "kcp.certificates.createIssuer" . }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -5,3 +6,4 @@ metadata:
   namespace: {{ .Values.kcp.namespace | default "kcp-system" }}
 spec:
   selfSigned: {}
+{{- end }}

--- a/charts/infra/templates/kcp/root-shard.yaml
+++ b/charts/infra/templates/kcp/root-shard.yaml
@@ -10,10 +10,7 @@ metadata:
 spec:
 {{- include "kcp.shard.spec" (dict "root" $ "replicas" .Values.kcp.rootShard.replicas "shardBaseURL" $rootShardBaseURL "extraArgs" .Values.kcp.rootShard.extraArgs "resources" .Values.kcp.rootShard.resources "hostname" .Values.kcp.external.hostname "port" .Values.kcp.external.port "webhookPort" .Values.kcp.webhook.port) | nindent 2 }}
   certificates:
-    issuerRef:
-      group: cert-manager.io
-      kind: Issuer
-      name: selfsigned
+{{- include "kcp.certificates" $ | nindent 4 }}
   cache:
     ref:
       name: {{ .Values.kcp.cacheServer.name }}

--- a/charts/infra/tests/kcp_certificates_test.yaml
+++ b/charts/infra/tests/kcp_certificates_test.yaml
@@ -1,0 +1,231 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: Test bring-your-own Issuer and CA for the kcp chain
+release:
+  name: infra
+  namespace: platform-mesh-system
+tests:
+
+- it: creates the self-signed Issuer when neither issuerRef nor caSecretRef is set
+  templates:
+    - kcp/issuer.yaml
+  asserts:
+    - hasDocuments:
+        count: 1
+    - equal:
+        path: metadata.name
+        value: selfsigned
+    - equal:
+        path: spec.selfSigned
+        value: {}
+
+- it: points the RootShard at the chart-created Issuer by default
+  templates:
+    - kcp/root-shard.yaml
+  documentSelector:
+    path: kind
+    value: RootShard
+  asserts:
+    - equal:
+        path: spec.certificates.issuerRef
+        value:
+          group: cert-manager.io
+          kind: Issuer
+          name: selfsigned
+    - notExists:
+        path: spec.certificates.caSecretRef
+
+- it: points the CacheServer at the chart-created Issuer by default
+  templates:
+    - kcp/cache-server.yaml
+  documentSelector:
+    path: kind
+    value: CacheServer
+  asserts:
+    - equal:
+        path: spec.certificates.issuerRef
+        value:
+          group: cert-manager.io
+          kind: Issuer
+          name: selfsigned
+    - notExists:
+        path: spec.certificates.caSecretRef
+
+- it: falls back to the self-signed Issuer when certificates is set but empty
+  set:
+    kcp:
+      certificates: {}
+  templates:
+    - kcp/root-shard.yaml
+  documentSelector:
+    path: kind
+    value: RootShard
+  asserts:
+    - equal:
+        path: spec.certificates.issuerRef.name
+        value: selfsigned
+
+- it: still creates the self-signed Issuer when certificates is set but empty
+  set:
+    kcp:
+      certificates: {}
+  templates:
+    - kcp/issuer.yaml
+  asserts:
+    - hasDocuments:
+        count: 1
+
+- it: does not create the self-signed Issuer when an issuerRef is supplied
+  set:
+    kcp:
+      certificates:
+        issuerRef:
+          kind: ClusterIssuer
+          name: corporate-ca
+  templates:
+    - kcp/issuer.yaml
+  asserts:
+    - hasDocuments:
+        count: 0
+
+- it: passes a supplied ClusterIssuer through to the RootShard
+  set:
+    kcp:
+      certificates:
+        issuerRef:
+          kind: ClusterIssuer
+          name: corporate-ca
+  templates:
+    - kcp/root-shard.yaml
+  documentSelector:
+    path: kind
+    value: RootShard
+  asserts:
+    - equal:
+        path: spec.certificates.issuerRef
+        value:
+          group: cert-manager.io
+          kind: ClusterIssuer
+          name: corporate-ca
+    - notExists:
+        path: spec.certificates.caSecretRef
+
+- it: passes a supplied ClusterIssuer through to the CacheServer
+  set:
+    kcp:
+      certificates:
+        issuerRef:
+          kind: ClusterIssuer
+          name: corporate-ca
+  templates:
+    - kcp/cache-server.yaml
+  documentSelector:
+    path: kind
+    value: CacheServer
+  asserts:
+    - equal:
+        path: spec.certificates.issuerRef
+        value:
+          group: cert-manager.io
+          kind: ClusterIssuer
+          name: corporate-ca
+
+- it: defaults issuerRef kind to Issuer and group to cert-manager.io
+  set:
+    kcp:
+      certificates:
+        issuerRef:
+          name: namespaced-ca
+  templates:
+    - kcp/root-shard.yaml
+  documentSelector:
+    path: kind
+    value: RootShard
+  asserts:
+    - equal:
+        path: spec.certificates.issuerRef
+        value:
+          group: cert-manager.io
+          kind: Issuer
+          name: namespaced-ca
+
+- it: does not create the self-signed Issuer when a caSecretRef is supplied
+  set:
+    kcp:
+      certificates:
+        caSecretRef:
+          name: corporate-ca-keypair
+  templates:
+    - kcp/issuer.yaml
+  asserts:
+    - hasDocuments:
+        count: 0
+
+- it: passes a supplied caSecretRef through to the RootShard and omits issuerRef
+  set:
+    kcp:
+      certificates:
+        caSecretRef:
+          name: corporate-ca-keypair
+  templates:
+    - kcp/root-shard.yaml
+  documentSelector:
+    path: kind
+    value: RootShard
+  asserts:
+    - equal:
+        path: spec.certificates.caSecretRef
+        value:
+          name: corporate-ca-keypair
+    - notExists:
+        path: spec.certificates.issuerRef
+
+- it: passes a supplied caSecretRef through to the CacheServer and omits issuerRef
+  set:
+    kcp:
+      certificates:
+        caSecretRef:
+          name: corporate-ca-keypair
+  templates:
+    - kcp/cache-server.yaml
+  documentSelector:
+    path: kind
+    value: CacheServer
+  asserts:
+    - equal:
+        path: spec.certificates.caSecretRef
+        value:
+          name: corporate-ca-keypair
+    - notExists:
+        path: spec.certificates.issuerRef
+
+- it: fails at template time when both issuerRef and caSecretRef are supplied
+  set:
+    kcp:
+      certificates:
+        issuerRef:
+          name: corporate-ca
+        caSecretRef:
+          name: corporate-ca-keypair
+  asserts:
+    - failedTemplate:
+        errorPattern: "mutually exclusive"
+
+- it: fails at template time when an issuerRef is supplied without a name
+  set:
+    kcp:
+      certificates:
+        issuerRef:
+          kind: ClusterIssuer
+  asserts:
+    - failedTemplate:
+        errorPattern: "name is required"
+
+- it: fails at template time when a caSecretRef is supplied without a name
+  set:
+    kcp:
+      certificates:
+        caSecretRef:
+          key: tls.crt
+  asserts:
+    - failedTemplate:
+        errorPattern: "name is required"

--- a/charts/infra/values.yaml
+++ b/charts/infra/values.yaml
@@ -9,6 +9,9 @@ kcp:
     repository: ""
     tag: ""
   namespace: platform-mesh-system
+  certificates:
+    issuerRef: {}
+    caSecretRef: {}
   external:
     hostname: localhost
     port: 8443

--- a/charts/infra/values.yaml
+++ b/charts/infra/values.yaml
@@ -10,7 +10,9 @@ kcp:
     tag: ""
   namespace: platform-mesh-system
   certificates:
+    # -- Existing Issuer/ClusterIssuer that signs the kcp certificate chain. It must be able to issue CA certificates. Mutually exclusive with caSecretRef.
     issuerRef: {}
+    # -- Existing CA to sign from directly. Secret must be of type kubernetes.io/tls and contain the CA certificate and its private key. Mutually exclusive with issuerRef.
     caSecretRef: {}
   external:
     hostname: localhost


### PR DESCRIPTION
Adds values allowing for `certificates.issuerRef` and `certificates.caSecretRef` passthrough. 

Unblocks the use of existing or separately managed (cluster/namespace) issuers. An existing CA certificate with its private key can also be passed via the secret ref.

Default behavior is not changed.  
Resolves #2277