### PR TITLE
local-setup: run kube-proxy in nftables mode

### DIFF
--- a/local-setup/kind/kind-config.yaml
+++ b/local-setup/kind/kind-config.yaml
@@ -2,6 +2,7 @@ apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
 networking:
   apiServerAddress: "0.0.0.0"  # Makes API server accessible from Docker network
+  kubeProxyMode: nftables
 containerdConfigPatches:
   - |-
     [plugins."io.containerd.grpc.v1.cri".registry]


### PR DESCRIPTION
This PR makes it so that local-setup's kind platform-mesh cluster is now created with kube-proxy running in nftables mode.

If not, graphql gateway would in sometimes fail and timeout while attempting to connect to the listener's grpc port:

```
I0723 15:21:39.061166       1 server.go:43] "Starting Gateway Server"
2026-07-23T15:21:39Z	INFO	Starting gRPC watcher	{"address": "kubernetes-graphql-gateway-listener.platform-mesh-system.svc.cluster.local:50051"}
2026-07-23T15:21:39Z	INFO	Starting HTTP server	{"addr": "0.0.0.0:8080"}
W0723 15:21:59.065103       1 logging.go:55] [core] [Channel #1 SubChannel #2] grpc: addrConn.createTransport failed to connect to {Addr: "10.96.68.104:50051", ServerName: "kubernetes-graphql-gateway-listener.platform-mesh-system.svc.cluster.local:50051", }. Err: connection error: desc = "transport: Error while dialing: dial tcp 10.96.68.104:50051: i/o timeout"
W0723 15:22:20.066777       1 logging.go:55] [core] [Channel #1 SubChannel #2] grpc: addrConn.createTransport failed to connect to {Addr: "10.96.68.104:50051", ServerName: "kubernetes-graphql-gateway-listener.platform-mesh-system.svc.cluster.local:50051", }. Err: connection error: desc = "transport: Error while dialing: dial tcp 10.96.68.104:50051: i/o timeout"
W0723 15:22:41.510719       1 logging.go:55] [core] [Channel #1 SubChannel #2] grpc: addrConn.createTransport failed to connect to {Addr: "10.96.68.104:50051", ServerName: "kubernetes-graphql-gateway-listener.platform-mesh-system.svc.cluster.local:50051", }. Err: connection error: desc = "transport: Error while dialing: dial tcp 10.96.68.104:50051: i/o timeout"
W0723 15:23:04.490714       1 logging.go:55] [core] [Channel #1 SubChannel #2] grpc: addrConn.createTransport failed to connect to {Addr: "10.96.68.104:50051", ServerName: "kubernetes-graphql-gateway-listener.platform-mesh-system.svc.cluster.local:50051", }. Err: connection error: desc = "transport: Error while dialing: dial tcp 10.96.68.104:50051: i/o timeout"
W0723 15:23:28.846574       1 logging.go:55] [core] [Channel #1 SubChannel #2] grpc: addrConn.createTransport failed to connect to {Addr: "10.96.68.104:50051", ServerName: "kubernetes-graphql-gateway-listener.platform-mesh-system.svc.cluster.local:50051", }. Err: connection error: desc = "transport: Error while dialing: dial tcp 10.96.68.104:50051: i/o timeout"
W0723 15:23:54.464323       1 logging.go:55] [core] [Channel #1 SubChannel #2] grpc: addrConn.createTransport failed to connect to {Addr: "10.96.68.104:50051", ServerName: "kubernetes-graphql-gateway-listener.platform-mesh-system.svc.cluster.local:50051", }. Err: connection error: desc = "transport: Error while dialing: dial tcp 10.96.68.104:50051: i/o timeout"
W0723 15:24:24.970211       1 logging.go:55] [core] [Channel #1 SubChannel #2] grpc: addrConn.createTransport failed to connect to {Addr: "10.96.68.104:50051", ServerName: "kubernetes-graphql-gateway-listener.platform-mesh-system.svc.cluster.local:50051", }. Err: connection error: desc = "transport: Error while dialing: dial tcp 10.96.68.104:50051: i/o timeout"
W0723 15:25:12.337848       1 logging.go:55] [core] [Channel #1 SubChannel #2] grpc: addrConn.createTransport failed to connect to {Addr: "10.96.68.104:50051", ServerName: "kubernetes-graphql-gateway-listener.platform-mesh-system.svc.cluster.local:50051", }. Err: connection error: desc = "transport: Error while dialing: dial tcp 10.96.68.104:50051: i/o timeout"
W0723 15:26:29.802117       1 logging.go:55] [core] [Channel #1 SubChannel #2] grpc: addrConn.createTransport failed to connect to {Addr: "10.96.68.104:50051", ServerName: "kubernetes-graphql-gateway-listener.platform-mesh-system.svc.cluster.local:50051", }. Err: connection error: desc = "transport: Error while dialing: dial tcp 10.96.68.104:50051: i/o timeout"
2026-07-23T15:26:38Z	ERROR	gRPC stream error, reconnecting	{"error": "failed to subscribe to schema updates: rpc error: code = Canceled desc = latest balancer error: connection error: desc = \"transport: Error while dialing: dial tcp 10.96.68.104:50051: i/o timeout\""}
go.platform-mesh.io/kubernetes-graphql-gateway/gateway/gateway/watcher.(*GRPCWatcher).Run.func2
	/workspace/services/kubernetes-graphql-gateway/gateway/gateway/watcher/grpc.go:108
k8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext.func1
	/go/pkg/mod/k8s.io/apimachinery@v0.36.0/pkg/util/wait/loop.go:53
k8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext
	/go/pkg/mod/k8s.io/apimachinery@v0.36.0/pkg/util/wait/loop.go:54
k8s.io/apimachinery/pkg/util/wait.DelayFunc.Until
	/go/pkg/mod/k8s.io/apimachinery@v0.36.0/pkg/util/wait/delay.go:39
go.platform-mesh.io/kubernetes-graphql-gateway/gateway/gateway/watcher.(*GRPCWatcher).Run
	/workspace/services/kubernetes-graphql-gateway/gateway/gateway/watcher/grpc.go:106
go.platform-mesh.io/kubernetes-graphql-gateway/gateway/gateway.(*Service).Run
	/workspace/services/kubernetes-graphql-gateway/gateway/gateway/server.go:82
go.platform-mesh.io/kubernetes-graphql-gateway/gateway.(*Server).Run.func1
	/workspace/services/kubernetes-graphql-gateway/gateway/server.go:47
sync.(*WaitGroup).Go.func1
	/usr/local/go/src/sync/waitgroup.go:258
E0723 15:26:38.784982       1 server.go:48] "Gateway encountered an error" err="context canceled"
```

I managed to track this down to kube-proxy having its msg for iptables too large:

```
$ kubectl -n kube-system logs kube-proxy-stlj6 -f
  I0723 15:20:43.790929       1 shared_informer.go:370] "Waiting for caches to sync"
  I0723 15:20:43.891242       1 shared_informer.go:377] "Caches are synced"
  I0723 15:20:43.891292       1 server.go:218] "Successfully retrieved NodeIPs" NodeIPs=["10.89.0.24"]
  E0723 15:20:43.891393       1 server.go:255] "Kube-proxy configuration may be incomplete or incorrect" err="nodePortAddresses is unset; NodePort connections will be accepted on all local IPs. Consider
   using `--nodeport-addresses primary`"
  I0723 15:20:43.922833       1 server.go:264] "kube-proxy running in dual-stack mode" primary ipFamily="IPv4"
  I0723 15:20:43.922905       1 server_linux.go:136] "Using iptables Proxier"
  I0723 15:20:43.926621       1 proxier.go:242] "Setting route_localnet=1 to allow node-ports on localhost; to change this either disable iptables.localhostNodePorts (--iptables-localhost-nodeports) or
  set nodePortAddresses (--nodeport-addresses) to filter loopback addresses" ipFamily="IPv4"
  I0723 15:20:43.926939       1 server.go:529] "Version info" version="v1.35.1"
  I0723 15:20:43.926955       1 server.go:531] "Golang settings" GOGC="" GOMAXPROCS="" GOTRACEBACK=""
  I0723 15:20:44.129203       1 config.go:200] "Starting service config controller"
  I0723 15:20:44.129221       1 shared_informer.go:349] "Waiting for caches to sync" controller="service config"
  I0723 15:20:44.129221       1 config.go:106] "Starting endpoint slice config controller"
  I0723 15:20:44.129239       1 shared_informer.go:349] "Waiting for caches to sync" controller="endpoint slice config"
  I0723 15:20:44.129291       1 config.go:403] "Starting serviceCIDR config controller"
  I0723 15:20:44.129298       1 shared_informer.go:349] "Waiting for caches to sync" controller="serviceCIDR config"
  I0723 15:20:44.129254       1 config.go:309] "Starting node config controller"
  I0723 15:20:44.129648       1 shared_informer.go:349] "Waiting for caches to sync" controller="node config"
  I0723 15:20:44.129721       1 shared_informer.go:356] "Caches are synced" controller="node config"
  I0723 15:20:44.230276       1 shared_informer.go:356] "Caches are synced" controller="service config"
  I0723 15:20:44.230294       1 shared_informer.go:356] "Caches are synced" controller="serviceCIDR config"
  I0723 15:20:44.230338       1 shared_informer.go:356] "Caches are synced" controller="endpoint slice config"
  E0723 15:20:44.279529       1 proxier.go:1501] "Failed to execute iptables-restore" err=<
      exit status 1: sendmsg() failed: Message too long
      iptables-restore: line 537 failed: Message too long.
   > ipFamily="IPv4"
  I0723 15:20:44.279565       1 proxier.go:768] "Sync failed" ipFamily="IPv4" retryingTime="30s"
```

This is unrecoverable because there are simply too many rules in the ruleset.

Moving to nftables (assuming recent enough kernel) fixes that.