### PR TITLE
fix(kcp): Remove invalid fields from frontProxy template

### DIFF
--- a/charts/infra/Chart.yaml
+++ b/charts/infra/Chart.yaml
@@ -2,7 +2,7 @@ type: application
 apiVersion: v2
 name: infra
 description: A Helm chart for Kubernetes
-version: 0.34.0
+version: 0.34.1
 appVersion: "0.0.0"
 
 dependencies:

--- a/charts/infra/templates/kcp/front-proxy.yaml
+++ b/charts/infra/templates/kcp/front-proxy.yaml
@@ -44,14 +44,6 @@ spec:
   {{- with .Values.kcp.frontProxy.clusterIP }}
       clusterIP: {{ . }}
   {{- end }}
-  {{- with .Values.kcp.frontProxy.port }}
-      ports:
-      - appProtocol: https
-        name: https
-        port: {{ . }}
-        protocol: TCP
-        targetPort: 6443
-  {{- end }}
   {{- with .Values.kcp.frontProxy.resources }}
   resources:
     {{- toYaml . | nindent 4 }}

--- a/charts/infra/tests/__snapshot__/application_test.yaml.snap
+++ b/charts/infra/tests/__snapshot__/application_test.yaml.snap
@@ -194,12 +194,6 @@ Gateway API enabled:
           name: root
       serviceTemplate:
         spec:
-          ports:
-            - appProtocol: https
-              name: https
-              port: 8443
-              protocol: TCP
-              targetPort: 6443
           type: ClusterIP
   7: |
     apiVersion: cert-manager.io/v1
@@ -855,12 +849,6 @@ Istio disabled:
           name: root
       serviceTemplate:
         spec:
-          ports:
-            - appProtocol: https
-              name: https
-              port: 8443
-              protocol: TCP
-              targetPort: 6443
           type: ClusterIP
   7: |
     apiVersion: cert-manager.io/v1
@@ -1516,12 +1504,6 @@ Istio enabled:
           name: root
       serviceTemplate:
         spec:
-          ports:
-            - appProtocol: https
-              name: https
-              port: 8443
-              protocol: TCP
-              targetPort: 6443
           type: ClusterIP
   7: |
     apiVersion: cert-manager.io/v1
@@ -2162,12 +2144,6 @@ configure frontproxy resources:
           name: root
       serviceTemplate:
         spec:
-          ports:
-            - appProtocol: https
-              name: https
-              port: 8443
-              protocol: TCP
-              targetPort: 6443
           type: ClusterIP
 configure rootshard resources:
   1: |
@@ -2506,12 +2482,6 @@ match snapshots:
           name: root
       serviceTemplate:
         spec:
-          ports:
-            - appProtocol: https
-              name: https
-              port: 8443
-              protocol: TCP
-              targetPort: 6443
           type: ClusterIP
   7: |
     apiVersion: cert-manager.io/v1
@@ -3190,12 +3160,6 @@ match snapshots w. hostAliases enabled:
       serviceTemplate:
         spec:
           clusterIP: 10.0.0.1
-          ports:
-            - appProtocol: https
-              name: https
-              port: 8443
-              protocol: TCP
-              targetPort: 6443
           type: ClusterIP
   7: |
     apiVersion: cert-manager.io/v1
@@ -3915,12 +3879,6 @@ match snapshots w. kcp version:
           name: root
       serviceTemplate:
         spec:
-          ports:
-            - appProtocol: https
-              name: https
-              port: 8443
-              protocol: TCP
-              targetPort: 6443
           type: ClusterIP
   7: |
     apiVersion: cert-manager.io/v1
@@ -4588,12 +4546,6 @@ match snapshots with mailpit enabled:
           name: root
       serviceTemplate:
         spec:
-          ports:
-            - appProtocol: https
-              name: https
-              port: 8443
-              protocol: TCP
-              targetPort: 6443
           type: ClusterIP
   7: |
     apiVersion: cert-manager.io/v1

--- a/charts/infra/tests/application_test.yaml
+++ b/charts/infra/tests/application_test.yaml
@@ -90,6 +90,23 @@ tests:
             memory: 128Mi
   asserts:
   - matchSnapshot: {}
+- it: frontproxy serviceTemplate only sets fields the CRD declares
+  templates:
+    - kcp/front-proxy.yaml
+  set:
+    kcp:
+      frontProxy:
+        clusterIP: "10.96.0.100"
+        port: 9443
+  asserts:
+  - notExists:
+      path: spec.serviceTemplate.spec.ports
+  - equal:
+      path: spec.serviceTemplate.spec.clusterIP
+      value: "10.96.0.100"
+  - equal:
+      path: spec.serviceTemplate.spec.type
+      value: ClusterIP
 - it: configure rootshard resources
   templates:
     - kcp/root-shard.yaml


### PR DESCRIPTION
The `ports` field is not declared of the `ServiceSpecTemplate`: https://github.com/kcp-dev/kcp-operator/blob/2b0f446f688ba20d3dcd363862eb6cde3a34715b/sdk/apis/operator/v1alpha1/common.go#L323-L326

Removed from the template and added a test.

Helm template diff after the change:
```diff
--- a/./front-proxy-before.yaml
+++ b/./front-proxy-after.yaml
@@ -32,12 +32,6 @@ spec:
   serviceTemplate:
     spec:
       type: ClusterIP
-      ports:
-      - appProtocol: https
-        name: https
-        port: 8443
-        protocol: TCP
-        targetPort: 6443
   deploymentTemplate:
     spec:
       template:
```

Fixes #2064 