### PR TITLE
Dump runtime cluster+kcp state on error in local-setup and CI

### DIFF
--- a/.github/workflows/kind-localsetup.yaml
+++ b/.github/workflows/kind-localsetup.yaml
@@ -102,14 +102,6 @@ jobs:
       - name: Run local-setup with sharded example data
         run: |
           task local-setup:concurrent:example-data
-      - name: Upload runtime artifacts
-        if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: runtime-artifacts
-          path: |
-            runtime-artifacts/
-          retention-days: 5
 
       - name: Setup Node.js 22
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -129,6 +121,19 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           task test:portal-e2e:video
+
+      - name: Dump cluster diagnostics
+        if: failure()
+        run: local-setup/scripts/dump-diagnostics.sh
+
+      - name: Upload runtime artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: runtime-artifacts
+          path: |
+            runtime-artifacts/
+          retention-days: 5
 
       - name: Upload Playwright artefacts
         if: failure()

--- a/.github/workflows/nightly-local-setup.yaml
+++ b/.github/workflows/nightly-local-setup.yaml
@@ -82,6 +82,19 @@ jobs:
         run: |
           task test:portal-e2e:video
 
+      - name: Dump cluster diagnostics
+        if: failure()
+        run: local-setup/scripts/dump-diagnostics.sh
+
+      - name: Upload runtime artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: runtime-artifacts
+          path: |
+            runtime-artifacts/
+          retention-days: 5
+
       - name: Upload Playwright artefacts
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ local-setup/scripts/load-custom-images.sh
 docs/migration-0.3/kcp-exports
 local-setup/backup
 tmp/
+/runtime-artifacts

--- a/local-setup/scripts/dump-diagnostics.sh
+++ b/local-setup/scripts/dump-diagnostics.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+# Small script to dump kcp+runtime cluster state when something fails in CI.
+
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BASE_DOMAIN="${BASE_DOMAIN:-portal.localhost}"
+KCP_URL="${KCP_URL:-https://kcp.api.${BASE_DOMAIN}:8443}"
+KCP_KUBECONFIG="${KCP_KUBECONFIG:-$ROOT_DIR/.secret/kcp/admin.kubeconfig}"
+OUT_DIR="${OUT_DIR:-$ROOT_DIR/runtime-artifacts}"
+
+runtime_kubectl() {
+    if [[ -n "${RUNTIME_KUBECONFIG:-}" ]]; then
+        kubectl --kubeconfig "$RUNTIME_KUBECONFIG" "$@"
+    else
+        kubectl "$@"
+    fi
+}
+
+dump_runtime() {
+    local out="$1"
+    mkdir -p "$out"
+
+    runtime_kubectl get -A -o yaml \
+        platformmesh,component,resource,helmrelease,helmchart,helmrepository,ocirepository,kustomization,deployment \
+        > "$out/resources.yaml"
+    runtime_kubectl get pods -A -o wide > "$out/pods.yaml"
+    runtime_kubectl get events -A -o yaml --sort-by=.lastTimestamp > "$out/events.yaml"
+
+    mkdir -p "$1/logs"
+    runtime_kubectl get pods -A -o custom-columns=NS:.metadata.namespace,N:.metadata.name --no-headers | while read -r ns pod; do
+        [[ -z "$ns" || -z "$pod" ]] && continue
+        mkdir -p "$OUT_DIR/logs/$ns"
+        runtime_kubectl logs -n "$ns" "$pod" --all-containers --tail=-1 > "$1/logs/$ns/$pod.log" 2>&1
+        runtime_kubectl logs -n "$ns" "$pod" --all-containers --previous --tail=-1 > "$1/logs/$ns/$pod.previous.log" 2>/dev/null || true
+    done
+}
+
+kcp_kubectl() {
+    kubectl --kubeconfig "$KCP_KUBECONFIG" --server "$KCP_URL/clusters/$1" "${@:2}"
+}
+
+dump_kcp() {
+    if [[ ! -f "$KCP_KUBECONFIG" ]]; then
+        echo "kcp admin kubeconfig not found at $KCP_KUBECONFIG, skipping kcp dump" >&2
+        return
+    fi
+    local out="$1"
+
+    kcp_kubectl root get workspaces.tenancy.kcp.io -o yaml > "$out/workspaces-root.yaml"
+    kcp_kubectl root:orgs get workspaces.tenancy.kcp.io -o yaml > "$out/workspaces-root_orgs.yaml"
+    kcp_kubectl root:orgs get workspacetypes.tenancy.kcp.io -o yaml > "$out/workspacetypes.yaml"
+
+    kcp_kubectl root:orgs get workspaces.tenancy.kcp.io -o custom-columns=N:.metadata.name --no-headers | while read -r orgs; do
+        [[ -z "$org" ]] && continue
+        kcp_kubectl "root:orgs:$org" get workspaces.tenancy.kcp.io -o yaml > "$out/workspaces-org-$org.yaml"
+        kcp_kubectl "root:orgs:$org" get accounts.core.platform-mesh.io -A -o yaml > "$out/accounts-$org.yaml"
+    done
+}
+
+dump_runtime "$OUT_DIR/runtime"
+dump_kcp "$OUT_DIR/kcp"

--- a/local-setup/scripts/start.sh
+++ b/local-setup/scripts/start.sh
@@ -660,11 +660,7 @@ wait_for_pm() {
 
 # If the wait hits timeout dump information for later analysis to see what blocked
 if ! wait_for_pm; then
-    mkdir -p runtime-artifacts
-    kubectl "${RUNTIME_KC[@]}" get platformmesh,component,resource,helmrelease,helmchart,helmrepository,ocirepository,kustomization,deployment -A -o yaml > runtime-artifacts/resources.yaml
-    kubectl "${RUNTIME_KC[@]}" logs -n platform-mesh-system deploy/platform-mesh-operator --all-containers > runtime-artifacts/platform-mesh-operator.log
-    kubectl "${RUNTIME_KC[@]}" get pods -A -o wide > runtime-artifacts/pods.yaml
-    kubectl "${RUNTIME_KC[@]}" get events -A -o yaml --sort-by=.lastTimestamp > runtime-artifacts/events.yaml
+    RUNTIME_KUBECONFIG="${RUNTIME_KC[1]:-}" "$SCRIPT_DIR/dump-diagnostics.sh"
     exit 1
 fi
 


### PR DESCRIPTION
This should make it easier to dissect CI failures when they come up.
Single script for local-setup + CI and CI calls the same script whenever either e2e workflow fails. 