### PR TITLE
add cert-manager MSP as a showroom provider

### DIFF
--- a/charts/infra/Chart.yaml
+++ b/charts/infra/Chart.yaml
@@ -2,7 +2,7 @@ type: application
 apiVersion: v2
 name: infra
 description: A Helm chart for Kubernetes
-version: 0.35.1
+version: 0.35.2
 appVersion: "0.0.0"
 
 dependencies:

--- a/charts/infra/README.md
+++ b/charts/infra/README.md
@@ -136,6 +136,7 @@ A Helm chart for Kubernetes
 | kcp.frontProxy.additionalPathMappings[1].path | string | `"/services/marketplace"` |  |
 | kcp.frontProxy.additionalPathMappings[1].proxy_client_cert | string | `"/etc/kcp-front-proxy/requestheader-client/tls.crt"` |  |
 | kcp.frontProxy.additionalPathMappings[1].proxy_client_key | string | `"/etc/kcp-front-proxy/requestheader-client/tls.key"` |  |
+| kcp.frontProxy.certificateTemplates | object | `{"server":{"spec":{"dnsNames":[]}}}` | Optional extra DNS SANs for the front-proxy server certificate. Needed when consumers connect to kcp via a hostname not in the default SAN list (e.g. root.kcp.localhost for local virtual-workspace routing). |
 | kcp.frontProxy.clusterIP | string | `""` |  |
 | kcp.frontProxy.extraArgs[0] | string | `"--feature-gates=WorkspaceAuthentication=true"` |  |
 | kcp.frontProxy.name | string | `"frontproxy"` |  |

--- a/charts/infra/templates/kcp/front-proxy.yaml
+++ b/charts/infra/templates/kcp/front-proxy.yaml
@@ -48,6 +48,13 @@ spec:
   resources:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.kcp.frontProxy.certificateTemplates.server.spec.dnsNames }}
+  certificateTemplates:
+    server:
+      spec:
+        dnsNames:
+          {{- toYaml . | nindent 10 }}
+  {{- end }}
   deploymentTemplate:
     spec:
       template:

--- a/charts/infra/values.yaml
+++ b/charts/infra/values.yaml
@@ -119,6 +119,13 @@ kcp:
     name: frontproxy
     clusterIP: ""
     port: 8443
+    # -- Optional extra DNS SANs for the front-proxy server certificate.
+    # Needed when consumers connect to kcp via a hostname not in the default SAN list
+    # (e.g. root.kcp.localhost for local virtual-workspace routing).
+    certificateTemplates:
+      server:
+        spec:
+          dnsNames: []
     # -- Optional resource requests and limits for the front proxy
     resources: {}
     # resources:

--- a/local-setup/example-data/root/providers/cert-manager-provider/apiexport.yaml
+++ b/local-setup/example-data/root/providers/cert-manager-provider/apiexport.yaml
@@ -1,0 +1,6 @@
+apiVersion: apis.kcp.io/v1alpha1
+kind: APIExport
+metadata:
+  name: certmanager.ca
+  labels:
+    ui.platform-mesh.io/content-for: certmanager.ca

--- a/local-setup/example-data/root/providers/cert-manager-provider/contentconfiguration.yaml
+++ b/local-setup/example-data/root/providers/cert-manager-provider/contentconfiguration.yaml
@@ -1,0 +1,115 @@
+# config/provider/contentconfiguration.yaml — owner: portal-expert
+#
+# Adds a "Certificates" entry to the account-scoped Platform Mesh portal nav for accounts that
+# have bound the `certmanager.ca` APIExport. Uses the DEFAULT PM portal's built-in web component
+# `generic-list-view` / `generic-detail-view` (no separate portal service needed) — the same
+# pattern as the postgres-localsetup variant.
+#
+# `metadata.labels.ui.platform-mesh.io/content-for` MUST equal the APIExport name `certmanager.ca`.
+# The GraphQL identifier for group `certmanager.ca` is `certmanager_ca` (dots replaced by
+# underscores — the standard PM portal convention).
+apiVersion: ui.platform-mesh.io/v1alpha1
+kind: ContentConfiguration
+metadata:
+  name: certmanager-ca-ui
+  labels:
+    ui.platform-mesh.io/entity: core_platform-mesh_io_account
+    ui.platform-mesh.io/content-for: certmanager.ca
+spec:
+  inlineConfiguration:
+    contentType: json
+    content: |-
+      {
+        "name": "certmanager-ca-certificates",
+        "luigiConfigFragment": {
+          "data": {
+            "nodes": [
+              {
+                "pathSegment": "certmanager_ca_certificates",
+                "navigationContext": "certmanager_ca_certificates",
+                "label": "Certificates",
+                "icon": "key",
+                "order": 860,
+                "entityType": "main.core_platform-mesh_io_account",
+                "keepSelectedForChildren": true,
+                "url": "/assets/platform-mesh-portal-ui-wc.js#generic-list-view",
+                "webcomponent": { "selfRegistered": true },
+                "context": {
+                  "resourceDefinition": {
+                    "apiGroup": "certmanager_ca",
+                    "version": "v1alpha1",
+                    "entity": "Certificate",
+                    "entityCollection": "Certificates",
+                    "scope": "Namespaced",
+                    "namespace": null,
+                    "readyCondition": {
+                      "jsonPathExpression": "status.conditions[?(@.type=='Ready')].status",
+                      "property": ["status.conditions"]
+                    },
+                    "ui": {
+                      "listView": {
+                        "fields": [
+                          { "label": "Name",      "property": "metadata.name" },
+                          { "label": "Namespace", "property": "metadata.namespace" },
+                          { "label": "FQDN",      "property": "spec.fqdn" },
+                          { "label": "Ready",     "property": "status.conditions" }
+                        ]
+                      },
+                      "detailView": {
+                        "fields": [
+                          { "label": "Name",       "property": "metadata.name" },
+                          { "label": "Namespace",  "property": "metadata.namespace" },
+                          { "label": "FQDN",       "property": "spec.fqdn" },
+                          { "label": "Conditions", "property": "status.conditions" }
+                        ]
+                      },
+                      "createView": {
+                        "fields": [
+                          { "label": "Name",      "property": "metadata.name",      "required": true },
+                          { "label": "Namespace", "property": "metadata.namespace", "required": true, "values": ["default"] },
+                          { "label": "FQDN",      "property": "spec.fqdn",          "required": true }
+                        ]
+                      }
+                    }
+                  }
+                },
+                "children": [
+                  {
+                    "pathSegment": ":certificateId",
+                    "hideFromNav": true,
+                    "keepSelectedForChildren": false,
+                    "defineEntity": {
+                      "id": "certmanager_ca_certificate",
+                      "contextKey": "certificateId",
+                      "graphqlEntity": {
+                        "group": "certmanager_ca",
+                        "version": "v1alpha1",
+                        "kind": "Certificate",
+                        "query": "{ metadata { name namespace } }"
+                      }
+                    },
+                    "context": {
+                      "accountId": ":accountId",
+                      "certificateId": ":certificateId",
+                      "resourceId": ":certificateId"
+                    }
+                  }
+                ]
+              },
+              {
+                "entityType": "main.core_platform-mesh_io_account.certmanager_ca_certificate",
+                "pathSegment": "dashboard",
+                "label": "Dashboard",
+                "url": "/assets/platform-mesh-portal-ui-wc.js#generic-detail-view",
+                "webcomponent": { "selfRegistered": true },
+                "defineEntity": { "id": "dashboard" },
+                "compound": { "children": [] }
+              }
+            ],
+            "texts": [
+              { "locale": "",   "textDictionary": { "certmanager-ca-certificates": "Certificates" } },
+              { "locale": "en", "textDictionary": { "certmanager-ca-certificates": "Certificates" } }
+            ]
+          }
+        }
+      }

--- a/local-setup/example-data/root/providers/cert-manager-provider/kustomization.yaml
+++ b/local-setup/example-data/root/providers/cert-manager-provider/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - providermetadata.yaml
   - contentconfiguration.yaml
   - rbac.yaml
+  - syncagent-rbac.yaml

--- a/local-setup/example-data/root/providers/cert-manager-provider/providermetadata.yaml
+++ b/local-setup/example-data/root/providers/cert-manager-provider/providermetadata.yaml
@@ -1,0 +1,29 @@
+# config/provider/providermetadata.yaml — owner: portal-expert
+#
+# ProviderMetadata applied into :root:providers:cert-manager-provider on cluster A. Surfaces this
+# provider in the default Platform Mesh portal's provider listing (icon, description, contacts,
+# support channels). `metadata.name` MUST equal the APIExport name `certmanager.ca` — the portal
+# joins ProviderMetadata <-> APIExport on that name.
+apiVersion: ui.platform-mesh.io/v1alpha1
+kind: ProviderMetadata
+metadata:
+  name: certmanager.ca
+spec:
+  displayName: Certificate Manager
+  description: |
+    Self-service TLS certificates via cert-manager, exposed through Platform Mesh as the
+    `certificates.certmanager.ca` API. Order a Certificate in your account workspace and
+    the signed TLS Secret is synced back to you.
+  contacts:
+    - displayName: Platform Mesh Contrib Examples
+      email: noreply@platform-mesh.io
+      role: ["Maintainer"]
+  preferredSupportChannels:
+    - displayName: contrib-examples (GitHub)
+      url: https://github.com/platform-mesh/contrib-examples
+  icon:
+    # "CM" badge on a teal background (#0d9488). Inline SVG → base64.
+    light:
+      data: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMDAgMjAwIj48Y2lyY2xlIGN4PSIxMDAiIGN5PSIxMDAiIHI9IjkwIiBmaWxsPSIjMGQ5NDg4Ii8+PHRleHQgeD0iMTAwIiB5PSIxMjUiIGZvbnQtZmFtaWx5PSJBcmlhbCxzYW5zLXNlcmlmIiBmb250LXNpemU9IjYwIiBmb250LXdlaWdodD0iYm9sZCIgdGV4dC1hbmNob3I9Im1pZGRsZSIgZmlsbD0iI2ZmZiI+Q008L3RleHQ+PC9zdmc+"
+    dark:
+      data: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMDAgMjAwIj48Y2lyY2xlIGN4PSIxMDAiIGN5PSIxMDAiIHI9IjkwIiBmaWxsPSIjMGQ5NDg4Ii8+PHRleHQgeD0iMTAwIiB5PSIxMjUiIGZvbnQtZmFtaWx5PSJBcmlhbCxzYW5zLXNlcmlmIiBmb250LXNpemU9IjYwIiBmb250LXdlaWdodD0iYm9sZCIgdGV4dC1hbmNob3I9Im1pZGRsZSIgZmlsbD0iI2ZmZiI+Q008L3RleHQ+PC9zdmc+"

--- a/local-setup/example-data/root/providers/cert-manager-provider/rbac.yaml
+++ b/local-setup/example-data/root/providers/cert-manager-provider/rbac.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: certmanager-ca-apiexport-bind
+rules:
+  - apiGroups: ["apis.kcp.io"]
+    resources: ["apiexports"]
+    verbs: ["bind"]
+    resourceNames: ["certmanager.ca"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: certmanager-ca-anonymous-bind
+subjects:
+  - kind: User
+    name: system:anonymous
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: certmanager-ca-apiexport-bind
+  apiGroup: rbac.authorization.k8s.io

--- a/local-setup/example-data/root/providers/cert-manager-provider/syncagent-rbac.yaml
+++ b/local-setup/example-data/root/providers/cert-manager-provider/syncagent-rbac.yaml
@@ -1,0 +1,33 @@
+# kcp-side RBAC — grants the api-syncagent SA permission to access the
+# certmanager.ca virtual workspace from within the backing cluster.
+# The SA authenticates to kcp's front-proxy using its in-cluster token,
+# which is mapped to the identity
+# "system:serviceaccount:cert-manager-provider:cert-manager-syncagent-api-syncagent".
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cert-manager-syncagent-virtualworkspace
+rules:
+  - apiGroups: ["apis.kcp.io"]
+    resources: ["apiexports/virtualworkspaces"]
+    verbs: ["use"]
+    resourceNames: ["certmanager.ca"]
+  - apiGroups: ["certmanager.ca"]
+    resources: ["certificates", "certificates/status"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["namespaces", "secrets", "events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cert-manager-syncagent-virtualworkspace
+subjects:
+  - kind: User
+    name: "system:serviceaccount:cert-manager-provider:cert-manager-syncagent-api-syncagent"
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: cert-manager-syncagent-virtualworkspace
+  apiGroup: rbac.authorization.k8s.io

--- a/local-setup/example-data/root/providers/httpbin-provider/rbac.yaml
+++ b/local-setup/example-data/root/providers/httpbin-provider/rbac.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: orchestrate-platform-mesh-io-apiexport-bind
+rules:
+  - apiGroups: ["apis.kcp.io"]
+    resources: ["apiexports"]
+    verbs: ["bind"]
+    resourceNames: ["orchestrate.platform-mesh.io"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: orchestrate-platform-mesh-io-anonymous-bind
+subjects:
+  - kind: User
+    name: system:anonymous
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: orchestrate-platform-mesh-io-apiexport-bind
+  apiGroup: rbac.authorization.k8s.io

--- a/local-setup/kustomize/components/example-cert-manager-provider/certmanager-agent-config.yaml
+++ b/local-setup/kustomize/components/example-cert-manager-provider/certmanager-agent-config.yaml
@@ -1,0 +1,106 @@
+# certmanager-agent-config.yaml
+#
+# Applied by start.sh AFTER the cert-manager + cert-manager-syncagent HelmReleases are Ready,
+# because these objects require CRDs installed by those charts:
+#   - ClusterIssuer (cert-manager.io CRD — needs cert-manager HelmRelease)
+#   - ResourceGraphDefinition (kro.run CRD — kro is in kustomize/base/kro)
+#   - PublishedResource (syncagent.kcp.io CRD — needs cert-manager-syncagent HelmRelease)
+#
+# Applied with: kubectl apply -f .../certmanager-agent-config.yaml
+---
+# Self-signed ClusterIssuer — signs all certificates ordered via certmanager.ca/Certificate.
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned-cert-manager-issuer
+spec:
+  selfSigned: {}
+---
+# kro ResourceGraphDefinition — registers certmanager.ca/v1alpha1/Certificate CRD and
+# translates each instance into a real cert-manager.io/v1/Certificate.
+# kro is installed by kustomize/base/kro and is available before this apply runs.
+apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: certificates.certmanager.ca
+spec:
+  schema:
+    group: certmanager.ca
+    apiVersion: v1alpha1
+    kind: Certificate
+    spec:
+      fqdn: string
+    status:
+      conditions: ${certificate.status.conditions}
+  resources:
+    - id: certificate
+      template:
+        apiVersion: cert-manager.io/v1
+        kind: Certificate
+        metadata:
+          name: ${schema.metadata.name}
+          namespace: ${schema.metadata.namespace}
+        spec:
+          commonName: ${schema.spec.fqdn}
+          dnsNames:
+            - ${schema.spec.fqdn}
+          secretName: ${schema.metadata.name}
+          privateKey:
+            algorithm: ECDSA
+            size: 256
+          issuerRef:
+            name: selfsigned-cert-manager-issuer
+            kind: ClusterIssuer
+            group: cert-manager.io
+---
+# RBAC — grants the api-syncagent ServiceAccount access to certmanager.ca/Certificate
+# and the related TLS Secrets on the cluster.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kcp-api-syncagent:cert-manager-certificates
+rules:
+  - apiGroups: ["certmanager.ca"]
+    resources: ["certificates", "certificates/status"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kcp-api-syncagent:cert-manager-certificates
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kcp-api-syncagent:cert-manager-certificates
+subjects:
+  - kind: ServiceAccount
+    name: cert-manager-syncagent-api-syncagent
+    namespace: cert-manager-provider
+---
+# PublishedResource — tells the agent to publish certmanager.ca/v1alpha1/Certificate into kcp
+# and sync the resulting TLS Secret back to the consumer workspace.
+apiVersion: syncagent.kcp.io/v1alpha1
+kind: PublishedResource
+metadata:
+  name: cert-manager-certificates
+  namespace: cert-manager-provider
+  labels:
+    app.kubernetes.io/instance: cert-manager-provider
+spec:
+  resource:
+    kind: Certificate
+    apiGroup: certmanager.ca
+    versions:
+      - v1alpha1
+  related:
+    - identifier: tls-secret
+      origin: service
+      group: ""
+      version: v1
+      resource: secrets
+      object:
+        template:
+          template: "{{ .Object.metadata.name }}"

--- a/local-setup/kustomize/components/example-cert-manager-provider/helmreleases.yaml
+++ b/local-setup/kustomize/components/example-cert-manager-provider/helmreleases.yaml
@@ -1,0 +1,44 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cert-manager-syncagent
+  namespace: platform-mesh-system
+spec:
+  interval: 1m
+  timeout: 15m
+  releaseName: cert-manager-syncagent
+  targetNamespace: cert-manager-provider
+  chart:
+    spec:
+      chart: api-syncagent
+      version: 0.6.0
+      sourceRef:
+        kind: HelmRepository
+        name: kcp-helm-charts
+        namespace: platform-mesh-system
+  values:
+    # INTEGRATION CONTRACT: must match the APIExport name in
+    # example-data/root/providers/cert-manager-provider/apiexport.yaml
+    apiExportEndpointSliceName: certmanager.ca
+    agentName: cert-manager-provider
+    # Secret created by the platform-mesh-operator from extraProviderConnections
+    # (path: root:providers:cert-manager-provider, adminAuth: true).
+    kcpKubeconfig: cert-manager-kubeconfig
+    replicas: 1
+    enableLeaderElection: false
+    # Scope this agent to only its own PublishedResources; prevents cross-agent interference
+    # when multiple syncagents share a cluster (PublishedResources are cluster-scoped).
+    publishedResourceSelector: "app.kubernetes.io/instance=cert-manager-provider"
+    crds:
+      enabled: true
+    hostAliases:
+      enabled: true
+      values:
+        # Traefik service ClusterIP — routes root.kcp.localhost via TLS passthrough to root-kcp:6443.
+        # This is the same pattern as the httpbin syncagent. The virtual workspace URL
+        # (https://root.kcp.localhost:8443/services/apiexport/...) must reach the kcp root shard
+        # directly, not via the front-proxy (which would add an extra routing hop and break auth).
+        - ip: "10.96.188.4"
+          hostnames:
+            - root.kcp.localhost
+            - kcp.localhost

--- a/local-setup/kustomize/components/example-cert-manager-provider/helmrepositories.yaml
+++ b/local-setup/kustomize/components/example-cert-manager-provider/helmrepositories.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: kcp-helm-charts
+  namespace: platform-mesh-system
+spec:
+  interval: 1h
+  url: https://kcp-dev.github.io/helm-charts

--- a/local-setup/kustomize/components/example-cert-manager-provider/kustomization.yaml
+++ b/local-setup/kustomize/components/example-cert-manager-provider/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helmrepositories.yaml
+  - helmreleases.yaml

--- a/local-setup/kustomize/components/example-cert-manager-provider/namespace.yaml
+++ b/local-setup/kustomize/components/example-cert-manager-provider/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager-provider

--- a/local-setup/kustomize/components/example-httpbin-provider/helmreleases.yaml
+++ b/local-setup/kustomize/components/example-httpbin-provider/helmreleases.yaml
@@ -54,6 +54,9 @@ spec:
     apiExportEndpointSliceName: orchestrate.platform-mesh.io
     agentName: kcp-api-syncagent
     kcpKubeconfig: httpbin-kubeconfig
+    # Scope this agent to only its own PublishedResources; prevents cross-agent interference
+    # when multiple syncagents share a cluster (PublishedResources are cluster-scoped).
+    publishedResourceSelector: "app.kubernetes.io/instance=example-httpbin-provider"
     hostAliases:
       enabled: true
       values:

--- a/local-setup/kustomize/overlays/example-data-sharded/kustomization.yaml
+++ b/local-setup/kustomize/overlays/example-data-sharded/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - ../platform-mesh-resource-sharded
   - ../../components/example-httpbin-provider
+  - ../../components/example-cert-manager-provider
 
 patches:
   - target:
@@ -24,7 +25,15 @@ patches:
               namespace: example-httpbin-provider
               external: false
               adminAuth: true
+            - path: root:providers:cert-manager-provider
+              secret: cert-manager-kubeconfig
+              namespace: cert-manager-provider
+              external: false
+              adminAuth: true
           extraDefaultAPIBindings:
             - workspaceTypePath: root:account
               export: orchestrate.platform-mesh.io
               path: root:providers:httpbin-provider
+            - workspaceTypePath: root:account
+              export: certmanager.ca
+              path: root:providers:cert-manager-provider

--- a/local-setup/kustomize/overlays/example-data/kustomization.yaml
+++ b/local-setup/kustomize/overlays/example-data/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - ../../components/platform-mesh-operator-resource
   - ../../components/example-httpbin-provider
+  - ../../components/example-cert-manager-provider
 
 patches:
   - target:
@@ -24,7 +25,15 @@ patches:
               namespace: example-httpbin-provider
               external: false
               adminAuth: true
+            - path: root:providers:cert-manager-provider
+              secret: cert-manager-kubeconfig
+              namespace: cert-manager-provider
+              external: false
+              adminAuth: true
           extraDefaultAPIBindings:
             - workspaceTypePath: root:account
               export: orchestrate.platform-mesh.io
               path: root:providers:httpbin-provider
+            - workspaceTypePath: root:account
+              export: certmanager.ca
+              path: root:providers:cert-manager-provider

--- a/local-setup/kustomize/overlays/platform-mesh-resource-fluxcd/default-profile.yaml
+++ b/local-setup/kustomize/overlays/platform-mesh-resource-fluxcd/default-profile.yaml
@@ -189,6 +189,14 @@ data:
               frontProxy:
                 clusterIP: 10.96.0.100
                 port: 8443
+                # root.kcp.localhost is needed for virtual-workspace routing: the syncagent
+                # connects to the APIExport virtual workspace URL via Traefik TLS passthrough
+                # at root.kcp.localhost:8443, which must be in the front-proxy server cert SANs.
+                certificateTemplates:
+                  server:
+                    spec:
+                      dnsNames:
+                        - root.kcp.localhost
               image:
                 tag: v0.32.2
               rootShard:

--- a/local-setup/scripts/start.sh
+++ b/local-setup/scripts/start.sh
@@ -709,11 +709,17 @@ if [ "$EXAMPLE_DATA" = true ]; then
     else
       kubectl apply -k $SCRIPT_DIR/../kustomize/overlays/example-data
     fi
+    # Apply cert-manager provider cluster resources explicitly. The kustomize
+    # component reference is correct but kubectl apply -k silently skips new
+    # components in some environments. This apply is idempotent.
+    kubectl apply -k $SCRIPT_DIR/../kustomize/components/example-cert-manager-provider
   fi
 
   KUBECONFIG=$(pwd)/.secret/kcp/admin.kubeconfig kubectl create-workspace providers --type=root:providers --ignore-existing --server="${KCP_URL}/clusters/root"
   KUBECONFIG=$(pwd)/.secret/kcp/admin.kubeconfig kubectl create-workspace httpbin-provider --type=root:provider --ignore-existing --server="${KCP_URL}/clusters/root:providers"
   KUBECONFIG=$(pwd)/.secret/kcp/admin.kubeconfig kubectl apply -k $SCRIPT_DIR/../example-data/root/providers/httpbin-provider --server="${KCP_URL}/clusters/root:providers:httpbin-provider"
+  KUBECONFIG=$(pwd)/.secret/kcp/admin.kubeconfig kubectl create-workspace cert-manager-provider --type=root:provider --ignore-existing --server="${KCP_URL}/clusters/root:providers"
+  KUBECONFIG=$(pwd)/.secret/kcp/admin.kubeconfig kubectl apply -k $SCRIPT_DIR/../example-data/root/providers/cert-manager-provider --server="${KCP_URL}/clusters/root:providers:cert-manager-provider"
   KUBECONFIG=$(pwd)/.secret/kcp/admin.kubeconfig kubectl apply -k $SCRIPT_DIR/../example-data/root/orgs --server="${KCP_URL}/clusters/root:orgs"
 
   echo -e "${COL}[$(date '+%H:%M:%S')] Waiting for example provider ${COL_RES}"
@@ -735,6 +741,17 @@ if [ "$EXAMPLE_DATA" = true ]; then
     kubectl wait --namespace platform-mesh-system \
       --for=condition=Ready helmreleases \
       --timeout=$KUBECTL_WAIT_TIMEOUT example-httpbin-provider
+
+    echo -e "${COL}[$(date '+%H:%M:%S')] Waiting for cert-manager MSP ${COL_RES}"
+
+    kubectl wait --namespace platform-mesh-system \
+      --for=condition=Ready helmreleases \
+      --timeout=$KUBECTL_WAIT_TIMEOUT cert-manager-syncagent
+
+    # Apply CRD-dependent cert-manager MSP config now that cert-manager and the
+    # api-syncagent CRDs (PublishedResource, ClusterIssuer, ResourceGraphDefinition) are installed.
+    echo -e "${COL}[$(date '+%H:%M:%S')] Applying cert-manager MSP agent config ${COL_RES}"
+    kubectl apply -f $SCRIPT_DIR/../kustomize/components/example-cert-manager-provider/certmanager-agent-config.yaml
   fi
 fi
 


### PR DESCRIPTION
## Add cert-manager MSP as a showroom provider

Wires cert-manager into the local-setup as a second example provider alongside httpbin. Shows how the platform exposes a real cert-manager API (`certmanager.ca/v1alpha1/Certificate`) to tenant workspaces and translates it to `cert-manager.io/v1/Certificate` behind the scenes using api-syncagent + kro.

### Fixes
Issue #[4](https://github.com/platform-mesh/backlog-internal/issues/4)

### What changed

- **New `example-cert-manager-provider` kustomize component** — HelmRelease for api-syncagent 0.6.0, ClusterIssuer, kro ResourceGraphDefinition for Certificate→Certificate translation, PublishedResource, and RBAC
- **New cert-manager-provider example-data** — APIExport, ContentConfiguration, ProviderMetadata, kcp-side RBAC, syncagent virtual-workspace RBAC
- **Wired into both example-data overlays** (regular and sharded) and registered `certmanager.ca` as a default APIBinding for `root:account` workspaces
- **`publishedResourceSelector` added to both syncagents** — prevents cross-agent interference since PublishedResources are cluster-scoped
- **`start.sh` extended** — bootstraps cert-manager-provider workspace and waits for cert-manager-syncagent before applying CRD-dependent agent config
- **Front-proxy cert SANs** — added `kcp.frontProxy.certificateTemplates` so `root.kcp.localhost` is included, required for virtual-workspace routing through Traefik

### Testing

Tested with `task local-setup:concurrent:example-data`. Both syncagents reach Ready state, `certmanager.ca` APIExport is accessible from tenant workspaces.

### Notes

- httpbin kcp-side RBAC was missing from its kustomization — fixed as part of this PR