### PR TITLE
feat: remove HTTPBin detail view

### DIFF
--- a/local-setup/example-data/root/providers/httpbin-provider/contentconfiguration.yaml
+++ b/local-setup/example-data/root/providers/httpbin-provider/contentconfiguration.yaml
@@ -44,6 +44,7 @@ spec:
                                   "ui": {
                                       "logoUrl": "https://www.kcp.io/icons/logo.svg",
                                       "listView": {
+                                          "deletable": true,
                                           "fields": [
                                               {
                                                   "label": "Name",
@@ -65,14 +66,6 @@ spec:
                                               }
                                           ]
                                       },
-                                      "detailView": {
-                                        "fields": [
-                                          {
-                                            "label": "Name",
-                                            "property": "metadata.name"
-                                          }
-                                        ]
-                                      },
                                       "createView": {
                                           "fields": [
                                               {
@@ -84,44 +77,7 @@ spec:
                                       }
                                   }
                               }
-                          },
-                          "children": [
-                            {
-                                "pathSegment": ":httpbinId",
-                                "hideFromNav": true,
-                                "keepSelectedForChildren": false,
-                                "defineEntity": {
-                                    "id": "orchestrate_platform-mesh_io_httpbin",
-                                    "contextKey": "httpbinId",
-                                    "graphqlEntity": {
-                                        "group": "orchestrate_platform-mesh_io",
-                                        "version": "v1alpha1",
-                                        "kind": "HttpBin",
-                                        "query": "{ metadata { name } }"
-                                    }
-                                },
-                                "context": {
-                                    "accountId": ":accountId",
-                                    "httpbinId": ":httpbinId",
-                                    "resourceId": ":httpbinId"
-                                }
-                            }
-                          ]
-                      },
-                      {
-                        "entityType": "main.core_platform-mesh_io_account.orchestrate_platform-mesh_io_httpbin",
-                        "pathSegment": "dashboard",
-                        "label": "Dashboard",
-                        "url": "/assets/platform-mesh-portal-ui-wc.js#generic-detail-view",
-                        "webcomponent": {
-                          "selfRegistered": true
-                        },
-                        "defineEntity": {
-                            "id": "dashboard"
-                        },
-                        "compound": {
-                            "children": []
-                        }
+                          }
                       }
                   ]
               }

--- a/local-setup/example-data/root/providers/httpbin-provider/contentconfiguration.yaml
+++ b/local-setup/example-data/root/providers/httpbin-provider/contentconfiguration.yaml
@@ -44,7 +44,6 @@ spec:
                                   "ui": {
                                       "logoUrl": "https://www.kcp.io/icons/logo.svg",
                                       "listView": {
-                                          "deletable": true,
                                           "fields": [
                                               {
                                                   "label": "Name",
@@ -62,6 +61,25 @@ spec:
                                                   "property": "status.url",
                                                   "uiSettings": {
                                                     "displayAs": "link"
+                                                  }
+                                              },
+                                              {
+                                                  "property": "metadata.name",
+                                                  "uiSettings": {
+                                                      "align": "end",
+                                                      "displayAs": "button",
+                                                      "columnWidth": "90px",
+                                                      "buttonSettings": {
+                                                          "icon": "decline",
+                                                          "design": "Transparent",
+                                                          "action": "delete-resource",
+                                                          "tooltip": "Delete"
+                                                      }
+                                                  },
+                                                  "group": {
+                                                      "name": "actions",
+                                                      "label": "",
+                                                      "multiline": false
                                                   }
                                               }
                                           ]


### PR DESCRIPTION
- Enable row-level deletion for the example HTTPBin list.
- Remove the redundant HTTPBin detail-view configuration and route.

Part of [platform-mesh/portal-ui-lib#438](https://github.com/platform-mesh/portal-ui-lib/issues/438).

Depends on [platform-mesh/portal-ui-lib#566](https://github.com/platform-mesh/portal-ui-lib/pull/566).