### PR TITLE
chore(local-setup,infra): prep image-ref profiles + fix CNPG imageName digest handling

### DIFF
--- a/charts/infra/Chart.yaml
+++ b/charts/infra/Chart.yaml
@@ -2,7 +2,7 @@ type: application
 apiVersion: v2
 name: infra
 description: A Helm chart for Kubernetes
-version: 0.35.0
+version: 0.35.1
 appVersion: "0.0.0"
 
 dependencies:

--- a/charts/infra/templates/cnpg/cluster.yaml
+++ b/charts/infra/templates/cnpg/cluster.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Values.cnpg.cluster.name }}
   namespace: {{ .Release.Namespace }}
 spec:
-  imageName: {{ include "common.image" (dict "Values" (dict "image" .Values.cnpg.cluster.image) "Chart" .Chart) }}
+  imageName: {{ printf "%s:%s" (include "common.image.name" (dict "Values" (dict "image" .Values.cnpg.cluster.image) "Chart" .Chart)) (include "common.image.tag" (dict "Values" (dict "image" .Values.cnpg.cluster.image) "Chart" .Chart)) }}{{ with .Values.cnpg.cluster.image.digest }}@{{ . }}{{ end }}
   instances: {{ .Values.cnpg.cluster.instances }}
   storage:
     size: {{ .Values.cnpg.cluster.storage.size }}

--- a/local-setup/kustomize/components/platform-mesh-operator-resource/default-profile.yaml
+++ b/local-setup/kustomize/components/platform-mesh-operator-resource/default-profile.yaml
@@ -316,6 +316,7 @@ data:
               repo: oci
               artifact: image
               for: init-agent
+              image-ref: combined
             absoluteReferencePath:
             - name: init-agent
           syncWave: 4
@@ -339,6 +340,13 @@ data:
           syncWave: 1
           external: true
           enabled: true
+          imageResources:
+          - name: kcp-operator-image
+            annotations:
+              repo: oci
+              artifact: image
+              for: kcp-operator
+              image-ref: combined
           targetNamespace: kcp-operator
         keycloak-operator:
           enabled: true
@@ -424,6 +432,7 @@ data:
               repo: oci
               artifact: image
               for: openfga
+              image-ref: combined
           - name: openfga-postgresql-image
             resource: postgresql-image
             resourceName: postgresql-image

--- a/local-setup/kustomize/overlays/platform-mesh-resource-argocd/default-profile.yaml
+++ b/local-setup/kustomize/overlays/platform-mesh-resource-argocd/default-profile.yaml
@@ -300,6 +300,13 @@ data:
               component: infra
               infra: "true"
             name: kcp-image
+          imageResources:
+          - name: kcp-operator-image
+            annotations:
+              repo: oci
+              artifact: image
+              for: kcp-operator
+              image-ref: combined
           targetNamespace: kcp-operator
         init-agent:
           helmRepo: true
@@ -310,6 +317,7 @@ data:
               repo: oci
               artifact: image
               for: init-agent
+              image-ref: combined
             absoluteReferencePath:
             - name: init-agent
           syncWave: 4
@@ -461,6 +469,7 @@ data:
               repo: oci
               artifact: image
               for: openfga
+              image-ref: combined
           - name: openfga-postgresql-image
             resource: postgresql-image
             annotations:

--- a/local-setup/kustomize/overlays/platform-mesh-resource-fluxcd/default-profile.yaml
+++ b/local-setup/kustomize/overlays/platform-mesh-resource-fluxcd/default-profile.yaml
@@ -246,6 +246,13 @@ data:
               component: infra
               infra: "true"
             name: kcp-image
+          imageResources:
+          - name: kcp-operator-image
+            annotations:
+              repo: oci
+              artifact: image
+              for: kcp-operator
+              image-ref: combined
           targetNamespace: kcp-operator
         init-agent:
           helmRepo: true
@@ -256,6 +263,7 @@ data:
               repo: oci
               artifact: image
               for: init-agent
+              image-ref: combined
             absoluteReferencePath:
             - name: init-agent
           syncWave: 4
@@ -383,6 +391,7 @@ data:
               repo: oci
               artifact: image
               for: openfga
+              image-ref: combined
           - name: openfga-postgresql-image
             resource: postgresql-image
             annotations:


### PR DESCRIPTION
Part of platform-mesh/helm-charts#1725, prep for platform-mesh/platform-mesh-operator#716 (https://github.com/platform-mesh/platform-mesh-operator/issues/715)

- **local-setup profiles**: `image-ref: combined` for `init-agent`/`openfga`, new `imageResources` entry for `kcp-operator`'s manager image.
- **infra**: fix CNPG `imageName` to keep the tag alongside the digest cause CNPG's admission webhook rejects digest-only image references. `common.image` drops the tag once a digest is set; built explicitly here instead.

Verified via local-setup.