### PR TITLE
Add helm and yq dependency checks to environment setup script

### DIFF
--- a/local-setup/scripts/check-environment.sh
+++ b/local-setup/scripts/check-environment.sh
@@ -96,6 +96,32 @@ check_jq_dependency() {
     return 0
 }
 
+check_helm_dependency() {
+    if ! command -v helm &> /dev/null; then
+        echo -e "${RED}❌ Error: 'helm' is not installed${COL_RES}"
+        echo -e "${COL}⎈ Helm is required to install charts (Flux, Argo CD, OCI registry) and build/push local charts.${COL_RES}"
+        echo -e "${COL}📚 Installation guide: https://helm.sh/docs/intro/install/${COL_RES}"
+        echo ""
+        return 1
+    fi
+
+    echo -e "${COL}[$(date '+%H:%M:%S')] ✅ helm is available${COL_RES}"
+    return 0
+}
+
+check_yq_dependency() {
+    if ! command -v yq &> /dev/null; then
+        echo -e "${RED}❌ Error: 'yq' is not installed${COL_RES}"
+        echo -e "${COL}📦 yq is required to parse and edit YAML files (kubeconfigs, chart manifests, OCM component descriptors).${COL_RES}"
+        echo -e "${COL}📚 Installation guide: https://github.com/mikefarah/yq#install${COL_RES}"
+        echo ""
+        return 1
+    fi
+
+    echo -e "${COL}[$(date '+%H:%M:%S')] ✅ yq is available${COL_RES}"
+    return 0
+}
+
 check_container_runtime_dependency() {
     local docker_available=false
     local podman_available=false
@@ -286,6 +312,16 @@ run_environment_checks() {
         checks_failed=$((checks_failed + 1))
     fi
 
+    # Check helm dependency (chart installs and local chart builds)
+    if ! check_helm_dependency; then
+        checks_failed=$((checks_failed + 1))
+    fi
+
+    # Check yq dependency (YAML parsing/editing)
+    if ! check_yq_dependency; then
+        checks_failed=$((checks_failed + 1))
+    fi
+
     # Check mkcert dependency
     if ! setup_mkcert_command; then
         checks_failed=$((checks_failed + 1))
@@ -328,6 +364,8 @@ export -f check_kind_infra_cluster
 export -f check_kind_dependency
 export -f check_kubectl_dependency
 export -f check_jq_dependency
+export -f check_helm_dependency
+export -f check_yq_dependency
 export -f check_docker_dependency
 export -f check_container_runtime_dependency
 export -f setup_mkcert_command


### PR DESCRIPTION
## Summary

Add `helm` and `yq` to the local-setup environment dependency checks. Both are used throughout the local-setup scripts but were never validated up front, so a missing binary surfaced only as a confusing mid-run failure.

## What changed

- Add `check_helm_dependency` and `check_yq_dependency` to `local-setup/scripts/check-environment.sh`, following the existing check pattern (error message, install-guide link, success line).
- Wire both into `run_environment_checks` after the `jq` check, so they contribute to the aggregate `checks_failed` count and block startup early with a clear message.
- Export both functions for use by the calling scripts.

## Why

`helm` and `yq` are required by the local-setup flow but weren't checked:
- `helm` — installs Flux, Argo CD, and the OCI registry, and builds/pushes local charts (`start.sh`, `setup-prerelease.sh`, `ocm-build-local-charts.sh`).
- `yq` — parses and edits kubeconfigs, chart manifests, and OCM component descriptors (`start.sh`, `createKcpAdminKubeconfig.sh`, `ocm-build-component.sh`, `ocm-build-local-charts.sh`).

Checking them alongside the other dependencies gives users an actionable "not installed" message with an install link instead of an opaque failure partway through setup.
