### PR TITLE
feat(observability): support external Prometheus remote-write endpoint

### DIFF
--- a/charts/observability/Chart.yaml
+++ b/charts/observability/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability
 description: OpenTelemetry-based observability stack for platform-mesh
 type: application
-version: 0.5.2
+version: 0.5.3
 appVersion: "0.0.0"
 dependencies:
   - name: prometheus

--- a/charts/observability/README.md
+++ b/charts/observability/README.md
@@ -31,9 +31,10 @@ OpenTelemetry-based observability stack for platform-mesh
 | otelCollector.mode | string | `"statefulset"` | Deployment mode (statefulset required for Target Allocator) |
 | otelCollector.name | string | `"otel-gateway"` | Name of the OpenTelemetryCollector CR |
 | otelCollector.replicas | int | `1` | Number of collector replicas |
-| prometheus | object | `{"alertmanager":{"enabled":false},"enabled":true,"kube-state-metrics":{"enabled":false},"prometheus-node-exporter":{"enabled":false},"prometheus-pushgateway":{"enabled":false},"server":{"extraFlags":["web.enable-remote-write-receiver","web.enable-lifecycle"],"persistentVolume":{"enabled":false},"service":{"type":"ClusterIP"}}}` | ---------------------------------------------------------------------------- |
+| prometheus | object | `{"alertmanager":{"enabled":false},"enabled":true,"external":{"url":""},"kube-state-metrics":{"enabled":false},"prometheus-node-exporter":{"enabled":false},"prometheus-pushgateway":{"enabled":false},"server":{"extraFlags":["web.enable-remote-write-receiver","web.enable-lifecycle"],"persistentVolume":{"enabled":false},"service":{"type":"ClusterIP"}}}` | ---------------------------------------------------------------------------- |
 | prometheus.alertmanager | object | `{"enabled":false}` | Disable components not needed for this POC |
 | prometheus.enabled | bool | `true` | Enable Prometheus deployment |
+| prometheus.external.url | string | `""` | Prometheus-compatible remote-write endpoint. When set, the OTel Collector sends metrics here instead of to the bundled Prometheus. Set prometheus.enabled to false separately to disable the bundled deployment. |
 | prometheus.server.extraFlags[0] | string | `"web.enable-remote-write-receiver"` | Enable remote write receiver (required for OTel Collector to push metrics) |
 | prometheus.server.extraFlags[1] | string | `"web.enable-lifecycle"` | Enable lifecycle API (required for config reloader sidecar) |
 | prometheus.server.persistentVolume.enabled | bool | `false` | Disable persistence for local development |
@@ -97,7 +98,7 @@ Example
 ```
 # observability
 
-![Version: 0.5.2](https://img.shields.io/badge/Version-0.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version: 0.5.3](https://img.shields.io/badge/Version-0.5.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
 
 OpenTelemetry-based observability stack for platform-mesh
 
@@ -137,9 +138,10 @@ OpenTelemetry-based observability stack for platform-mesh
 | otelCollector.mode | string | `"statefulset"` | Deployment mode (statefulset required for Target Allocator) |
 | otelCollector.name | string | `"otel-gateway"` | Name of the OpenTelemetryCollector CR |
 | otelCollector.replicas | int | `1` | Number of collector replicas |
-| prometheus | object | `{"alertmanager":{"enabled":false},"enabled":true,"kube-state-metrics":{"enabled":false},"prometheus-node-exporter":{"enabled":false},"prometheus-pushgateway":{"enabled":false},"server":{"extraFlags":["web.enable-remote-write-receiver","web.enable-lifecycle"],"persistentVolume":{"enabled":false},"service":{"type":"ClusterIP"}}}` | ---------------------------------------------------------------------------- |
+| prometheus | object | `{"alertmanager":{"enabled":false},"enabled":true,"external":{"url":""},"kube-state-metrics":{"enabled":false},"prometheus-node-exporter":{"enabled":false},"prometheus-pushgateway":{"enabled":false},"server":{"extraFlags":["web.enable-remote-write-receiver","web.enable-lifecycle"],"persistentVolume":{"enabled":false},"service":{"type":"ClusterIP"}}}` | ---------------------------------------------------------------------------- |
 | prometheus.alertmanager | object | `{"enabled":false}` | Disable components not needed for this POC |
 | prometheus.enabled | bool | `true` | Enable Prometheus deployment |
+| prometheus.external.url | string | `""` | Prometheus-compatible remote-write endpoint. When set, the OTel Collector sends metrics here instead of to the bundled Prometheus. Set prometheus.enabled to false separately to disable the bundled deployment. |
 | prometheus.server.extraFlags[0] | string | `"web.enable-remote-write-receiver"` | Enable remote write receiver (required for OTel Collector to push metrics) |
 | prometheus.server.extraFlags[1] | string | `"web.enable-lifecycle"` | Enable lifecycle API (required for config reloader sidecar) |
 | prometheus.server.persistentVolume.enabled | bool | `false` | Disable persistence for local development |

--- a/charts/observability/templates/_helpers.tpl
+++ b/charts/observability/templates/_helpers.tpl
@@ -52,7 +52,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Prometheus remote write endpoint
 */}}
 {{- define "observability.prometheusEndpoint" -}}
-http://{{ .Release.Name }}-prometheus-server:80/api/v1/write
+{{- default (printf "http://%s-prometheus-server:80/api/v1/write" .Release.Name) .Values.prometheus.external.url -}}
 {{- end }}
 
 {{/* repository:tag, with @digest appended when set (common.image is tag-XOR-digest) */}}

--- a/charts/observability/templates/otel-collector.yaml
+++ b/charts/observability/templates/otel-collector.yaml
@@ -24,7 +24,7 @@ spec:
         timeout: {{ .Values.otelCollector.config.batchTimeout }}
     exporters:
       prometheusremotewrite:
-        endpoint: {{ include "observability.prometheusEndpoint" . }}
+        endpoint: {{ include "observability.prometheusEndpoint" . | quote }}
     service:
       pipelines:
         metrics:

--- a/charts/observability/tests/prometheus_endpoint_test.yaml
+++ b/charts/observability/tests/prometheus_endpoint_test.yaml
@@ -1,0 +1,21 @@
+suite: Prometheus remote-write endpoint
+templates:
+  - templates/otel-collector.yaml
+release:
+  name: observability
+  namespace: observability
+tests:
+  - it: uses the bundled Prometheus endpoint by default
+    asserts:
+      - equal:
+          path: spec.config.exporters.prometheusremotewrite.endpoint
+          value: http://observability-prometheus-server:80/api/v1/write
+
+  - it: uses an external Prometheus-compatible endpoint when configured
+    set:
+      prometheus.enabled: false
+      prometheus.external.url: https://mimir.example.com/api/v1/push
+    asserts:
+      - equal:
+          path: spec.config.exporters.prometheusremotewrite.endpoint
+          value: https://mimir.example.com/api/v1/push

--- a/charts/observability/values.yaml
+++ b/charts/observability/values.yaml
@@ -9,6 +9,11 @@ createNamespace: false
 prometheus:
   # -- Enable Prometheus deployment
   enabled: true
+  external:
+    # -- Prometheus-compatible remote-write endpoint. When set, the OTel Collector
+    # sends metrics here instead of to the bundled Prometheus. Set prometheus.enabled
+    # to false separately to disable the bundled deployment.
+    url: ""
   server:
     persistentVolume:
       # -- Disable persistence for local development


### PR DESCRIPTION
Adds `prometheus.external.url` to configure the OpenTelemetry Collector’s remote-write target. When unset, the collector continues to use the bundled Prometheus endpoint.

To use an existing Prometheus-compatible backend without deploying the bundled one:

```yaml
prometheus:
  enabled: false
  external:
    url: https://mimir.example.com/api/v1/push
```

`prometheus.enabled` remains independent: it controls whether the bundled Prometheus is installed, while `prometheus.external.url` controls where the collector sends metrics.

## Follow-up

This change covers URL selection only. Authentication, tenant headers, TLS, and secret references will be considered separately once the concrete backend requirements are defined.

## Testing

- `helm unittest charts/observability`

Fixes #2335